### PR TITLE
Create Invoice popup: Mark memo field as required

### DIFF
--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -359,7 +359,7 @@
         filled
         dense
         v-model.trim="receive.data.memo"
-        label="Memo"
+        label="Memo *"
         placeholder="LNbits invoice"
       ></q-input>
       <div v-if="receive.status == 'pending'" class="row q-mt-lg">


### PR DESCRIPTION
Both amount and memo are required by the API, but only the amount field is marked as such in the UI. This commit also marks the memo field as required.