### PR TITLE
Display QRcode for easy wallet export

### DIFF
--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -219,9 +219,6 @@
   <div class="col-12 col-md-5 q-gutter-y-md">
     <q-card>
       <q-card-section>
-        <q-btn flat color="grey" @click="exportCSV" class="float-right"
-          >Renew keys</q-btn
-        >
         <h6 class="text-subtitle1 q-mt-none q-mb-sm">LNbits wallet</h6>
         <strong>Wallet name: </strong><em>{{ wallet.name }}</em><br />
         <p></p>

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -224,6 +224,14 @@
         >
         <h6 class="text-subtitle1 q-mt-none q-mb-sm">LNbits wallet</h6>
         <strong>Wallet name: </strong><em>{{ wallet.name }}</em><br />
+        <p></p>
+        <strong>Scan this QRcode to open this wallet somewhere else (e.g. your cell phone)</strong><p></p>
+        <q-responsive :ratio="1" class="q-mx-xl">
+          <qrcode
+            :value="'{{request.url_root}}'+'wallet?usr={{user.id}}&wal={{wallet.it}}'"
+            :options="{width:240}"
+          ></qrcode>
+        </q-responsive><p></p>
         <strong>Wallet ID: </strong><em>{{ wallet.id }}</em><br />
         <strong>Admin key: </strong><em>{{ wallet.adminkey }}</em><br />
         <strong>Invoice/read key: </strong><em>{{ wallet.inkey }}</em>

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -228,7 +228,7 @@
         <strong>Scan this QRcode to open this wallet somewhere else (e.g. your cell phone)</strong><p></p>
         <q-responsive :ratio="1" class="q-mx-xl">
           <qrcode
-            :value="'{{request.url_root}}'+'wallet?usr={{user.id}}&wal={{wallet.it}}'"
+            :value="'{{request.url_root}}'+'wallet?usr={{user.id}}&wal={{wallet.id}}'"
             :options="{width:240}"
           ></qrcode>
         </q-responsive><p></p>

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -221,14 +221,6 @@
       <q-card-section>
         <h6 class="text-subtitle1 q-mt-none q-mb-sm">LNbits wallet</h6>
         <strong>Wallet name: </strong><em>{{ wallet.name }}</em><br />
-        <p></p>
-        <strong>Scan this QRcode to open this wallet somewhere else (e.g. your cell phone)</strong><p></p>
-        <q-responsive :ratio="1" class="q-mx-xl">
-          <qrcode
-            :value="'{{request.url_root}}'+'wallet?usr={{user.id}}&wal={{wallet.id}}'"
-            :options="{width:240}"
-          ></qrcode>
-        </q-responsive><p></p>
         <strong>Wallet ID: </strong><em>{{ wallet.id }}</em><br />
         <strong>Admin key: </strong><em>{{ wallet.adminkey }}</em><br />
         <strong>Invoice/read key: </strong><em>{{ wallet.inkey }}</em>
@@ -237,6 +229,22 @@
         <q-separator></q-separator>
         <q-list>
           {% include "core/_api_docs.html" %}
+          <q-separator></q-separator>
+          <q-expansion-item
+            group="extras"
+            icon="settings_cell"
+            label="Export to Phone with QR Code"
+          >
+            <q-card>
+              <q-card-section>
+                <p>This QR code contains your wallet URL with full access. You can scan it from your phone to open your wallet from there.</p>
+                <qrcode
+                  :value="'{{request.url_root}}'+'wallet?usr={{user.id}}&wal={{wallet.id}}'"
+                  :options="{width:240}"
+                ></qrcode>
+              </q-card-section>
+            </q-card>
+          </q-expansion-item>
           <q-separator></q-separator>
           <q-expansion-item
             group="extras"


### PR DESCRIPTION
This adds a QRcode of the "url_root/wallet?usr=#####&wal=####" so that
the user can create a wallet on desktop and easily use it on his phone.
Also, in a use case where the User Manager extension is used, the
manager can create a wallet and show the QRcode for the user to take it
(e.g. in a hotel front desk the clerk creates it and the user takes it
in his phone browser, to pay for laundry, massage, soda machine...)