### PR TITLE
make gh workflows only run on pull_request

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: codeql
 
 on:
-  push:
-    branches: [main, ]
   pull_request:
     branches: [main]
   schedule:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,8 +1,6 @@
 name: formatting
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,6 +1,6 @@
 name: mypy
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   check:

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -1,6 +1,6 @@
 name: regtest
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   LndRestWallet:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   venv-sqlite:


### PR DESCRIPTION
make github workflows only run on pull_request.

they run twice now in some cases.

![screenshot-1665042259](https://user-images.githubusercontent.com/1743657/194259748-6c261f66-e95d-4a6e-a5b7-0f7797e65a3b.jpg)
