### PR TITLE
Modify Dockerfile to use pipenv instead of pip

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,10 @@ FLASK_ENV=development
 LNBITS_SITE_TITLE=LNbits
 LNBITS_ALLOWED_USERS="all"
 LNBITS_DEFAULT_WALLET_NAME="LNbits wallet"
-LNBITS_DATA_FOLDER="/your_custom_data_folder"
+LNBITS_DATA_FOLDER=lnbits/data
 LNBITS_DISABLED_EXTENSIONS="amilk,events"
 LNBITS_FORCE_HTTPS=1
-LNBITS_SERVICE_FEE="0.0"
+LNBITS_SERVICE_FEE=0.0
 
 # Choose from LNPayWallet, OpenNodeWallet, LntxbotWallet, LndWallet (gRPC), LndRestWallet, CLightningWallet, LnbitsWallet
 LNBITS_BACKEND_WALLET_CLASS=LntxbotWallet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,23 @@
 FROM python:3.7
 
-WORKDIR /app
-COPY requirements.txt /app/
-RUN pip install --no-cache-dir -q -r requirements.txt
-COPY . /app
+RUN adduser --disabled-login lnbits
+
+WORKDIR /home/lnbits
+
+COPY Pipfile.lock Pipfile.lock
+COPY Pipfile Pipfile
+
+ARG FLASK_ENV
+COPY pipenv-install.sh pipenv-install.sh
+RUN chmod +x pipenv-install.sh && ./pipenv-install.sh
+
+COPY . /home/lnbits
+
+COPY boot.sh ./
+RUN chmod +x boot.sh
+
+RUN chown -R lnbits:lnbits ./
+USER lnbits
 
 EXPOSE 5000
+ENTRYPOINT ["./boot.sh"]

--- a/boot.sh
+++ b/boot.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+pipenv run flask migrate
+
+exec pipenv run gunicorn -b :5000 -w 1--access-logfile - --error-logfile - lnbits:app

--- a/boot.sh
+++ b/boot.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 pipenv run flask migrate
 
-exec pipenv run gunicorn -b :5000 -w 1--access-logfile - --error-logfile - lnbits:app
+exec pipenv run gunicorn -b :5000 -w 1 lnbits:app

--- a/pipenv-install.sh
+++ b/pipenv-install.sh
@@ -1,0 +1,7 @@
+pip install pipenv
+
+if [ "${FLASK_ENV}" = "development" ]; then
+  pipenv install --deploy --system --dev
+else
+  pipenv install --deploy --system
+fi


### PR DESCRIPTION
Modified the Dockerfile which now does the following:

1. Runs the pipenv-install.sh script to Install all dependencies using pipenv instead of pip. It also check the FLASK_ENV value to see whether to install dev packages or not
2. Runs a boot.sh script to start a gunicorn server on port 5000 (single worker)

The LNBits docker image can be built and ran with the following commands:

$ docker build -t lnbits .
$ docker run  --name lnbits -v /lnbits/data:/home/lnbits/lnbits/data --env-file .env -p 5000:5000  lnbits

Docker-compose could further ease the setup to use a single 'docker-compose up' command but would require the installation of Docker Compose by the user, so I haven't included it in the PR. It's open to discussion though. 