### PR TITLE
Use https in base url to avoid mixed content

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,7 @@ title: "LNbits docs"
 remote_theme: pmarsceill/just-the-docs
 logo: "/logos/lnbits-full.png"
 search_enabled: true
+url: https://lnbits.org
 aux_links:
   "LNbits on GitHub":
     - "//github.com/lnbits/lnbits"


### PR DESCRIPTION
Currently the HTTPS version of lnbits.org looks like this when loaded over HTTPS:
![2020-05-04-181828_5760x1080_scrot](https://user-images.githubusercontent.com/1876998/80989087-bbe4d080-8e34-11ea-8b8a-039f9cb5402d.png)

This seems to be due to loading assets over HTTP, which browsers rightfully block. This PR intends to fix this by using a HTTPS base URL.