### PR TITLE
api: Fix order of operations causing invoice unit to be ignored

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -99,7 +99,7 @@ async def api_payments_create_invoice():
         description_hash = b""
         memo = g.data["memo"]
 
-    if g.data.get("unit") or "sat" == "sat":
+    if (g.data.get("unit") or "sat") == "sat":
         amount = g.data["amount"]
     else:
         price_in_sats = await fiat_amount_as_satoshis(g.data["amount"], g.data["unit"])


### PR DESCRIPTION
In function api_payments_create_invoice() the line:

> if g.data.get("unit") or "sat" == "sat":

Was being interpreted as

> if g.data.get("unit") or ("sat" == "sat"):

Which is always true, resulting in the selected unit being ignored.

Replace with:

> if (g.data.get("unit") or "sat") == "sat":

Which results in intended behavior.