### PR TITLE
Documentation improved in example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ PORT=5000
 
 DEBUG=false
 
+# Find "usr" string in wallet url to explicit allow users or set admins (comma separated list)
 LNBITS_ALLOWED_USERS=""
 LNBITS_ADMIN_USERS=""
 # Extensions only admin can access


### PR DESCRIPTION
LNBITS_ALLOWED_USERS and LNBITS_ADMIN_USERS wants usr string from wallet url

List needs to be comma separated if used more than one user