### PR TITLE
[WIP] fix warnings in python 3.10 for tests, event_loop

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,24 +16,19 @@ from tests.helpers import credit_wallet, get_random_invoice_data
 
 @pytest_asyncio.fixture(scope="session")
 def event_loop():
-    loop = asyncio.get_event_loop()
+    """Overrides pytest default function scoped event loop"""
+    policy = asyncio.get_event_loop_policy()
+    loop = policy.new_event_loop()
     yield loop
     loop.close()
 
 
 # use session scope to run once before and once after all tests
 @pytest_asyncio.fixture(scope="session")
-def app(event_loop):
+async def app():
     app = create_app()
-    # use redefined version of the event loop for scope="session"
-    # loop = asyncio.get_event_loop()
-    loop = event_loop
-    loop.run_until_complete(migrate_databases())
+    await migrate_databases()
     yield app
-    # # get the current event loop and gracefully stop any running tasks
-    # loop = event_loop
-    loop.run_until_complete(loop.shutdown_asyncgens())
-    # loop.close()
 
 
 @pytest_asyncio.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,11 @@
 import asyncio
-from typing import Tuple
 
 import pytest_asyncio
 from httpx import AsyncClient
 
 from lnbits.app import create_app
 from lnbits.commands import migrate_databases
-from lnbits.core.crud import create_account, create_wallet, get_wallet
-from lnbits.core.models import BalanceCheck, Payment, User, Wallet
+from lnbits.core.crud import create_account, create_wallet
 from lnbits.core.views.api import CreateInvoiceData, api_payments_create_invoice
 from lnbits.db import Database
 from lnbits.settings import HOST, PORT
@@ -20,6 +18,7 @@ def event_loop():
     policy = asyncio.get_event_loop_policy()
     loop = policy.new_event_loop()
     yield loop
+    loop.run_until_complete(loop.shutdown_asyncgens())
     loop.close()
 
 


### PR DESCRIPTION
fixes following deprecating warnings on running tests `make test`

```

tests/core/views/test_api.py::test_core_views_generic
/home/dni/repos/lnbits/FinalAdminUI/lnbits/extensions/subdomains/__init__.py:24: DeprecationWarning: There is no current event loop
loop = asyncio.get_event_loop()

tests/core/views/test_api.py::test_core_views_generic
/home/dni/repos/lnbits/FinalAdminUI/lnbits/extensions/splitpayments/__init__.py:34: DeprecationWarning: There is no current event loop
loop = asyncio.get_event_loop()

tests/core/views/test_api.py::test_core_views_generic
/home/dni/repos/lnbits/FinalAdminUI/lnbits/extensions/lnaddress/__init__.py:25: DeprecationWarning: There is no current event loop
loop = asyncio.get_event_loop()

tests/core/views/test_api.py::test_core_views_generic
/home/dni/repos/lnbits/FinalAdminUI/lnbits/extensions/jukebox/__init__.py:33: DeprecationWarning: There is no current event loop
loop = asyncio.get_event_loop()
```

