### PR TITLE
Adding missing theme options in conf example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,8 @@ LNBITS_RESERVE_FEE_PERCENT=1.0
 LNBITS_SITE_TITLE="LNbits"
 LNBITS_SITE_TAGLINE="free and open-source lightning wallet"
 LNBITS_SITE_DESCRIPTION="Some description about your service, will display if title is not 'LNbits'"
-# Choose from mint, flamingo, freedom, salvador, autumn, monochrome, classic
-LNBITS_THEME_OPTIONS="classic, bitcoin, freedom, mint, autumn, monochrome, salvador"
+# Choose from bitcoin, mint, flamingo, freedom, salvador, autumn, monochrome, classic
+LNBITS_THEME_OPTIONS="classic, bitcoin, flamingo, freedom, mint, autumn, monochrome, salvador"
 # LNBITS_CUSTOM_LOGO="https://lnbits.com/assets/images/logo/logo.svg"
 
 # Choose from LNPayWallet, OpenNodeWallet, LntxbotWallet, ClicheWallet


### PR DESCRIPTION
This PR adds missing theme options in  `.env.example`:
- The `bitcoin` theme in the comment
- The `flamingo` theme in the list of values for `LNBITS_THEME_OPTIONS`