### PR TITLE
Holdinvoice

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -30,6 +30,7 @@ from .crud import (
     check_internal,
     create_payment,
     delete_payment,
+    get_standalone_payment,
     get_wallet,
     get_wallet_payment,
     update_payment_details,
@@ -155,6 +156,19 @@ async def cancel_hold_invoice(
     )
     if not ok:
         raise InvoiceFailure("Unexpected backend error.")
+
+    return True
+
+async def subscribe_hold_invoice(
+    *,
+    wallet_id: str,
+    payment_hash: bytes,
+    conn: Optional[Connection] = None,
+) -> bool:
+    payment = await get_standalone_payment(payment_hash, incoming=True)
+    asyncio.create_task(WALLET.hold_invoices_stream(
+        payment_hash=payment_hash, webhook=payment.webhook
+    ))
 
     return True
 

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -1,4 +1,5 @@
 import asyncio
+from distutils.log import error
 import json
 from binascii import unhexlify
 from io import BytesIO
@@ -93,6 +94,55 @@ async def create_invoice(
 
     return invoice.payment_hash, payment_request
 
+async def create_hold_invoice(
+    *,
+    wallet_id: str,
+    amount: int,  # in satoshis
+    memo: str,
+    hash: Optional[bytes] = None,
+    description_hash: Optional[bytes] = None,
+    extra: Optional[Dict] = None,
+    webhook: Optional[str] = None,
+    conn: Optional[Connection] = None,
+) -> Tuple[str, str]:
+    invoice_memo = None if description_hash else memo
+
+    ok, checking_id, payment_request, error_message = await WALLET.create_hold_invoice(
+        amount=amount, memo=invoice_memo, hash=hash, description_hash=description_hash
+    )
+    if not ok:
+        raise InvoiceFailure(error_message or "Unexpected backend error.")
+
+    invoice = bolt11.decode(payment_request)
+
+    amount_msat = amount * 1000
+    await create_payment(
+        wallet_id=wallet_id,
+        checking_id=checking_id,
+        payment_request=payment_request,
+        payment_hash=invoice.payment_hash,
+        amount=amount_msat,
+        memo=memo,
+        extra=extra,
+        webhook=webhook,
+        conn=conn,
+    )
+
+    return invoice.payment_hash, payment_request
+
+async def settle_hold_invoice(
+    *,
+    wallet_id: str,
+    preimage: bytes,
+    conn: Optional[Connection] = None,
+) -> bool:
+    ok = await WALLET.settle_hold_invoice(
+        preimage=preimage
+    )
+    if not ok:
+        raise InvoiceFailure("Unexpected backend error.")
+
+    return True
 
 async def pay_invoice(
     *,

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -144,6 +144,20 @@ async def settle_hold_invoice(
 
     return True
 
+async def cancel_hold_invoice(
+    *,
+    wallet_id: str,
+    payment_hash: bytes,
+    conn: Optional[Connection] = None,
+) -> bool:
+    ok = await WALLET.cancel_hold_invoice(
+        payment_hash=payment_hash
+    )
+    if not ok:
+        raise InvoiceFailure("Unexpected backend error.")
+
+    return True
+
 async def pay_invoice(
     *,
     wallet_id: str,

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -440,7 +440,7 @@ class SettleInvoice(BaseModel):
 async def api_payments_settle(
     data: SettleInvoice, wallet: WalletTypeInfo = Depends(require_invoice_key),
 ):
-    if wallet.wallet_type > 0 and wallet.wallet_type < 2:
+    if wallet.wallet_type > -1 and wallet.wallet_type < 2:
         # invoice or admin key
         return await api_payments_settle_invoice(data.preimage, wallet.wallet)
     else:

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -440,8 +440,8 @@ class SettleInvoice(BaseModel):
 async def api_payments_settle(
     data: SettleInvoice, wallet: WalletTypeInfo = Depends(require_invoice_key),
 ):
-    if wallet.wallet_type != 0:
-        # invoice key
+    if wallet.wallet_type > 0 and wallet.wallet_type < 2:
+        # invoice or admin key
         return await api_payments_settle_invoice(data.preimage, wallet.wallet)
     else:
         raise HTTPException(

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -159,7 +159,20 @@ class LndRestWallet(Wallet):
             )
 
         if r.is_error or r.json().get("payment_error"):
-            error_message = r.json().get("payment_error") or r.text
+            return False
+
+        return True
+
+    async def cancel_hold_invoice(self, payment_hash: str) -> PaymentResponse:
+        async with httpx.AsyncClient(verify=self.cert) as client:
+            data: Dict = {"payment_hash": base64.b64encode(payment_hash).decode("ascii")}
+            r = await client.post(
+                url=f"{self.endpoint}/v2/invoices/cancel",
+                headers=self.auth,
+                json=data,
+            )
+
+        if r.is_error or r.json().get("payment_error"):
             return False
 
         return True

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -22,7 +22,7 @@ from .macaroon import AESCipher, load_macaroon
 
 
 class LndRestWallet(Wallet):
-    """https://api.lightning.community/rest/index.html#lnd-rest-api-reference"""
+    """https://api.lightning.community/#lnd-rest-api-reference"""
 
     def __init__(self):
         endpoint = getenv("LND_REST_ENDPOINT")


### PR DESCRIPTION
* add holdinvoice endpoints for lndrest
* add webhooks for holdinvoice updates e.g. `state=ACCEPTED` or `state=CANCELED` as per LND REST API

This is useful when apps/extensions want to use hold invoice functionality instead of custodially accepting payments and then refunding them.
