### PR TITLE
Documentation for postgresql default port

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -220,8 +220,8 @@ You need to edit the `.env` file.
 
 ```sh
 # add the database connection string to .env 'nano .env' LNBITS_DATABASE_URL=
-# postgres://<user>:<myPassword>@<host>/<lnbits> - alter line bellow with your user, password and db name
-LNBITS_DATABASE_URL="postgres://postgres:postgres@localhost/lnbits"
+# postgres://<user>:<myPassword>@<host>:5432/<lnbits> - alter line bellow with your user, password and db name
+LNBITS_DATABASE_URL="postgres://postgres:postgres@localhost:5432/lnbits"
 # save and exit
 ```
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -220,7 +220,7 @@ You need to edit the `.env` file.
 
 ```sh
 # add the database connection string to .env 'nano .env' LNBITS_DATABASE_URL=
-# postgres://<user>:<myPassword>@<host>:5432/<lnbits> - alter line bellow with your user, password and db name
+# postgres://<user>:<myPassword>@<host>:<port>/<lnbits> - alter line bellow with your user, password and db name
 LNBITS_DATABASE_URL="postgres://postgres:postgres@localhost:5432/lnbits"
 # save and exit
 ```


### PR DESCRIPTION
A port is necessary for postgresql config. Add postgresql default port 5432 in documentation for LNBITS_DATABASE_URL config