### PR TITLE
use callback instead of callback.base to preserve port

### DIFF
--- a/lnbits/core/views/lnurl.py
+++ b/lnbits/core/views/lnurl.py
@@ -34,7 +34,7 @@ def lnurlwallet():
         abort(HTTPStatus.INTERNAL_SERVER_ERROR, error_message)
 
     r = requests.get(
-        withdraw_res.callback.base,
+        withdraw_res.callback,
         params={**withdraw_res.callback.query_params, **{"k1": withdraw_res.k1, "pr": payment_request}},
     )
 

--- a/lnbits/extensions/amilk/views_api.py
+++ b/lnbits/extensions/amilk/views_api.py
@@ -45,7 +45,7 @@ def api_amilkit(amilk_id):
         error_message = False, str(e)
 
     r = requests.get(
-        withdraw_res.callback.base,
+        withdraw_res.callback,
         params={**withdraw_res.callback.query_params, **{"k1": withdraw_res.k1, "pr": payment_request}},
     )
 


### PR DESCRIPTION
As mentioned in https://github.com/rootzoll/raspiblitz/issues/1348.

In my point of view switching from `withdraw_res.callback.base` to `withdraw_res.callback` should not do any "damage".