### PR TITLE
added meta-tags to base.html to allow fullscreen app launch on mobiles.

### DIFF
--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -14,6 +14,8 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     {% block head_scripts %}{% endblock %}
   </head>
 


### PR DESCRIPTION
Added head meta tags to base.html. Allows you to save from browser to homescreen. When you click on "App", lnbits will launch fullscreen. Tested on android. Added bonus of masking the url!
![image](https://user-images.githubusercontent.com/58051461/114029398-5e8da680-9871-11eb-9861-5f5bb227b95a.png)
