### PR TITLE
LNURLw extension: refactor try except block

### DIFF
--- a/lnbits/extensions/withdraw/lnurl.py
+++ b/lnbits/extensions/withdraw/lnurl.py
@@ -78,34 +78,35 @@ async def api_lnurl_callback(
         return {"status": "ERROR", "reason": f"Wait {link.open_time - now} seconds."}
 
     usescsv = ""
+
+    for x in range(1, link.uses - link.used):
+        usecv = link.usescsv.split(",")
+        usescsv += "," + str(usecv[x])
+    usecsvback = usescsv
+
+    found = False
+    if id_unique_hash is not None:
+        useslist = link.usescsv.split(",")
+        for ind, x in enumerate(useslist):
+            tohash = link.id + link.unique_hash + str(x)
+            if id_unique_hash == shortuuid.uuid(name=tohash):
+                found = True
+                useslist.pop(ind)
+                usescsv = ",".join(useslist)
+        if not found:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND, detail="LNURL-withdraw not found."
+            )
+    else:
+        usescsv = usescsv[1:]
+
+    changesback = {
+        "open_time": link.wait_time,
+        "used": link.used,
+        "usescsv": usecsvback,
+    }
+
     try:
-        for x in range(1, link.uses - link.used):
-            usecv = link.usescsv.split(",")
-            usescsv += "," + str(usecv[x])
-        usecsvback = usescsv
-
-        found = False
-        if id_unique_hash is not None:
-            useslist = link.usescsv.split(",")
-            for ind, x in enumerate(useslist):
-                tohash = link.id + link.unique_hash + str(x)
-                if id_unique_hash == shortuuid.uuid(name=tohash):
-                    found = True
-                    useslist.pop(ind)
-                    usescsv = ",".join(useslist)
-            if not found:
-                raise HTTPException(
-                    status_code=HTTPStatus.NOT_FOUND, detail="LNURL-withdraw not found."
-                )
-        else:
-            usescsv = usescsv[1:]
-
-        changesback = {
-            "open_time": link.wait_time,
-            "used": link.used,
-            "usescsv": usecsvback,
-        }
-
         changes = {
             "open_time": link.wait_time + now,
             "used": link.used + 1,


### PR DESCRIPTION
If the lnurlw link was not found, the code would raise an `HTTPException` (line 97) which would in turn then trigger the `except` block in line 144, where the code tries to access the variable `changesback` which was still undefined. 

Now the `try: except:` block starts later.


Here is the full stack trace:

```bash
2022-10-26 09:52:16.95 | ERROR | lnbits.app:basic_error:197 | handled error
2022-10-26 09:52:16.95 | ERROR | lnbits.app:basic_error:198 | ERROR:
Traceback (most recent call last):
  File "/root/fast/lnbits-legend/lnbits/extensions/withdraw/lnurl.py", line 97, in api_lnurl_callback
    raise HTTPException(
fastapi.exceptions.HTTPException
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/gzip.py", line 24, in __call__
    await responder(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/gzip.py", line 43, in __call__
    await self.app(scope, receive, self.send_with_gzip)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/cors.py", line 84, in __call__
    await self.app(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/exceptions.py", line 93, in __call__
    raise exc
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/routing.py", line 266, in handle
    await self.app(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/routing.py", line 65, in app
    response = await func(request)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/routing.py", line 227, in app
    raw_response = await run_endpoint_function(
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/routing.py", line 160, in run_endpoint_function
    return await dependant.call(**values)
  File "/root/fast/lnbits-legend/lnbits/extensions/withdraw/lnurl.py", line 144, in api_lnurl_callback
    await update_withdraw_link(link.id, **changesback)
UnboundLocalError: local variable 'changesback' referenced before assignment
2022-10-26 09:52:16.95 | ERROR | Exception in ASGI application
ERROR:uvicorn.error:Exception in ASGI application
Traceback (most recent call last):
  File "/root/fast/lnbits-legend/lnbits/extensions/withdraw/lnurl.py", line 97, in api_lnurl_callback
    raise HTTPException(
fastapi.exceptions.HTTPException
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/gzip.py", line 24, in __call__
    await responder(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/gzip.py", line 43, in __call__
    await self.app(scope, receive, self.send_with_gzip)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/cors.py", line 84, in __call__
    await self.app(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/exceptions.py", line 93, in __call__
    raise exc
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/routing.py", line 266, in handle
    await self.app(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/routing.py", line 65, in app
    response = await func(request)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/routing.py", line 227, in app
    raw_response = await run_endpoint_function(
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/routing.py", line 160, in run_endpoint_function
    return await dependant.call(**values)
  File "/root/fast/lnbits-legend/lnbits/extensions/withdraw/lnurl.py", line 144, in api_lnurl_callback
    await update_withdraw_link(link.id, **changesback)
UnboundLocalError: local variable 'changesback' referenced before assignment
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/uvicorn/protocols/http/httptools_impl.py", line 401, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/fastapi/applications.py", line 269, in __call__
    await super().__call__(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/middleware/errors.py", line 174, in __call__
    response = await self.handler(request, exc)
  File "/root/fast/lnbits-legend/lnbits/app.py", line 212, in basic_error
    return JSONResponse(
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/responses.py", line 187, in __init__
    super().__init__(content, status_code, headers, media_type, background)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/responses.py", line 49, in __init__
    self.body = self.render(content)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/starlette/responses.py", line 190, in render
    return json.dumps(
  File "/usr/lib/python3.8/json/__init__.py", line 234, in dumps
    return cls(
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/root/.cache/pypoetry/virtualenvs/lnbits-3PdPdHve-py3.8/lib/python3.8/site-packages/pyln/client/lightning.py", line 13, in _patched_default
    return getattr(obj.__class__, "to_json", _patched_default.default)(obj)
TypeError: default() missing 1 required positional argument: 'o'
2022-10-26 09:52:16.96 | INFO | 186.223.171.237:0 - "GET /withdraw/api/v1/lnurl/cb
```