### PR TITLE
Fix misleading instruction about VoidWallet

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -21,11 +21,9 @@ mkdir data
 ./venv/bin/hypercorn -k trio --bind 0.0.0.0:5000 'lnbits.app:create_app()'
 ```
 
-Now you can visit your LNbits at http://localhost:5000/.
-
 Now modify the `.env` file with any settings you prefer and add a proper [funding source](./wallets.md) by modifying the value of `LNBITS_BACKEND_WALLET_CLASS` and providing the extra information and credentials related to the chosen funding source.
 
-Then you can restart it and it will be using the new settings.
+Then you can restart it and it will be using the new settings. Now you can visit your LNbits at http://localhost:5000/.
 
 You might also need to install additional packages or perform additional setup steps, depending on the chosen backend. See [the short guide](./wallets.md) on each different funding source.
 


### PR DESCRIPTION
Moved line which prompts user to try Lnbits with VoidWallet. Temporarily solves #340 if running with VoidWallet is not allowed