### PR TITLE
Stream Alerts: Enforce sensible length limits on Name and Message

### DIFF
--- a/lnbits/extensions/streamalerts/templates/streamalerts/display.html
+++ b/lnbits/extensions/streamalerts/templates/streamalerts/display.html
@@ -10,6 +10,7 @@
             filled
             dense
             v-model.trim="donationDialog.data.name"
+            maxlength="25"
             type="name"
             label="Your Name (leave blank for Anonymous donation)"
           ></q-input>
@@ -19,6 +20,7 @@
             v-model.number="donationDialog.data.sats"
             type="number"
             min="1"
+            max="2100000000000000"
             suffix="sats"
             :rules="[val => val > 0 || 'Choose a positive number of sats!']"
             label="Amount of sats"
@@ -27,6 +29,7 @@
             filled
             dense
             v-model.trim="donationDialog.data.message"
+            maxlength="255"
             type="textarea"
             label="Donation Message (you can leave this blank too)"
           ></q-input>

--- a/lnbits/extensions/streamalerts/views_api.py
+++ b/lnbits/extensions/streamalerts/views_api.py
@@ -108,7 +108,7 @@ async def api_create_donation():
     # Currency is hardcoded while frotnend is limited
     cur_code = "USD"
     sats = g.data["sats"]
-    message = g.data.get("message", "")
+    message = g.data.get("message", "")[:255]
     # Fiat amount is calculated here while frontend is limited
     price = await btc_price(cur_code)
     amount = sats * (10 ** (-8)) * price
@@ -116,7 +116,7 @@ async def api_create_donation():
     service_id = g.data["service"]
     service = await get_service(service_id)
     charge_details = await get_charge_details(service.id)
-    name = g.data.get("name", "")
+    name = g.data.get("name", "")[:25]
     if not name:
         name = "Anonymous"
     description = f"{sats} sats donation from {name} to {service.twitchuser}"


### PR DESCRIPTION
This adds `maxlength`s of 25 and 255 on the donor name and donation message respectively.
In case of inspect element abuse, anything longer than this gets truncated by the backend.
The limits were chosen like this:
 * Maximum length for Twitch usernames is 25 characters
 * Streamlabs' native tipping page has a maximum configurable message length of 255 characters