### PR TITLE
api_payments_create API return error for wrong key

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -367,13 +367,8 @@ async def api_payments_sse(
 
 
 @core_app.get("/api/v1/payments/{payment_hash}")
-async def api_payment(payment_hash, X_Api_Key: Optional[str] = Header(None)):
-    wallet = None
-    try:
-        if X_Api_Key.extra:
-            print("No key")
-    except:
-        wallet = await get_wallet_for_key(X_Api_Key)
+async def api_payment(payment_hash, wal: WalletTypeInfo = Depends(require_invoice_key)):
+    wallet = wal.wallet
     payment = await get_standalone_payment(payment_hash)
     await check_invoice_status(payment.wallet_id, payment_hash)
     payment = await get_standalone_payment(payment_hash)

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -326,7 +326,7 @@ async def api_payments_pay_lnurl(
 
 
 async def subscribe(request: Request, wallet: Wallet):
-    this_wallet_id = wallet.wallet.id
+    this_wallet_id = wallet.id
 
     payment_queue = asyncio.Queue(0)
 
@@ -363,14 +363,19 @@ async def api_payments_sse(
     request: Request, wallet: WalletTypeInfo = Depends(get_key_type)
 ):
     return EventSourceResponse(
-        subscribe(request, wallet), ping=20, media_type="text/event-stream"
+        subscribe(request, wallet.wallet), ping=20, media_type="text/event-stream"
     )
 
 
 @core_app.get("/api/v1/payments/{payment_hash}")
-async def api_payment(payment_hash, wal: WalletTypeInfo = Depends(require_invoice_key)):
-    wallet = wal.wallet
+async def api_payment(payment_hash, X_Api_Key: Optional[str] = Header(None)):
+    # We use X_Api_Key here because we want this call to work with and without keys
+    wallet = await get_wallet_for_key(X_Api_Key) if X_Api_Key is not None else None
     payment = await get_standalone_payment(payment_hash)
+    if payment is None:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail="Payment does not exist."
+        )
     await check_invoice_status(payment.wallet_id, payment_hash)
     payment = await get_standalone_payment(payment_hash)
     if not payment:

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -249,7 +249,8 @@ async def api_payments_create(
         return await api_payments_create_invoice(invoiceData, wallet.wallet)
     else:
         raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail="Key type is invalid"
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="Invoice (or Admin) key required.",
         )
 
 


### PR DESCRIPTION
Instead of assuming that the user wants to create an invoice if they use an invoice key, we now check whether invoice creation was actually intended (or they just used the wrong key when trying to _make_ a payment)