### PR TITLE
make sure tests not spamming boltz live servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ checkisort:
 	poetry run isort --check-only .
 
 test:
+	BOLTZ_NETWORK="regtest" \
+	BOLTZ_URL="http://127.0.0.1:9001" \
+	BOLTZ_MEMPOOL_SPACE_URL="http://127.0.0.1:8080" \
+	BOLTZ_MEMPOOL_SPACE_URL_WS="ws://127.0.0.1:8080" \
 	LNBITS_BACKEND_WALLET_CLASS="FakeWallet" \
 	FAKE_WALLET_SECRET="ToTheMoon1" \
 	LNBITS_DATA_FOLDER="./tests/data" \
@@ -46,6 +50,10 @@ test-real-wallet:
 	poetry run pytest
 
 test-venv:
+	BOLTZ_NETWORK="regtest" \
+	BOLTZ_URL="http://127.0.0.1:9001" \
+	BOLTZ_MEMPOOL_SPACE_URL="http://127.0.0.1:8080" \
+	BOLTZ_MEMPOOL_SPACE_URL_WS="ws://127.0.0.1:8080" \
 	LNBITS_BACKEND_WALLET_CLASS="FakeWallet" \
 	FAKE_WALLET_SECRET="ToTheMoon1" \
 	LNBITS_DATA_FOLDER="./tests/data" \

--- a/tests/extensions/boltz/test_api.py
+++ b/tests/extensions/boltz/test_api.py
@@ -5,18 +5,21 @@ from tests.helpers import is_fake, is_regtest
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(is_fake, reason="this test is only passes with regtest")
 async def test_mempool_url(client):
     response = await client.get("/boltz/api/v1/swap/mempool")
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(is_fake, reason="this test is only passes with regtest")
 async def test_boltz_config(client):
     response = await client.get("/boltz/api/v1/swap/boltz")
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(is_fake, reason="this test is only passes with regtest")
 async def test_endpoints_unauthenticated(client):
     response = await client.get("/boltz/api/v1/swap?all_wallets=true")
     assert response.status_code == 401
@@ -33,6 +36,7 @@ async def test_endpoints_unauthenticated(client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(is_fake, reason="this test is only passes with regtest")
 async def test_endpoints_inkey(client, inkey_headers_to):
     response = await client.get(
         "/boltz/api/v1/swap?all_wallets=true", headers=inkey_headers_to
@@ -56,6 +60,7 @@ async def test_endpoints_inkey(client, inkey_headers_to):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(is_fake, reason="this test is only passes with regtest")
 async def test_endpoints_adminkey_nocontent(client, adminkey_headers_to):
     response = await client.post("/boltz/api/v1/swap", headers=adminkey_headers_to)
     assert response.status_code == 204
@@ -71,54 +76,6 @@ async def test_endpoints_adminkey_nocontent(client, adminkey_headers_to):
         "/boltz/api/v1/swap/status", headers=adminkey_headers_to
     )
     assert response.status_code == 204
-
-
-@pytest.mark.asyncio
-@pytest.mark.skipif(is_regtest, reason="this test is only passes with fakewallet")
-async def test_endpoints_adminkey_fakewallet(client, from_wallet, adminkey_headers_to):
-    response = await client.post(
-        "/boltz/api/v1/swap/check", headers=adminkey_headers_to
-    )
-    assert response.status_code == 200
-    swap = {
-        "wallet": from_wallet.id,
-        "refund_address": "bcrt1q3cwq33y435h52gq3qqsdtczh38ltlnf69zvypm",
-        "amount": 50_000,
-    }
-    response = await client.post(
-        "/boltz/api/v1/swap", json=swap, headers=adminkey_headers_to
-    )
-    assert response.status_code == 405
-    reverse_swap = {
-        "wallet": from_wallet.id,
-        "instant_settlement": True,
-        "onchain_address": "bcrt1q4vfyszl4p8cuvqh07fyhtxve5fxq8e2ux5gx43",
-        "amount": 50_000,
-    }
-    response = await client.post(
-        "/boltz/api/v1/swap/reverse", json=reverse_swap, headers=adminkey_headers_to
-    )
-    assert response.status_code == 201
-    reverse_swap = response.json()
-    assert reverse_swap["id"] is not None
-    response = await client.post(
-        "/boltz/api/v1/swap/status",
-        params={"swap_id": reverse_swap["id"]},
-        headers=adminkey_headers_to,
-    )
-    assert response.status_code == 200
-    response = await client.post(
-        "/boltz/api/v1/swap/status",
-        params={"swap_id": "wrong"},
-        headers=adminkey_headers_to,
-    )
-    assert response.status_code == 404
-    response = await client.post(
-        "/boltz/api/v1/swap/refund",
-        params={"swap_id": "wrong"},
-        headers=adminkey_headers_to,
-    )
-    assert response.status_code == 404
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
our github workflow tests, may have created swaps on boltz.exchange.
This PR makes sure, it is uses localhost api URL, even though they are not running because no regtest is running.
It is fine for the tests, they are expected to fail for boltz tests not in regtest.
