### PR TITLE
Internal payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [lnbits.org](https://lnbits.org) for more detailed documentation.
 
 Checkout the LNbits [YouTube](https://www.youtube.com/playlist?list=PLPj3KCksGbSYG0ciIQUWJru1dWstPHshe) video series.
 
-LNbits is inspired by all the great work of [opennode.com](https://www.opennode.com/), and in particular [lnpay.co](https://lnpay.co/). Both work as excellent funding sources for LNbits!
+LNbits is inspired by all the great work of [opennode.com](https://www.opennode.com/), and in particular [lnpay.co](https://lnpay.co/). Both work as excellent funding sources for LNbits.
 
 ## LNbits as an account system
 

--- a/lnbits/__init__.py
+++ b/lnbits/__init__.py
@@ -89,4 +89,5 @@ def migrate_databases():
 # ----
 
 if __name__ == "__main__":
-    app.run()
+    app.run(debug=True)
+

--- a/lnbits/__init__.py
+++ b/lnbits/__init__.py
@@ -89,5 +89,5 @@ def migrate_databases():
 # ----
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run()
 

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -192,7 +192,7 @@ def create_payment(
         db.execute(
             """
             INSERT INTO apipayment (wallet, id, payment_hash, amount, pending, memo, fee)
-            VALUES (?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (wallet_id, checking_id, payment_hash, amount, int(pending), memo, fee),
         )

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -140,9 +140,9 @@ def get_wallet_payment(wallet_id: str, checking_id: str) -> Optional[Payment]:
     with open_db() as db:
         row = db.fetchone(
             """
-            SELECT payhash as checking_id, amount, fee, pending, memo, time
-            FROM apipayments
-            WHERE wallet = ? AND payhash = ?
+            SELECT id as checking_id, amount, fee, pending, memo, time
+            FROM apipayment
+            WHERE wallet = ? AND id = ?
             """,
             (wallet_id, checking_id),
         )
@@ -159,8 +159,8 @@ def get_wallet_payments(wallet_id: str, *, include_all_pending: bool = False) ->
 
         rows = db.fetchall(
             f"""
-            SELECT payhash as checking_id, amount, fee, pending, memo, time
-            FROM apipayments
+            SELECT id as checking_id, amount, fee, pending, memo, time
+            FROM apipayment
             WHERE wallet = ? AND {clause}
             ORDER BY time DESC
             """,
@@ -175,7 +175,7 @@ def delete_wallet_payments_expired(wallet_id: str, *, seconds: int = 86400) -> N
         db.execute(
             """
             DELETE
-            FROM apipayments WHERE wallet = ? AND pending = 1 AND time < strftime('%s', 'now') - ?
+            FROM apipayment WHERE wallet = ? AND pending = 1 AND time < strftime('%s', 'now') - ?
             """,
             (wallet_id, seconds),
         )
@@ -191,7 +191,7 @@ def create_payment(
     with open_db() as db:
         db.execute(
             """
-            INSERT INTO apipayments (wallet, id, payment_hash, amount, pending, memo, fee)
+            INSERT INTO apipayment (wallet, id, payment_hash, amount, pending, memo, fee)
             VALUES (?, ?, ?, ?, ?, ?)
             """,
             (wallet_id, checking_id, payment_hash, amount, int(pending), memo, fee),
@@ -205,17 +205,17 @@ def create_payment(
 
 def update_payment_status(checking_id: str, pending: bool) -> None:
     with open_db() as db:
-        db.execute("UPDATE apipayments SET pending = ? WHERE id = ?", (int(pending), checking_id,))
+        db.execute("UPDATE apipayment SET pending = ? WHERE id = ?", (int(pending), checking_id,))
 
 
 def delete_payment(checking_id: str) -> None:
     with open_db() as db:
-        db.execute("DELETE FROM apipayments WHERE id = ?", (checking_id,))
+        db.execute("DELETE FROM apipayment WHERE id = ?", (checking_id,))
 
 
 def check_internal(payment_hash: str) -> None:
     with open_db() as db:
-        row = db.fetchone("SELECT * FROM apipayments WHERE payment_hash = ?", (payment_hash,))
+        row = db.fetchone("SELECT * FROM apipayment WHERE payment_hash = ?", (payment_hash,))
         if not row:
             return False
         else:

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -70,6 +70,55 @@ def m001_initial(db):
     )
 
 
+def m002_changed(db):
+
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS apipayment (
+            id TEXT NOT NULL,
+            payment_hash TEXT NOT NULL,
+            amount INTEGER NOT NULL,
+            fee INTEGER NOT NULL DEFAULT 0,
+            wallet TEXT NOT NULL,
+            pending BOOLEAN NOT NULL,
+            memo TEXT,
+            time TIMESTAMP NOT NULL DEFAULT (strftime('%s', 'now')),
+
+            UNIQUE (wallet, id)
+        );
+    """
+    )
+
+
+    for row in [list(row) for row in db.fetchall("SELECT * FROM apipayments")]:
+        db.execute(
+            """
+            INSERT INTO apipayment (
+                id,
+                payment_hash,
+                amount,
+                fee,
+                wallet,
+                pending,
+                memo,
+                time
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row[0], 
+                "oldinvoice",
+                row[1], 
+                row[2], 
+                row[3],
+                row[4], 
+                row[5], 
+                row[6],
+            ),
+        )
+    db.execute("DROP TABLE apipayments")
+
 def migrate():
     with open_db() as db:
         m001_initial(db)
+        m002_changed(db)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -4,7 +4,7 @@ from lnbits.bolt11 import decode as bolt11_decode # type: ignore
 from lnbits.helpers import urlsafe_short_hash
 from lnbits.settings import WALLET
 
-from .crud import get_wallet, create_payment, delete_payment, check_internal
+from .crud import get_wallet, create_payment, delete_payment, check_internal, update_payment_status
 
 
 def create_invoice(*, wallet_id: str, amount: int, memo: str) -> Tuple[str, str]:
@@ -15,9 +15,10 @@ def create_invoice(*, wallet_id: str, amount: int, memo: str) -> Tuple[str, str]
 
     if not ok:
         raise Exception(error_message or "Unexpected backend error.")
+    invoice = bolt11_decode(payment_request)
 
     amount_msat = amount * 1000
-    create_payment(wallet_id=wallet_id, checking_id=checking_id, amount=amount_msat, memo=memo)
+    create_payment(wallet_id=wallet_id, checking_id=checking_id, payment_hash=invoice.payment_hash, amount=amount_msat, memo=memo)
 
     return checking_id, payment_request
 

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -4,7 +4,7 @@ from lnbits.bolt11 import decode as bolt11_decode # type: ignore
 from lnbits.helpers import urlsafe_short_hash
 from lnbits.settings import WALLET
 
-from .crud import get_wallet, create_payment, delete_payment
+from .crud import get_wallet, create_payment, delete_payment, check_internal
 
 
 def create_invoice(*, wallet_id: str, amount: int, memo: str) -> Tuple[str, str]:
@@ -26,33 +26,50 @@ def pay_invoice(*, wallet_id: str, bolt11: str, max_sat: Optional[int] = None) -
     temp_id = f"temp_{urlsafe_short_hash()}"
     try:
         invoice = bolt11_decode(bolt11)
+        print(invoice.payment_hash)
+        internal = check_internal(invoice.payment_hash)
 
         if invoice.amount_msat == 0:
             raise ValueError("Amountless invoices not supported.")
 
         if max_sat and invoice.amount_msat > max_sat * 1000:
             raise ValueError("Amount in invoice is too high.")
-
+        
         fee_reserve = max(1000, int(invoice.amount_msat * 0.01))
-        create_payment(
-            wallet_id=wallet_id,
-            checking_id=temp_id,
-            amount=-invoice.amount_msat,
-            fee=-fee_reserve,
-            memo=temp_id,
-        )
-
+        
+        if not internal:
+            create_payment(
+                wallet_id=wallet_id,
+                checking_id=temp_id,
+                payment_hash=invoice.payment_hash,
+                amount=-invoice.amount_msat,
+                fee=-fee_reserve,
+                memo=temp_id,
+            )
         wallet = get_wallet(wallet_id)
         assert wallet, "invalid wallet id"
         if wallet.balance_msat < 0:
             raise PermissionError("Insufficient balance.")
+        print(internal)
+        if internal:
+            create_payment(
+                wallet_id=wallet_id,
+                checking_id=temp_id,
+                payment_hash=invoice.payment_hash,
+                amount=-invoice.amount_msat,
+                fee=0,
+                pending=False,
+                memo=invoice.description,
+            )
+            update_payment_status(checking_id=internal, pending=False)
+            return temp_id
 
         ok, checking_id, fee_msat, error_message = WALLET.pay_invoice(bolt11)
-
         if ok:
             create_payment(
                 wallet_id=wallet_id,
                 checking_id=checking_id,
+                payment_hash=invoice.payment_hash,
                 amount=-invoice.amount_msat,
                 fee=fee_msat,
                 memo=invoice.description,

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -27,7 +27,6 @@ def pay_invoice(*, wallet_id: str, bolt11: str, max_sat: Optional[int] = None) -
     temp_id = f"temp_{urlsafe_short_hash()}"
     try:
         invoice = bolt11_decode(bolt11)
-        print(invoice.payment_hash)
         internal = check_internal(invoice.payment_hash)
 
         if invoice.amount_msat == 0:
@@ -51,7 +50,6 @@ def pay_invoice(*, wallet_id: str, bolt11: str, max_sat: Optional[int] = None) -
         assert wallet, "invalid wallet id"
         if wallet.balance_msat < 0:
             raise PermissionError("Insufficient balance.")
-        print(internal)
         if internal:
             create_payment(
                 wallet_id=wallet_id,


### PR DESCRIPTION
If payments are internal the pay request is decoded and handled internally.
I had to add an extra field to apipayments table to store the decoded invoice hash, as all these funding sources have their own internal checking_ids the use, the migration file seems to work and no data is lost