### PR TITLE
Allow more than 2-nd level domain in incoming ln-addresses

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -459,7 +459,7 @@ async def api_lnurlscan(code: str, wallet: WalletTypeInfo = Depends(get_key_type
     except:
         # parse internet identifier (user@domain.com)
         name_domain = code.split("@")
-        if len(name_domain) == 2 and len(name_domain[1].split(".")) == 2:
+        if len(name_domain) == 2 and len(name_domain[1].split(".")) >= 2:
             name, domain = name_domain
             url = (
                 ("http://" if domain.endswith(".onion") else "https://")


### PR DESCRIPTION
Make /api/v1/lnurlscan  no longer require exactly 2 parts for name's domain split by "."

Payment to addresses like anton@bits.my-ns.me is now possible.