### PR TITLE
API DOCS button in footer toolbar

### DIFF
--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -203,6 +203,18 @@
             flat
             dense
             :color="($q.dark.isActive) ? 'white' : 'primary'"
+            type="a"
+            href="/docs"
+            target="_blank"
+            rel="noopener"
+          >
+            API DOCS
+            <q-tooltip>View LNbits Swagger API docs</q-tooltip>
+          </q-btn>
+          <q-btn
+            flat
+            dense
+            :color="($q.dark.isActive) ? 'white' : 'primary'"
             icon="code"
             type="a"
             href="https://github.com/lnbits/lnbits"


### PR DESCRIPTION
added a API DOCS button linking to /docs swagger api docs into the footer toolbar.

![screenshot-1667824218](https://user-images.githubusercontent.com/1743657/200311383-9690e553-3aa6-468e-8d0c-b886ecdb3def.jpg)
![screenshot-1667824392](https://user-images.githubusercontent.com/1743657/200311468-a8efa547-d464-428a-af7e-a428f637e753.jpg)

