### PR TITLE
Update .env.example due to recent changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-FLASK_APP=lnbits
+FLASK_APP=lnbits.app
 FLASK_ENV=development
 
 LNBITS_SITE_TITLE=LNbits
-LNBITS_ALLOWED_USERS="all"
+LNBITS_ALLOWED_USERS=""
 LNBITS_DEFAULT_WALLET_NAME="LNbits wallet"
 LNBITS_DATA_FOLDER="/your_custom_data_folder"
 LNBITS_DISABLED_EXTENSIONS="amilk,events"


### PR DESCRIPTION
The name of the flask app has changed and the word "all" has been eliminated as unnecessary because allowing anyone to use lnbits is the default.