### PR TITLE
fix: allow both `description_hash` and `unhashed_description` to be present

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -155,30 +155,29 @@ class CreateInvoiceData(BaseModel):
 
 
 async def api_payments_create_invoice(data: CreateInvoiceData, wallet: Wallet):
-    if data.description_hash:
+    if data.description_hash or data.unhashed_description:
         try:
-            description_hash = binascii.unhexlify(data.description_hash)
+            description_hash = (
+                binascii.unhexlify(data.description_hash)
+                if data.description_hash
+                else b""
+            )
+            unhashed_description = (
+                binascii.unhexlify(data.unhashed_description)
+                if data.unhashed_description
+                else b""
+            )
         except binascii.Error:
             raise HTTPException(
                 status_code=HTTPStatus.BAD_REQUEST,
-                detail="'description_hash' must be a valid hex string",
+                detail="'description_hash' and 'unhashed_description' must be a valid hex strings",
             )
-        unhashed_description = b""
-        memo = ""
-    elif data.unhashed_description:
-        try:
-            unhashed_description = binascii.unhexlify(data.unhashed_description)
-        except binascii.Error:
-            raise HTTPException(
-                status_code=HTTPStatus.BAD_REQUEST,
-                detail="'unhashed_description' must be a valid hex string",
-            )
-        description_hash = b""
         memo = ""
     else:
         description_hash = b""
         unhashed_description = b""
         memo = data.memo or LNBITS_SITE_TITLE
+
     if data.unit == "sat":
         amount = int(data.amount)
     else:


### PR DESCRIPTION
### Summary
Currently the `unhashed_description` is discarded if `description_hash` is present (and vice-versa).
This results in the `"'description_hash' unsupported by CLN, provide 'unhashed_description'"` being thrown for a LNbits instance with a `CLightningWallet` back-end wallet. 

The current fix allows both `description_hash` and `unhashed_description` to be present at the same time.

### Test

**The call:**
```
curl --location --request POST 'https://legend.lnbits.com/api/v1/payments' \
--header 'x-api-key: xxxxxxxxxxxxxxxxxxxxxxxx' \
--header 'Content-Type: application/json' \
--data-raw '{
    "out": false,
    "amount": 3,
    "description_hash": "4abe6ea61212e956ca0a3c81ea04d441527df9bd7674a6ee5113b53cf5fbb824",
    "unhashed_description": "5b5b22746578742f706c61696e222c20225061796d656e7420746f206d6f746f72696e6130225d2c205b22746578742f6964656e746966696572222c20226d6f746f72696e6130406c6e626974732e6c696e6b225d5d",
    "memo": ""
}'
```

**Returns:**
```
{
    "detail": "'description_hash' unsupported by CLN, provide 'unhashed_description'"
}
```