### PR TITLE
Stream Alerts: Fix donations table and default donor name "Anonymous"

### DIFF
--- a/lnbits/extensions/streamalerts/templates/streamalerts/index.html
+++ b/lnbits/extensions/streamalerts/templates/streamalerts/index.html
@@ -101,14 +101,12 @@
           dense
           flat
           :data="donations"
-          row-key="id"
           :columns="donationsTable.columns"
           :pagination.sync="donationsTable.pagination"
         >
           {% raw %}
           <template v-slot:header="props">
             <q-tr :props="props">
-              <q-th auto-width></q-th>
               <q-th v-for="col in props.cols" :key="col.name" :props="props">
                 {{ col.label }}
               </q-th>
@@ -119,7 +117,6 @@
               <q-td v-for="col in props.cols" :key="col.name" :props="props">
                 {{ col.value }}
               </q-td>
-
               <q-td auto-width>
                 <q-btn
                   flat
@@ -329,8 +326,8 @@
               label: 'Service',
               field: 'service'
             },
-            {name: 'donor', align: 'left', label: 'Donor', field: 'donor'},
-            {name: 'ltext', align: 'left', label: 'Message', field: 'ltext'},
+            {name: 'name', align: 'left', label: 'Donor', field: 'name'},
+            {name: 'message', align: 'left', label: 'Message', field: 'message'},
             {name: 'sats', align: 'left', label: 'Sats', field: 'sats'}
           ],
           pagination: {

--- a/lnbits/extensions/streamalerts/templates/streamalerts/index.html
+++ b/lnbits/extensions/streamalerts/templates/streamalerts/index.html
@@ -326,9 +326,11 @@
               label: 'Service',
               field: 'service'
             },
+            {name: 'id', align: 'left', label: 'Charge ID', field: 'id'},
             {name: 'name', align: 'left', label: 'Donor', field: 'name'},
             {name: 'message', align: 'left', label: 'Message', field: 'message'},
-            {name: 'sats', align: 'left', label: 'Sats', field: 'sats'}
+            {name: 'sats', align: 'left', label: 'Sats', field: 'sats'},
+            {name: 'posted', align: 'left', label: 'Posted to API', field: 'posted'}
           ],
           pagination: {
             rowsPerPage: 10

--- a/lnbits/extensions/streamalerts/templates/streamalerts/index.html
+++ b/lnbits/extensions/streamalerts/templates/streamalerts/index.html
@@ -115,19 +115,7 @@
             </q-tr>
           </template>
           <template v-slot:body="props">
-            <q-tr :props="props" v-if="props.row.paid">
-              <q-td auto-width>
-                <q-btn
-                  unelevated
-                  dense
-                  size="xs"
-                  icon="email"
-                  :color="($q.dark.isActive) ? 'grey-7' : 'grey-5'"
-                  type="a"
-                  :href="'mailto:' + props.row.email"
-                ></q-btn>
-              </q-td>
-
+            <q-tr :props="props">
               <q-td v-for="col in props.cols" :key="col.name" :props="props">
                 {{ col.value }}
               </q-td>

--- a/lnbits/extensions/streamalerts/views_api.py
+++ b/lnbits/extensions/streamalerts/views_api.py
@@ -2,7 +2,7 @@ from quart import g, redirect, request, jsonify
 from http import HTTPStatus
 
 from lnbits.decorators import api_validate_post_request, api_check_wallet_key
-from lnbits.core.crud import get_wallet, get_user
+from lnbits.core.crud import get_user
 from lnbits.utils.exchange_rates import btc_price
 
 from . import streamalerts_ext
@@ -43,9 +43,8 @@ async def api_create_service():
         service = await create_service(**g.data)
     except Exception as e:
         return jsonify({"message": str(e)}), HTTPStatus.INTERNAL_SERVER_ERROR
-    
-    return jsonify(service._asdict()), HTTPStatus.CREATED
 
+    return jsonify(service._asdict()), HTTPStatus.CREATED
 
 
 @streamalerts_ext.route("/api/v1/getaccess/<service_id>", methods=["GET"])
@@ -117,7 +116,9 @@ async def api_create_donation():
     service_id = g.data["service"]
     service = await get_service(service_id)
     charge_details = await get_charge_details(service.id)
-    name = g.data.get("name", "Anonymous")
+    name = g.data.get("name", "")
+    if not name:
+        name = "Anonymous"
     description = f"{sats} sats donation from {name} to {service.twitchuser}"
     charge = await create_charge(
         amount=sats,


### PR DESCRIPTION
This fixes two bugs with the Stream Alerts extension.
The first bug prevents donations from showing up in `index.html`. This has now been fixed and more important information is included in the table as well.
The second bug leads do empty name fields for donations, which might cause issues with the Streamlabs API. The name now gets set correctly to "Anonymous."

Edit: I'm pretty sure I fixed this like three weeks ago, but I must have dreamt that or something, as I couldn't find the code anywhere haha. Reimplemented the fix and tested the whole donation process again. No-name+no-message donations go through smoothly.