### PR TITLE
refactor: share env variables between LndWallet and LndRestWallet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,16 +19,13 @@ LNBITS_ADMIN_MACAROON=LNBITS_ADMIN_MACAROON
 
 LND_GRPC_ENDPOINT=127.0.0.1
 LND_GRPC_PORT=11009
+
+LND_REST_ENDPOINT=https://localhost:8080/
+
 LND_CERT="/home/bob/.config/Zap/lnd/bitcoin/mainnet/wallet-1/data/chain/bitcoin/mainnet/tls.cert"
 LND_ADMIN_MACAROON="/home/bob/.config/Zap/lnd/bitcoin/mainnet/wallet-1/data/chain/bitcoin/mainnet/admin.macaroon"
 LND_INVOICE_MACAROON="/home/bob/.config/Zap/lnd/bitcoin/mainnet/wallet-1/data/chain/bitcoin/mainnet/invoice.macaroon"
 LND_READ_MACAROON="/home/bob/.config/Zap/lnd/bitcoin/mainnet/wallet-1/data/chain/bitcoin/mainnet/read.macaroon"
-
-LND_REST_ENDPOINT=https://localhost:8080/
-LND_REST_CERT="/home/bob/.config/Zap/lnd/bitcoin/mainnet/wallet-1/data/chain/bitcoin/mainnet/tls.cert"
-LND_REST_ADMIN_MACAROON="HEXSTRING"
-LND_REST_INVOICE_MACAROON="HEXSTRING"
-LND_REST_READ_MACAROON="HEXSTRING"
 
 LNPAY_API_ENDPOINT=https://lnpay.co/v1/
 LNPAY_API_KEY=LNPAY_API_KEY

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -1,32 +1,34 @@
-from os import getenv
-import os
-import base64
+from os import getenv, path
 from requests import get, post
+
 from .base import InvoiceResponse, PaymentResponse, PaymentStatus, Wallet
+
+
+def macaroon_to_hex(macaroon_path: str) -> str:
+    with open(path.expanduser(macaroon_path), "rb") as f:
+        macaroon_bytes: bytes = f.read()
+
+    return macaroon_bytes.hex().upper()
 
 
 class LndRestWallet(Wallet):
     """https://api.lightning.community/rest/index.html#lnd-rest-api-reference"""
 
     def __init__(self):
-
         endpoint = getenv("LND_REST_ENDPOINT")
         self.endpoint = endpoint[:-1] if endpoint.endswith("/") else endpoint
-        print(self.endpoint)
-        self.auth_admin = {"Grpc-Metadata-macaroon": getenv("LND_REST_ADMIN_MACAROON")}
-        self.auth_invoice = {"Grpc-Metadata-macaroon": getenv("LND_REST_INVOICE_MACAROON")}
-        self.auth_read = {"Grpc-Metadata-macaroon": getenv("LND_REST_READ_MACAROON")}
-        self.auth_cert = getenv("LND_REST_CERT")
-
+        self.auth_admin = {"Grpc-Metadata-macaroon": macaroon_to_hex(getenv("LND_ADMIN_MACAROON"))}
+        self.auth_invoice = {"Grpc-Metadata-macaroon": macaroon_to_hex(getenv("LND_INVOICE_MACAROON"))}
+        self.auth_read = {"Grpc-Metadata-macaroon": macaroon_to_hex(getenv("LND_READ_MACAROON"))}
+        self.auth_cert = getenv("LND_CERT")
 
     def create_invoice(self, amount: int, memo: str = "") -> InvoiceResponse:
-
         r = post(
             url=f"{self.endpoint}/v1/invoices",
-            headers=self.auth_invoice, verify=self.auth_cert,
+            headers=self.auth_invoice,
+            verify=self.auth_cert,
             json={"value": amount, "memo": memo, "private": True},
         )
-        print(self.auth_invoice)
 
         ok, checking_id, payment_request, error_message = r.ok, None, None, None
 
@@ -35,19 +37,20 @@ class LndRestWallet(Wallet):
             payment_request = data["payment_request"]
 
         r = get(url=f"{self.endpoint}/v1/payreq/{payment_request}", headers=self.auth_read, verify=self.auth_cert,)
-        print(r)
+
         if r.ok:
-            checking_id = r.json()["payment_hash"].replace("/","_")
-            print(checking_id)
+            checking_id = r.json()["payment_hash"].replace("/", "_")
             error_message = None
             ok = True
 
         return InvoiceResponse(ok, checking_id, payment_request, error_message)
 
-
     def pay_invoice(self, bolt11: str) -> PaymentResponse:
         r = post(
-            url=f"{self.endpoint}/v1/channels/transactions", headers=self.auth_admin, verify=self.auth_cert, json={"payment_request": bolt11}
+            url=f"{self.endpoint}/v1/channels/transactions",
+            headers=self.auth_admin,
+            verify=self.auth_cert,
+            json={"payment_request": bolt11},
         )
         ok, checking_id, fee_msat, error_message = r.ok, None, 0, None
         r = get(url=f"{self.endpoint}/v1/payreq/{bolt11}", headers=self.auth_admin, verify=self.auth_cert,)
@@ -59,25 +62,28 @@ class LndRestWallet(Wallet):
 
         return PaymentResponse(ok, checking_id, fee_msat, error_message)
 
-
     def get_invoice_status(self, checking_id: str) -> PaymentStatus:
-        checking_id = checking_id.replace("_","/")
-        print(checking_id)
+        checking_id = checking_id.replace("_", "/")
+
         r = get(url=f"{self.endpoint}/v1/invoice/{checking_id}", headers=self.auth_invoice, verify=self.auth_cert,)
-        print(r.json()["settled"])
-        if not r or r.json()["settled"] == False:
+
+        if not r or not r.json()["settled"]:
             return PaymentStatus(None)
 
         return PaymentStatus(r.json()["settled"])
 
     def get_payment_status(self, checking_id: str) -> PaymentStatus:
-        r = get(url=f"{self.endpoint}/v1/payments", headers=self.auth_admin, verify=self.auth_cert, params={"include_incomplete": "True", "max_payments": "20"})
+        r = get(
+            url=f"{self.endpoint}/v1/payments",
+            headers=self.auth_admin,
+            verify=self.auth_cert,
+            params={"include_incomplete": "True", "max_payments": "20"},
+        )
 
         if not r.ok:
             return PaymentStatus(None)
 
         payments = [p for p in r.json()["payments"] if p["payment_hash"] == checking_id]
-        print(checking_id)
         payment = payments[0] if payments else None
 
         # check payment.status: https://api.lightning.community/rest/index.html?python#peersynctype


### PR DESCRIPTION
macaroon hex is calculated from the file, so we can always use paths for both backend wallets.

[RazpiBlitz prefers to work with file paths](https://github.com/rootzoll/raspiblitz/pull/1156#issuecomment-623462404), so this can be a solution.