### PR TITLE
Docker file fix for missing directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:$PATH"
 
 WORKDIR /app
+RUN mkdir -p /app/lnbits/data
 
 COPY . .
 


### PR DESCRIPTION
Currently Docker will error and exit because `data` directory is not created. 

This commit adds automatic `data` directory creation to Dockerfile so that the following docker command will not error. 

```
docker run --detach --publish 5000:5000 --name lnbits-legend --volume ${PWD}/.env:/app/.env --volume ${PWD}/data/:/app/data lnbits-legend
```