### PR TITLE
Move comments above variables in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,10 @@ LNBITS_ADMIN_USERS=""
 LNBITS_ADMIN_EXTENSIONS="ngrok"
 LNBITS_DEFAULT_WALLET_NAME="LNbits wallet"
 
-LNBITS_AD_SPACE="" # csv ad image filepaths or urls, extensions can choose to honor
-LNBITS_HIDE_API=false # Hides wallet api, extensions can choose to honor
+# csv ad image filepaths or urls, extensions can choose to honor
+LNBITS_AD_SPACE=""
+# Hides wallet api, extensions can choose to honor
+LNBITS_HIDE_API=false 
 
 # Disable extensions for all users, use "all" to disable all extensions
 LNBITS_DISABLED_EXTENSIONS="amilk"
@@ -25,8 +27,10 @@ LNBITS_DATA_FOLDER="./data"
 
 LNBITS_FORCE_HTTPS=true
 LNBITS_SERVICE_FEE="0.0"
-LNBITS_RESERVE_FEE_MIN=2000 # value in millisats
-LNBITS_RESERVE_FEE_PERCENT=1.0 # value in percent
+# value in millisats
+LNBITS_RESERVE_FEE_MIN=2000
+# value in percent
+LNBITS_RESERVE_FEE_PERCENT=1.0
 
 # Change theme
 LNBITS_SITE_TITLE="LNbits"


### PR DESCRIPTION
Some env variables had an inline comment next to them. The comment is included in the value though, not considered a comment. Some numbers and booleans are considered invalid and the ad space became a list of 2 values: `# csv ad image filepaths or urls` and `extensions can choose to honor`. Moving the comments above the variables fixes this.