### PR TITLE
feat: make boltcard message customizable

### DIFF
--- a/lnbits/extensions/boltcards/crud.py
+++ b/lnbits/extensions/boltcards/crud.py
@@ -20,6 +20,7 @@ async def create_card(data: CreateCardData, wallet_id: str) -> Card:
             external_id,
             wallet,
             card_name,
+            message,
             counter,
             tx_limit,
             daily_limit,
@@ -29,7 +30,7 @@ async def create_card(data: CreateCardData, wallet_id: str) -> Card:
             k2,
             otp
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             card_id,
@@ -37,6 +38,7 @@ async def create_card(data: CreateCardData, wallet_id: str) -> Card:
             extenal_id,
             wallet_id,
             data.card_name,
+            data.message,
             data.counter,
             data.tx_limit,
             data.daily_limit,

--- a/lnbits/extensions/boltcards/lnurl.py
+++ b/lnbits/extensions/boltcards/lnurl.py
@@ -94,7 +94,9 @@ async def api_scan(p, c, request: Request, external_id: str = None):
         "k1": hit.id,
         "minWithdrawable": 1 * 1000,
         "maxWithdrawable": card.tx_limit * 1000,
-        "defaultDescription": f"Boltcard (refund address lnurl://{lnurlpay})",
+        "defaultDescription": card.message
+            .replace("{refund_url}", f"lnurl://{lnurlpay}")
+            .replace("{card_name}", card.card_name),
     }
 
 

--- a/lnbits/extensions/boltcards/migrations.py
+++ b/lnbits/extensions/boltcards/migrations.py
@@ -58,3 +58,10 @@ async def m001_initial(db):
         );
     """
     )
+
+
+async def m002_add_message(db):
+    """
+    Add column for card message that gets shown on scan.
+    """
+    await db.execute("ALTER TABLE boltcards.cards ADD COLUMN message TEXT NOT NULL DEFAULT 'Boltcard (refund address {refund_url})'")

--- a/lnbits/extensions/boltcards/models.py
+++ b/lnbits/extensions/boltcards/models.py
@@ -17,6 +17,7 @@ class Card(BaseModel):
     id: str
     wallet: str
     card_name: str
+    message: str
     uid: str
     external_id: str
     counter: int
@@ -45,6 +46,7 @@ class Card(BaseModel):
 
 class CreateCardData(BaseModel):
     card_name: str = Query(...)
+    message: str = Query("Boltcard (refund address {refund_url})")
     uid: str = Query(...)
     counter: int = Query(0)
     tx_limit: int = Query(0)

--- a/lnbits/extensions/boltcards/templates/boltcards/index.html
+++ b/lnbits/extensions/boltcards/templates/boltcards/index.html
@@ -278,6 +278,16 @@
             </q-btn>
           </div>
         </div>
+        <q-input
+          filled
+          dense
+          emit-value
+          v-model.trim="cardDialog.data.message"
+          type="text"
+          label="Message"
+        >
+          <q-tooltip>Message that gets shown on scan.</q-tooltip>
+        </q-input>
 
         <q-toggle
           v-model="toggleAdvanced"


### PR DESCRIPTION
This adds a field to the card create/edit screen that allows you to customize the message that gets sent with the scan response.

The current default message which includes a long URL for refunds can be jarring to look at. There needs to be a way to opt out from that.