### PR TITLE
fix: use bigint for amounts in postgres

### DIFF
--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -52,6 +52,12 @@ class Compat:
             return ""
         return "<nothing>"
 
+    @property
+    def big_int(self) -> str:
+        if self.type in {POSTGRES}:
+            return "BIGINT"
+        return "INT"
+
 
 class Connection(Compat):
     def __init__(self, conn: AsyncConnection, txn, typ, name, schema):

--- a/lnbits/extensions/boltcards/migrations.py
+++ b/lnbits/extensions/boltcards/migrations.py
@@ -29,7 +29,7 @@ async def m001_initial(db):
     )
 
     await db.execute(
-        """
+        f"""
         CREATE TABLE boltcards.hits (
             id TEXT PRIMARY KEY UNIQUE,
             card_id TEXT NOT NULL,
@@ -38,7 +38,7 @@ async def m001_initial(db):
             useragent TEXT,
             old_ctr INT NOT NULL DEFAULT 0,
             new_ctr INT NOT NULL DEFAULT 0,
-            amount INT NOT NULL,
+            amount {db.big_int} NOT NULL,
             time TIMESTAMP NOT NULL DEFAULT """
         + db.timestamp_now
         + """
@@ -47,11 +47,11 @@ async def m001_initial(db):
     )
 
     await db.execute(
-        """
+        f"""
         CREATE TABLE boltcards.refunds (
             id TEXT PRIMARY KEY UNIQUE,
             hit_id TEXT NOT NULL,
-            refund_amount INT NOT NULL,
+            refund_amount {db.big_int} NOT NULL,
             time TIMESTAMP NOT NULL DEFAULT """
         + db.timestamp_now
         + """

--- a/lnbits/extensions/boltz/migrations.py
+++ b/lnbits/extensions/boltz/migrations.py
@@ -1,16 +1,16 @@
 async def m001_initial(db):
     await db.execute(
-        """
+        f"""
         CREATE TABLE boltz.submarineswap (
             id TEXT PRIMARY KEY,
             wallet TEXT NOT NULL,
             payment_hash TEXT NOT NULL,
-            amount INT NOT NULL,
+            amount {db.big_int} NOT NULL,
             status TEXT NOT NULL,
             boltz_id TEXT NOT NULL,
             refund_address TEXT NOT NULL,
             refund_privkey TEXT NOT NULL,
-            expected_amount INT NOT NULL,
+            expected_amount {db.big_int} NOT NULL,
             timeout_block_height INT NOT NULL,
             address TEXT NOT NULL,
             bip21 TEXT NOT NULL,
@@ -22,12 +22,12 @@ async def m001_initial(db):
     """
     )
     await db.execute(
-        """
+        f"""
         CREATE TABLE boltz.reverse_submarineswap (
             id TEXT PRIMARY KEY,
             wallet TEXT NOT NULL,
             onchain_address TEXT NOT NULL,
-            amount INT NOT NULL,
+            amount {db.big_int} NOT NULL,
             instant_settlement BOOLEAN NOT NULL,
             status TEXT NOT NULL,
             boltz_id TEXT NOT NULL,
@@ -37,7 +37,7 @@ async def m001_initial(db):
             claim_privkey TEXT NOT NULL,
             lockup_address TEXT NOT NULL,
             invoice TEXT NOT NULL,
-            onchain_amount INT NOT NULL,
+            onchain_amount {db.big_int} NOT NULL,
             time TIMESTAMP NOT NULL DEFAULT """
         + db.timestamp_now
         + """

--- a/lnbits/extensions/invoices/migrations.py
+++ b/lnbits/extensions/invoices/migrations.py
@@ -45,7 +45,7 @@ async def m001_initial_invoices(db):
            id TEXT PRIMARY KEY,
            invoice_id TEXT NOT NULL,
 
-           amount INT NOT NULL,
+           amount {db.big_int} NOT NULL,
 
            time TIMESTAMP NOT NULL DEFAULT {db.timestamp_now},
 

--- a/lnbits/extensions/lnurldevice/migrations.py
+++ b/lnbits/extensions/lnurldevice/migrations.py
@@ -29,7 +29,7 @@ async def m001_initial(db):
             payhash TEXT,
             payload TEXT NOT NULL,
             pin INT,
-            sats INT, 
+            sats {db.big_int}, 
             timestamp TIMESTAMP NOT NULL DEFAULT {db.timestamp_now}
         );
     """

--- a/lnbits/extensions/lnurlpayout/migrations.py
+++ b/lnbits/extensions/lnurlpayout/migrations.py
@@ -3,14 +3,14 @@ async def m001_initial(db):
     Initial lnurlpayouts table.
     """
     await db.execute(
-        """
+        f"""
         CREATE TABLE lnurlpayout.lnurlpayouts (
             id TEXT PRIMARY KEY,
             title TEXT NOT NULL,
             wallet TEXT NOT NULL,
             admin_key TEXT NOT NULL,
             lnurlpay TEXT NOT NULL,
-            threshold INT NOT NULL
+            threshold {db.big_int} NOT NULL
         );
     """
     )

--- a/lnbits/extensions/streamalerts/migrations.py
+++ b/lnbits/extensions/streamalerts/migrations.py
@@ -25,7 +25,7 @@ async def m001_initial(db):
             name TEXT NOT NULL,
             message TEXT NOT NULL,
             cur_code TEXT NOT NULL,
-            sats INT NOT NULL,
+            sats {db.big_int} NOT NULL,
             amount FLOAT NOT NULL,
             service INTEGER NOT NULL,
             posted BOOLEAN NOT NULL,

--- a/lnbits/extensions/tipjar/migrations.py
+++ b/lnbits/extensions/tipjar/migrations.py
@@ -19,8 +19,8 @@ async def m001_initial(db):
             wallet TEXT NOT NULL,
             name TEXT NOT NULL,
             message TEXT NOT NULL,
-            sats INT NOT NULL,
-            tipjar INT NOT NULL,
+            sats {db.big_int} NOT NULL,
+            tipjar {db.big_int} NOT NULL,
             FOREIGN KEY(tipjar) REFERENCES {db.references_schema}TipJars(id)
         );
         """


### PR DESCRIPTION
The amount in `sats` can be higher than the the `INT` type in postgres (2^32)
**Solution**:
 - add the `big_int` property (simialr with `timestamp_now`)

**Note**:
 - in Postgres `int8` is an alias for `BIGINT`
 - expected_amount: `BIGINT`
 - timeout_block_height: `INT`

![image](https://user-images.githubusercontent.com/2951406/193531305-21f2fce3-d59d-4eeb-acee-4305880d021c.png)
