### PR TITLE
Add missing instruction to dev installation guide

### DIFF
--- a/docs/devs/installation.md
+++ b/docs/devs/installation.md
@@ -40,6 +40,13 @@ Take a look at [Polar][polar] for an excellent way of spinning up a Lightning Ne
 ## Running the server
 
 LNbits uses [Quart][quart] as an application server.
+Before running the server for the first time, make sure to create the data folder:
+
+```sh
+$ mkdir data
+```
+
+To then run the server, use:
 
 ```sh
 $ pipenv run python -m lnbits


### PR DESCRIPTION
The missing data folder will throw an exception:
`sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file`