### PR TITLE
QRCode for LNURLw points to /?lightning 

### DIFF
--- a/lnbits/extensions/withdraw/templates/withdraw/display.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/display.html
@@ -10,7 +10,7 @@
           <a href="{{ link.lnurl }}">
             <q-responsive :ratio="1" class="q-mx-md">
               <qrcode
-                :value="this.here + '/?lightning={{link.lnurl }}'"
+                :value="'lightning:{{link.lnurl }}'"
                 :options="{width: 800}"
                 class="rounded-borders"
               ></qrcode>

--- a/lnbits/extensions/withdraw/templates/withdraw/index.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/index.html
@@ -303,7 +303,7 @@
     <q-card v-if="qrCodeDialog.data" class="q-pa-lg lnbits__dialog-card">
       <q-responsive :ratio="1" class="q-mx-xl q-mb-md">
         <qrcode
-          :value="qrCodeDialog.data.url + '/?lightning=' + qrCodeDialog.data.lnurl"
+          :value="'lightning:' + qrCodeDialog.data.lnurl"
           :options="{width: 800}"
           class="rounded-borders"
         ></qrcode>

--- a/lnbits/extensions/withdraw/templates/withdraw/print_qr.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/print_qr.html
@@ -11,7 +11,7 @@
           <td style="width: 105mm">
             <center>
               <qrcode
-                :value="theurl + '/?lightning={{one}}'"
+                :value="'lightning:{{one}}'"
                 :options="{width: 150}"
               ></qrcode>
             </center>


### PR DESCRIPTION
discovered issue through twitter where certain wallets can't scan LNURL QR codes from LNBITS

https://twitter.com/wpeace4886/status/1405354548307263493

Not sure why the QRcode includes the domain name, makes for a funky redirect.  Made a change to just use 'lightning:' prefix 

Tested on local instance on multiple wallets, works as intended now

