### PR TITLE
Added warning to backup keys

### DIFF
--- a/lnbits/extensions/boltcards/templates/boltcards/index.html
+++ b/lnbits/extensions/boltcards/templates/boltcards/index.html
@@ -380,7 +380,10 @@
         <strong>Lock key:</strong> {{ qrCodeDialog.data.k0 }}<br />
         <strong>Meta key:</strong> {{ qrCodeDialog.data.k1 }}<br />
         <strong>File key:</strong> {{ qrCodeDialog.data.k2 }}<br />
+          <br />
+          Always backup all keys that you're trying to write on the card. Without them you may not be able to change them in the future!<br />
       </p>
+
       <br />
       <q-btn
         unelevated

--- a/lnbits/extensions/boltcards/templates/boltcards/index.html
+++ b/lnbits/extensions/boltcards/templates/boltcards/index.html
@@ -380,8 +380,9 @@
         <strong>Lock key:</strong> {{ qrCodeDialog.data.k0 }}<br />
         <strong>Meta key:</strong> {{ qrCodeDialog.data.k1 }}<br />
         <strong>File key:</strong> {{ qrCodeDialog.data.k2 }}<br />
-          <br />
-          Always backup all keys that you're trying to write on the card. Without them you may not be able to change them in the future!<br />
+        <br />
+        Always backup all keys that you're trying to write on the card. Without
+        them you may not be able to change them in the future!<br />
       </p>
 
       <br />


### PR DESCRIPTION
It was written in the README, but I think it's better to warn in the UI as well. 
Missed it and lost a Boltcard in the process ;-) 