### PR TITLE
Fix Lightning Address issues (handle subdomains, enforce case insensitivity)

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -383,13 +383,13 @@ async def api_lnurlscan(code: str):
     except:
         # parse internet identifier (user@domain.com)
         name_domain = code.split("@")
-        if len(name_domain) == 2 and len(name_domain[1].split(".")) == 2:
+        if len(name_domain) == 2 and len(name_domain[1].split(".")) >= 2:
             name, domain = name_domain
             url = (
                 ("http://" if domain.endswith(".onion") else "https://")
                 + domain
                 + "/.well-known/lnurlp/"
-                + name
+                + name.lower()
             )
             # will proceed with these values
         else:


### PR DESCRIPTION
This fixes two issues with sending to lightning addresses:
1. Lightning addresses with subdomains (like [ln.fitti.io](https://ln.fitti.io)) caused an `invalid lnurl` 400 error
1. Usernames were case sensitive (the spec only allows lowercase https://github.com/fiatjaf/lnurl-rfc/commit/3363ce9e4e274b37c0432d5132f5837197567270)