### PR TITLE
Use LNPay backend for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ python:
     - "3.7"
     - "3.8"
 
+env:
+  global:
+    - LNBITS_BACKEND_WALLET_CLASS=LNPayWallet
+    - LNBITS_FORCE_HTTPS=0
+    - LNPAY_API_ENDPOINT=https://lnpay.co/v1/
+    - LNPAY_API_KEY=sak_gG5pSFZhFgOLHm26a8hcWvXKt98yd
+    - LNPAY_ADMIN_KEY=waka_HqWfOoNE0TPqmQHSYErbF4n9
+    - LNPAY_INVOICE_KEY=waki_ZqFEbhrTyopuPlOZButZUw
+    - LNPAY_READ_KEY=wakr_6IyTaNrvSeu3jbojSWt4ou6h
+
 install:
     - pip install -r requirements.txt
     - pip install pytest pytest-cov codecov


### PR DESCRIPTION
As a quickfix to make travis happy we'll use an empty LNPay wallet as backend in tests. This should be replaced with a mock backend later on.