### PR TITLE
Run Dockerfile as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,12 @@ RUN pip install lndgrpc purerpc
 # Production image
 FROM python:3.7-slim as lnbits
 
+# Run as non-root
+USER 1000:1000
+
 # Copy over virtualenv
 ENV VIRTUAL_ENV="/opt/venv"
-COPY --from=builder $VIRTUAL_ENV $VIRTUAL_ENV
+COPY --from=builder --chown=1000:1000 $VIRTUAL_ENV $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Setup Quart
@@ -38,7 +41,7 @@ ENV LNBITS_BIND="0.0.0.0:5000"
 
 # Copy in app source
 WORKDIR /app
-COPY lnbits /app/lnbits
+COPY --chown=1000:1000 lnbits /app/lnbits
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-slim as builder
 
 # Setup virtualenv
 ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
+RUN python -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Install build deps


### PR DESCRIPTION
This change creates the Dockerfile with the appropriate filesystem permissions to be executed as a non-root user. This is a requirement for Umbrel.

It's also changed to run as non-root by default.

You can still optionally run the container as root just like before with `docker run --user root lnbits`.