### PR TITLE
Fix issue #340

### DIFF
--- a/lnbits/wallets/void.py
+++ b/lnbits/wallets/void.py
@@ -20,10 +20,8 @@ class VoidWallet(Wallet):
         raise Unsupported("")
 
     async def status(self) -> StatusResponse:
-        return StatusResponse(
-            "This backend does nothing, it is here just as a placeholder, you must configure an actual backend before being able to do anything useful with LNbits.",
-            0,
-        )
+        print("This backend does nothing, it is here just as a placeholder, you must configure an actual backend before being able to do anything useful with LNbits.")
+        return StatusResponse(None, 0)
 
     async def pay_invoice(self, bolt11: str) -> PaymentResponse:
         raise Unsupported("")


### PR DESCRIPTION
fix voidwallet sys.exit
LNbits no longer crashes when using VoidWallet. It gives out a bunch of terminal errors but UI runs without crash.
#340