### PR TITLE
nicer logger formatting for successful backend connection

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -126,7 +126,7 @@ def check_funding_source(app: FastAPI) -> None:
             logger.info("Retrying connection to backend in 5 seconds...")
             await asyncio.sleep(5)
         signal.signal(signal.SIGINT, original_sigint_handler)
-        logger.info(
+        logger.success(
             f"✔️ Backend {WALLET.__class__.__name__} connected and with a balance of {balance} msat."
         )
 


### PR DESCRIPTION

![screenshot-1665124136](https://user-images.githubusercontent.com/1743657/194482485-edac6559-74e0-4019-bb0e-e7661b91f119.jpg)

i changed the log of a successful backend connection from INFO to SUCCESS, looks better :), it is green now.
