### PR TITLE
Fix/splitpayments scrub multi wallet

### DIFF
--- a/lnbits/extensions/scrub/README.md
+++ b/lnbits/extensions/scrub/README.md
@@ -4,6 +4,8 @@
 
 SCRUB is a small but handy extension that allows a user to take advantage of all the functionalities inside **LNbits** and upon a payment received to your LNbits wallet, automatically forward it to your desired wallet via LNURL or LNAddress!
 
+<small>Only whole values, integers, are Scrubbed, amounts will be rounded down (example: 6.3 will be 6)! The decimals, if existing, will be kept in your wallet!</small>
+
 [**Wallets supporting LNURL**](https://github.com/fiatjaf/awesome-lnurl#wallets)
 
 ## Usage

--- a/lnbits/extensions/scrub/tasks.py
+++ b/lnbits/extensions/scrub/tasks.py
@@ -44,7 +44,7 @@ async def on_invoice_paid(payment: Payment) -> None:
     # I REALLY HATE THIS DUPLICATION OF CODE!! CORE/VIEWS/API.PY, LINE 267
     domain = urlparse(data["callback"]).netloc
     rounded_amount = floor(payment.amount / 1000) * 1000
-    
+
     async with httpx.AsyncClient() as client:
         try:
             r = await client.get(
@@ -68,7 +68,7 @@ async def on_invoice_paid(payment: Payment) -> None:
         )
 
     invoice = bolt11.decode(params["pr"])
-    
+
     if invoice.amount_msat != rounded_amount:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,

--- a/lnbits/extensions/splitpayments/tasks.py
+++ b/lnbits/extensions/splitpayments/tasks.py
@@ -28,6 +28,10 @@ async def on_invoice_paid(payment: Payment) -> None:
 
     # now we make some special internal transfers (from no one to the receiver)
     targets = await get_targets(payment.wallet_id)
+
+    if not targets:
+        return
+
     transfers = [
         (target.wallet, int(target.percent * payment.amount / 100))
         for target in targets
@@ -39,9 +43,6 @@ async def on_invoice_paid(payment: Payment) -> None:
         logger.error(
             "splitpayments failure: amount_left is negative.", payment.payment_hash
         )
-        return
-
-    if not targets:
         return
 
     # mark the original payment with one extra key, "splitted"
@@ -76,5 +77,5 @@ async def on_invoice_paid(payment: Payment) -> None:
         )
 
         # manually send this for now
-    await internal_invoice_queue.put(internal_checking_id)
+        await internal_invoice_queue.put(internal_checking_id)
     return


### PR DESCRIPTION
Fix issue with using split payments and scrub!

split payments wasn't properly notifying wallets of a new payment!

scrub had an issue with non integer amounts, which were coming from splitpayments. amount is now rounded down to integer, and "change" the decimal part is kept in user's wallet! 