### PR TITLE
Improved Dockerfile and auto build lnbits image on commit

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - docker-image # For testing purposes
 
 jobs:
     build:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,0 +1,59 @@
+name: Docker build on push
+
+env:
+    DOCKER_CLI_EXPERIMENTAL: enabled
+
+on:
+  push:
+    branches:
+      - master
+      - docker-image # For testing purposes
+
+jobs:
+    build:
+        runs-on: ubuntu-20.04
+        name: Build and push lnbits image
+        steps:
+            - name: Login to Docker Hub
+              run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+            - name: Checkout project
+              uses: actions/checkout@v2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v1
+              id: qemu
+
+            - name: Setup Docker buildx action
+              uses: docker/setup-buildx-action@v1
+              id: buildx
+
+            - name: Show available Docker buildx platforms
+              run: echo ${{ steps.buildx.outputs.platforms }}
+
+            - name: Cache Docker layers
+              uses: actions/cache@v2
+              id: cache
+              with:
+                path: /tmp/.buildx-cache
+                key: ${{ runner.os }}-buildx-${{ github.sha }}
+                restore-keys: |
+                  ${{ runner.os }}-buildx-
+
+            - name: Run Docker buildx against commit hash
+              run: |
+                  docker buildx build \
+                  --cache-from "type=local,src=/tmp/.buildx-cache" \
+                  --cache-to "type=local,dest=/tmp/.buildx-cache" \
+                  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+                  --tag ${{ secrets.DOCKER_USERNAME }}/lnbits:${GITHUB_SHA:0:7} \
+                  --output "type=registry" ./
+
+            - name: Run Docker buildx against latest
+              run: |
+                  docker buildx build \
+                  --cache-from "type=local,src=/tmp/.buildx-cache" \
+                  --cache-to "type=local,dest=/tmp/.buildx-cache" \
+                  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+                  --tag ${{ secrets.DOCKER_USERNAME }}/lnbits:latest \
+                  --output "type=registry" ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,45 @@
-FROM python:3.7-slim
+# Build image
+FROM python:3.7-slim as builder
 
+# Setup virtualenv
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install build deps
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends build-essential
+
+# Install runtime deps
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+# Install c-lightning specific deps
+RUN pip install pylightning
+
+# Install LND specific deps
+RUN pip install lndgrpc purerpc
+
+# Production image
+FROM python:3.7-slim as lnbits
+
+# Copy over virtualenv
+ENV VIRTUAL_ENV="/opt/venv"
+COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Setup Quart
+ENV QUART_APP="lnbits.app:create_app()"
+ENV QUART_ENV="development"
+ENV QUART_DEBUG="true"
+
+# App
+ENV LNBITS_BIND="0.0.0.0:5000"
+
+# Copy in app source
 WORKDIR /app
-COPY requirements.txt /app/
-RUN pip install --no-cache-dir -q -r requirements.txt
-COPY . /app
+COPY lnbits /app/lnbits
 
 EXPOSE 5000
+
+CMD quart assets && quart migrate && hypercorn -k trio --bind $LNBITS_BIND 'lnbits.app:create_app()'


### PR DESCRIPTION
This PR follows a discussion with @arcbtc on Telegram. It improves the `Dockerfile` and adds a new workflow to automatically build the `lnbits` image, tag it with the short commit hash, and push it to Docker Hub. It is triggered on push to `master`.

The workflow (GitHub Action) needs the following repository secrets:
- `DOCKER_USERNAME`: Docker Hub username hosting the repository images.
- `DOCKER_PASSWORD`: Docker Hub access token 

This will allow a better LNbits integration on Umbrel (@getumbrel).

w/ @lukechilds