### PR TITLE
let poetry run lnbits recognize forwarded_allow_ips for https

### DIFF
--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -1,9 +1,7 @@
-import time
-
 import click
 import uvicorn
 
-from lnbits.settings import HOST, PORT
+from lnbits.settings import FORWARDED_ALLOW_IPS, HOST, PORT
 
 
 @click.command(
@@ -14,10 +12,20 @@ from lnbits.settings import HOST, PORT
 )
 @click.option("--port", default=PORT, help="Port to listen on")
 @click.option("--host", default=HOST, help="Host to run LNBits on")
+@click.option(
+    "--forwarded-allow-ips", default=FORWARDED_ALLOW_IPS, help="Allowed proxy servers"
+)
 @click.option("--ssl-keyfile", default=None, help="Path to SSL keyfile")
 @click.option("--ssl-certfile", default=None, help="Path to SSL certificate")
 @click.pass_context
-def main(ctx, port: int, host: str, ssl_keyfile: str, ssl_certfile: str):
+def main(
+    ctx,
+    port: int,
+    host: str,
+    forwarded_allow_ips: str,
+    ssl_keyfile: str,
+    ssl_certfile: str,
+):
     """Launched with `poetry run lnbits` at root level"""
     # this beautiful beast parses all command line arguments and passes them to the uvicorn server
     d = dict()
@@ -37,6 +45,7 @@ def main(ctx, port: int, host: str, ssl_keyfile: str, ssl_certfile: str):
         "lnbits.__main__:app",
         port=port,
         host=host,
+        forwarded_allow_ips=forwarded_allow_ips,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         **d

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -18,6 +18,8 @@ DEBUG = env.bool("DEBUG", default=False)
 HOST = env.str("HOST", default="127.0.0.1")
 PORT = env.int("PORT", default=5000)
 
+FORWARDED_ALLOW_IPS = env.str("FORWARDED_ALLOW_IPS", default="127.0.0.1")
+
 LNBITS_PATH = path.dirname(path.realpath(__file__))
 LNBITS_DATA_FOLDER = env.str(
     "LNBITS_DATA_FOLDER", default=path.join(LNBITS_PATH, "data")


### PR DESCRIPTION
running lnbits with `poetry run lnbits` did not take FORWARDED_ALLOW_IPS into account, so https was not working correctly
