### PR TITLE
Add Rounding as tipping option

### DIFF
--- a/lnbits/extensions/tpos/templates/tpos/index.html
+++ b/lnbits/extensions/tpos/templates/tpos/index.html
@@ -139,8 +139,12 @@
           input-debounce="0"
           new-value-mode="add-unique"
           label="Tip % Options (hit enter to add values)"
-          ><q-tooltip>Hit enter to add values</q-tooltip></q-select
-        >
+          ><q-tooltip>Hit enter to add values</q-tooltip>
+          <template v-slot:hint>
+            You can leave this blank. A default rounding option is available
+            (round amount to a value)
+          </template>
+        </q-select>
         <div class="row q-mt-lg">
           <q-btn
             unelevated

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -230,7 +230,7 @@
             :outline="!($q.dark.isActive)"
             rounded
             color="primary"
-            label="Round"
+            label="Custom"
           ></q-btn>
           <q-input
             class="q-my-lg"
@@ -239,10 +239,10 @@
             filled
             v-model.number="tipRounding"
             :placeholder="roundToSugestion"
-            hint="Rounded amount"
+            hint="Total amount including tip"
           >
             <template v-slot:append>
-              <q-icon name="send" @click="calculatePercent" />
+              <q-icon name="check" @click="calculatePercent" />
             </template>
           </q-input>
         </div>
@@ -449,7 +449,7 @@
         if (change < 0) {
           this.$q.notify({
             type: 'warning',
-            message: 'Value must be greater than initial amount'
+            message: 'Amount with tip must be greater than initial amount.'
           })
           this.tipRounding = this.roundToSugestion
           return

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -17,6 +17,7 @@
           <h5 class="q-mt-none q-mb-sm">
             {% raw %}{{ fsat }}{% endraw %} <small>sat</small>
           </h5>
+          <p>{% raw %}{{ parseFloat(roundToSugestion) }}{% endraw %}</p>
         </div>
       </div>
     </q-page-sticky>
@@ -214,14 +215,37 @@
             style="padding: 10px; margin: 3px"
             unelevated
             @click="processTipSelection(tip)"
-            size="xl"
+            size="lg"
             :outline="!($q.dark.isActive)"
             rounded
             color="primary"
-            v-for="tip in this.tip_options"
+            v-for="tip in tip_options.filter(f => f != 'Round')"
             :key="tip"
             >{% raw %}{{ tip }}{% endraw %}%</q-btn
           >
+          <q-btn
+            style="padding: 10px; margin: 3px"
+            unelevated
+            @click="setRounding"
+            size="lg"
+            :outline="!($q.dark.isActive)"
+            rounded
+            color="primary"
+            label="Round"
+            ></q-btn
+          >          
+          <q-input
+            ref="inputRounding"
+            v-if="rounding"
+            filled
+            v-model.number="tipRounding"
+            :placeholder="roundToSugestion"
+            hint="Rounded amount"
+          >
+        <template v-slot:append>
+          <q-icon name="send" @click="processTipSelection((1 - (amount/tipRounding))*100)" />
+        </template>
+      </q-input>
         </div>
         <div class="text-center q-mb-xl">
           <p><a @click="processTipSelection(0)"> No, thanks</a></p>
@@ -336,6 +360,7 @@
         exchangeRate: null,
         stack: [],
         tipAmount: 0.0,
+        tipRounding: null,
         hasNFC: false,
         nfcTagReading: false,
         lastPaymentsDialog: {
@@ -356,7 +381,8 @@
         },
         complete: {
           show: false
-        }
+        },
+        rounding: false
       }
     },
     computed: {
@@ -389,9 +415,36 @@
       },
       fsat: function () {
         return LNbits.utils.formatSat(this.sat)
+      },
+      isRoundValid(){
+        return this.tipRounding > this.amount
+      },
+      roundToSugestion(){        
+        //let toNext = 1
+        switch(true){
+          case this.amount > 50:
+            toNext = 10
+            break
+          case this.amount > 6:
+            toNext = 5
+            break
+          case this.amount > 2.5:
+            toNext = 1
+            break
+          default:
+            toNext = 0.5
+            break
+        }
+        
+        return Math.ceil(this.amount/toNext)*toNext
       }
     },
     methods: {
+      setRounding(){
+        this.rounding = true
+        this.tipRounding = this.roundToSugestion
+        this.$nextTick(() => this.$refs.inputRounding.focus())
+      },
       closeInvoiceDialog: function () {
         this.stack = []
         this.tipAmount = 0.0
@@ -589,6 +642,10 @@
         '{{ tpos.tip_options | tojson }}' == 'null'
           ? null
           : JSON.parse('{{ tpos.tip_options }}')
+
+      if('{{ tpos.tip_wallet }}') {
+        this.tip_options.push("Round")
+      }
       setInterval(function () {
         getRates()
       }, 120000)

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -242,9 +242,6 @@
               hint="Total amount including tip"
               :prefix="currency"
             >
-              <!-- <template v-slot:append>
-                <q-icon name="send" @click="calculatePercent" />
-              </template> -->
             </q-input>
             <q-btn
               class="q-ml-sm"
@@ -428,7 +425,6 @@
         return this.tipRounding > this.amount
       },
       roundToSugestion() {
-        //let toNext = 1
         switch (true) {
           case this.amount > 50:
             toNext = 10
@@ -675,17 +671,15 @@
   })
 </script>
 <style scoped>
-  
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
 
-/* Firefox */
-input[type=number] {
-  -moz-appearance: textfield;
-}
-  
+  /* Firefox */
+  input[type='number'] {
+    -moz-appearance: textfield;
+  }
 </style>
 {% endblock %}

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -230,21 +230,25 @@
             :outline="!($q.dark.isActive)"
             rounded
             color="primary"
-            label="Custom"
+            label="Round to"
           ></q-btn>
-          <q-input
-            class="q-my-lg"
-            ref="inputRounding"
-            v-if="rounding"
-            filled
-            v-model.number="tipRounding"
-            :placeholder="roundToSugestion"
-            hint="Total amount including tip"
+          <div class="row q-my-lg" v-if="rounding">
+            <q-input
+              class="col"
+              ref="inputRounding"
+              v-model.number="tipRounding"
+              :placeholder="roundToSugestion"
+              hint="Total amount including tip"
+              :prefix="currency"
+            >
+              <!-- <template v-slot:append>
+                <q-icon name="send" @click="calculatePercent" />
+              </template> -->
+            </q-input>
+            <q-btn class="q-ml-sm" style="margin-bottom: 20px;" color="primary" @click="calculatePercent"
+            >Ok</q-btn
           >
-            <template v-slot:append>
-              <q-icon name="check" @click="calculatePercent" />
-            </template>
-          </q-input>
+          </div>
         </div>
         <div class="row q-mt-lg">
           <q-btn flat color="primary" @click="processTipSelection(0)"
@@ -478,6 +482,8 @@
       },
       submitForm: function () {
         if (this.tip_options && this.tip_options.length) {
+          this.rounding = false
+          this.tipRounding = null
           this.showTipModal()
         } else {
           this.showInvoice()

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -245,9 +245,13 @@
                 <q-icon name="send" @click="calculatePercent" />
               </template> -->
             </q-input>
-            <q-btn class="q-ml-sm" style="margin-bottom: 20px;" color="primary" @click="calculatePercent"
-            >Ok</q-btn
-          >
+            <q-btn
+              class="q-ml-sm"
+              style="margin-bottom: 20px"
+              color="primary"
+              @click="calculatePercent"
+              >Ok</q-btn
+            >
           </div>
         </div>
         <div class="row q-mt-lg">

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -238,6 +238,7 @@
               ref="inputRounding"
               v-model.number="tipRounding"
               :placeholder="roundToSugestion"
+              type="number"
               hint="Total amount including tip"
               :prefix="currency"
             >
@@ -673,4 +674,18 @@
     }
   })
 </script>
+<style scoped>
+  
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+/* Firefox */
+input[type=number] {
+  -moz-appearance: textfield;
+}
+  
+</style>
 {% endblock %}

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -17,7 +17,6 @@
           <h5 class="q-mt-none q-mb-sm">
             {% raw %}{{ fsat }}{% endraw %} <small>sat</small>
           </h5>
-          <p>{% raw %}{{ parseFloat(roundToSugestion) }}{% endraw %}</p>
         </div>
       </div>
     </q-page-sticky>
@@ -232,9 +231,9 @@
             rounded
             color="primary"
             label="Round"
-            ></q-btn
-          >          
+          ></q-btn>
           <q-input
+            class="q-my-lg"
             ref="inputRounding"
             v-if="rounding"
             filled
@@ -242,15 +241,15 @@
             :placeholder="roundToSugestion"
             hint="Rounded amount"
           >
-        <template v-slot:append>
-          <q-icon name="send" @click="processTipSelection((1 - (amount/tipRounding))*100)" />
-        </template>
-      </q-input>
-        </div>
-        <div class="text-center q-mb-xl">
-          <p><a @click="processTipSelection(0)"> No, thanks</a></p>
+            <template v-slot:append>
+              <q-icon name="send" @click="calculatePercent" />
+            </template>
+          </q-input>
         </div>
         <div class="row q-mt-lg">
+          <q-btn flat color="primary" @click="processTipSelection(0)"
+            >No, thanks</q-btn
+          >
           <q-btn v-close-popup flat color="grey" class="q-ml-auto">Close</q-btn>
         </div>
       </q-card>
@@ -416,12 +415,12 @@
       fsat: function () {
         return LNbits.utils.formatSat(this.sat)
       },
-      isRoundValid(){
+      isRoundValid() {
         return this.tipRounding > this.amount
       },
-      roundToSugestion(){        
+      roundToSugestion() {
         //let toNext = 1
-        switch(true){
+        switch (true) {
           case this.amount > 50:
             toNext = 10
             break
@@ -435,15 +434,27 @@
             toNext = 0.5
             break
         }
-        
-        return Math.ceil(this.amount/toNext)*toNext
+
+        return Math.ceil(this.amount / toNext) * toNext
       }
     },
     methods: {
-      setRounding(){
+      setRounding() {
         this.rounding = true
         this.tipRounding = this.roundToSugestion
         this.$nextTick(() => this.$refs.inputRounding.focus())
+      },
+      calculatePercent() {
+        let change = ((this.tipRounding - this.amount) / this.amount) * 100
+        if (change < 0) {
+          this.$q.notify({
+            type: 'warning',
+            message: 'Value must be greater than initial amount'
+          })
+          this.tipRounding = this.roundToSugestion
+          return
+        }
+        this.processTipSelection(change)
       },
       closeInvoiceDialog: function () {
         this.stack = []
@@ -643,8 +654,8 @@
           ? null
           : JSON.parse('{{ tpos.tip_options }}')
 
-      if('{{ tpos.tip_wallet }}') {
-        this.tip_options.push("Round")
+      if ('{{ tpos.tip_wallet }}') {
+        this.tip_options.push('Round')
       }
       setInterval(function () {
         getRates()


### PR DESCRIPTION
Adds the option for a costumer to round the value to pay, as a tip.

Ex: amount is 1.25, costumer pays 2. 
0.75 is set as the tip and goes to selected tip wallet!