### PR TITLE
fix https being stripped from QRCodes when showing print view

### DIFF
--- a/lnbits/extensions/withdraw/templates/withdraw/print_qr.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/print_qr.html
@@ -68,12 +68,12 @@
     mixins: [windowMixin],
     data: function () {
       return {
-        theurl: location.host,
+        theurl: location.protocol + '//' + location.host,
         printDialog: {
           show: true,
           data: null
         }
-      }
+      };
     }
   })
 </script>


### PR DESCRIPTION
Make sure the schema (e.g. HTTPS) is included correctly from the request.