### PR TITLE
Fix issue #327

### DIFF
--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -252,7 +252,6 @@ async def btc_price(currency: str) -> float:
         nursery.start_soon(controller, nursery)
         for key, provider in exchange_rate_providers.items():
             nursery.start_soon(fetch_price, key, provider)
-
     if not rates:
         return 9999999999
 
@@ -260,7 +259,7 @@ async def btc_price(currency: str) -> float:
 
 
 async def get_fiat_rate_satoshis(currency: str) -> float:
-    return int(100_000_000 / (await btc_price(currency)))
+    return float(100_000_000 / (await btc_price(currency)))
 
 
 async def fiat_amount_as_satoshis(amount: float, currency: str) -> int:


### PR DESCRIPTION
fix price conversion for Colombian Peso COP #327

1 COP is less than 1 sat, it was getting parsed as 0.