### PR TITLE
WIP: check if uncheckable to avoid error

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -319,7 +319,7 @@ async def check_invoice_status(
     wallet_id: str, payment_hash: str, conn: Optional[Connection] = None
 ) -> PaymentStatus:
     payment = await get_wallet_payment(wallet_id, payment_hash, conn=conn)
-    if not payment:
+    if not payment or payment.is_uncheckable:
         return PaymentStatus(None)
     status = await WALLET.get_invoice_status(payment.checking_id)
     if not payment.pending:

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -372,10 +372,6 @@ async def api_payment(payment_hash, X_Api_Key: Optional[str] = Header(None)):
     except:
         wallet = await get_wallet_for_key(X_Api_Key)
     payment = await get_standalone_payment(payment_hash)
-    if payment.is_uncheckable:
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail="Payment is uncheckable"
-        )
     await check_invoice_status(payment.wallet_id, payment_hash)
     payment = await get_standalone_payment(payment_hash)
     if not payment:


### PR DESCRIPTION
Checking the status of an uncheckable (== `internal_` or `temp_`) payment will result in an error. This change will avoid calling the payment source payment check and just return  returns `PaymentStatus(None)`. If called by `core/views/api.py:api_payment()`, this will not change anything.

Question: What is the response of the payment source when trying to check an uncheckable payment?