### PR TITLE
Use inkey in wallet details headers

### DIFF
--- a/lnbits/core/templates/core/_api_docs.html
+++ b/lnbits/core/templates/core/_api_docs.html
@@ -19,7 +19,7 @@
       <q-card-section>
         <code><span class="text-light-green">GET</span> /api/v1/wallet</code>
         <h5 class="text-caption q-mt-sm q-mb-none">Headers</h5>
-        <code>{"X-Api-Key": "<i>{{ wallet.adminkey }}</i>"}</code><br />
+        <code>{"X-Api-Key": "<i>{{ wallet.inkey }}</i>"}</code><br />
         <h5 class="text-caption q-mt-sm q-mb-none">
           Returns 200 OK (application/json)
         </h5>


### PR DESCRIPTION
Instead of the admin key. Currently, the admin key is used in the headers and invoice key in the curl example