### PR TITLE
fix `staspay` webhook for LN payment

### DIFF
--- a/lnbits/extensions/satspay/crud.py
+++ b/lnbits/extensions/satspay/crud.py
@@ -98,7 +98,7 @@ async def delete_charge(charge_id: str) -> None:
     await db.execute("DELETE FROM satspay.charges WHERE id = ?", (charge_id,))
 
 
-async def check_address_balance(charge_id: str) -> List[Charges]:
+async def check_address_balance(charge_id: str) -> Optional[Charges]:
     charge = await get_charge(charge_id)
     if not charge.paid:
         if charge.onchainaddress:
@@ -120,8 +120,7 @@ async def check_address_balance(charge_id: str) -> List[Charges]:
 
             if invoice_status["paid"]:
                 return await update_charge(charge_id=charge_id, balance=charge.amount)
-    row = await db.fetchone("SELECT * FROM satspay.charges WHERE id = ?", (charge_id,))
-    return Charges.from_row(row) if row else None
+    return await get_charge(charge_id)
 
 
 async def get_charge_config(charge_id: str):

--- a/lnbits/extensions/satspay/crud.py
+++ b/lnbits/extensions/satspay/crud.py
@@ -1,6 +1,8 @@
+import json
 from typing import List, Optional
 
 import httpx
+from loguru import logger
 
 from lnbits.core.services import create_invoice
 from lnbits.core.views.api import api_payment
@@ -18,6 +20,10 @@ from .models import Charges, CreateCharge
 async def create_charge(user: str, data: CreateCharge) -> Charges:
     charge_id = urlsafe_short_hash()
     if data.onchainwallet:
+        config = await get_config(user)
+        data.extra = json.dumps(
+            {"mempool_endpoint": config.mempool_endpoint, "network": config.network}
+        )
         onchain = await get_fresh_address(data.onchainwallet)
         onchainaddress = onchain.address
     else:
@@ -48,9 +54,10 @@ async def create_charge(user: str, data: CreateCharge) -> Charges:
             completelinktext,
             time,
             amount,
-            balance
+            balance,
+            extra
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             charge_id,
@@ -67,6 +74,7 @@ async def create_charge(user: str, data: CreateCharge) -> Charges:
             data.time,
             data.amount,
             0,
+            data.extra,
         ),
     )
     return await get_charge(charge_id)
@@ -100,31 +108,27 @@ async def delete_charge(charge_id: str) -> None:
 
 async def check_address_balance(charge_id: str) -> Optional[Charges]:
     charge = await get_charge(charge_id)
+
     if not charge.paid:
         if charge.onchainaddress:
-            config = await get_charge_config(charge_id)
+            endpoint = (
+                f"{charge.config['mempool_endpoint']}/testnet"
+                if charge.config["network"] == "Testnet"
+                else charge.config["mempool_endpoint"]
+            )
             try:
                 async with httpx.AsyncClient() as client:
                     r = await client.get(
-                        config.mempool_endpoint
-                        + "/api/address/"
-                        + charge.onchainaddress
+                        endpoint + "/api/address/" + charge.onchainaddress
                     )
                     respAmount = r.json()["chain_stats"]["funded_txo_sum"]
                     if respAmount > charge.balance:
                         await update_charge(charge_id=charge_id, balance=respAmount)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(e)
         if charge.lnbitswallet:
             invoice_status = await api_payment(charge.payment_hash)
 
             if invoice_status["paid"]:
                 return await update_charge(charge_id=charge_id, balance=charge.amount)
     return await get_charge(charge_id)
-
-
-async def get_charge_config(charge_id: str):
-    row = await db.fetchone(
-        """SELECT "user" FROM satspay.charges WHERE id = ?""", (charge_id,)
-    )
-    return await get_config(row.user)

--- a/lnbits/extensions/satspay/helpers.py
+++ b/lnbits/extensions/satspay/helpers.py
@@ -1,8 +1,8 @@
 from .models import Charges
 
 
-def compact_charge(charge: Charges):
-    return {
+def public_charge(charge: Charges):
+    c = {
         "id": charge.id,
         "description": charge.description,
         "onchainaddress": charge.onchainaddress,
@@ -13,5 +13,12 @@ def compact_charge(charge: Charges):
         "balance": charge.balance,
         "paid": charge.paid,
         "timestamp": charge.timestamp,
-        "completelink": charge.completelink,  # should be secret?
+        "time_elapsed": charge.time_elapsed,
+        "time_left": charge.time_left,
+        "paid": charge.paid,
     }
+
+    if charge.paid:
+        c["completelink"] = charge.completelink
+
+    return c

--- a/lnbits/extensions/satspay/helpers.py
+++ b/lnbits/extensions/satspay/helpers.py
@@ -44,7 +44,7 @@ async def call_webhook(charge: Charges):
 
 async def fetch_onchain_balance(charge: Charges):
     endpoint = (
-        f"{charge.config['mempool_endpoint']}/testnet"
+        f"{charge.config.mempool_endpoint}/testnet"
         if charge.config.network == "Testnet"
         else charge.config.mempool_endpoint
     )

--- a/lnbits/extensions/satspay/helpers.py
+++ b/lnbits/extensions/satspay/helpers.py
@@ -35,18 +35,18 @@ async def call_webhook(charge: Charges):
                 json=public_charge(charge),
                 timeout=40,
             )
-        except AssertionError:
-            charge.webhook = None
+            return {"webhook_success": r.is_success, "webhook_message": r.reason_phrase}
         except Exception as e:
             logger.warning(f"Failed to call webhook for charge {charge.id}")
             logger.warning(e)
+            return {"webhook_success": False, "webhook_message": str(e)}
 
 
 async def fetch_onchain_balance(charge: Charges):
     endpoint = (
         f"{charge.config['mempool_endpoint']}/testnet"
-        if charge.config["network"] == "Testnet"
-        else charge.config["mempool_endpoint"]
+        if charge.config.network == "Testnet"
+        else charge.config.mempool_endpoint
     )
     async with httpx.AsyncClient() as client:
         r = await client.get(endpoint + "/api/address/" + charge.onchainaddress)

--- a/lnbits/extensions/satspay/migrations.py
+++ b/lnbits/extensions/satspay/migrations.py
@@ -30,7 +30,7 @@ async def m001_initial(db):
 
 async def m002_add_charge_extra_data(db):
     """
-    Add 'exta' for storing various config about the charge
+    Add 'extra' column for storing various config about the charge (JSON format)
     """
     await db.execute(
         """ALTER TABLE satspay.charges 

--- a/lnbits/extensions/satspay/migrations.py
+++ b/lnbits/extensions/satspay/migrations.py
@@ -26,3 +26,14 @@ async def m001_initial(db):
         );
     """
     )
+
+
+async def m002_add_charge_extra_data(db):
+    """
+    Add 'exta' for storing various config about the charge
+    """
+    await db.execute(
+        """ALTER TABLE satspay.charges 
+            ADD COLUMN extra TEXT DEFAULT '{"mempool_endpoint": "https://mempool.space", "network": "Mainnet"}';
+        """
+    )

--- a/lnbits/extensions/satspay/models.py
+++ b/lnbits/extensions/satspay/models.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 from sqlite3 import Row
 from typing import Optional
@@ -15,6 +16,7 @@ class CreateCharge(BaseModel):
     completelinktext: str = Query(None)
     time: int = Query(..., ge=1)
     amount: int = Query(..., ge=1)
+    extra: str = "{}"
 
 
 class Charges(BaseModel):
@@ -28,6 +30,7 @@ class Charges(BaseModel):
     webhook: Optional[str]
     completelink: Optional[str]
     completelinktext: Optional[str] = "Back to Merchant"
+    extra: str = "{}"
     time: int
     amount: int
     balance: int
@@ -54,3 +57,7 @@ class Charges(BaseModel):
             return True
         else:
             return False
+
+    @property
+    def config(self):
+        return json.loads(self.extra)

--- a/lnbits/extensions/satspay/models.py
+++ b/lnbits/extensions/satspay/models.py
@@ -19,6 +19,13 @@ class CreateCharge(BaseModel):
     extra: str = "{}"
 
 
+class ChargeConfig(BaseModel):
+    mempool_endpoint: Optional[str]
+    network: Optional[str]
+    webhook_success: Optional[bool] = False
+    webhook_message: Optional[str]
+
+
 class Charges(BaseModel):
     id: str
     description: Optional[str]
@@ -59,5 +66,9 @@ class Charges(BaseModel):
             return False
 
     @property
-    def config(self):
-        return json.loads(self.extra)
+    def config(self) -> ChargeConfig:
+        charge_config = json.loads(self.extra)
+        return ChargeConfig(**charge_config)
+
+    def must_call_webhook(self):
+        return self.webhook and self.paid and self.config.webhook_success == False

--- a/lnbits/extensions/satspay/static/js/utils.js
+++ b/lnbits/extensions/satspay/static/js/utils.js
@@ -14,7 +14,7 @@ const retryWithDelay = async function (fn, retryCount = 0) {
 }
 
 const mapCharge = (obj, oldObj = {}) => {
-  const charge = _.clone(obj)
+  const charge = {...obj, ...oldObj}
 
   charge.progress = obj.time_left < 0 ? 1 : 1 - obj.time_left / obj.time
   charge.time = minutesToTime(obj.time)

--- a/lnbits/extensions/satspay/static/js/utils.js
+++ b/lnbits/extensions/satspay/static/js/utils.js
@@ -14,15 +14,14 @@ const retryWithDelay = async function (fn, retryCount = 0) {
 }
 
 const mapCharge = (obj, oldObj = {}) => {
-  const charge = {...obj, ...oldObj}
+  const charge = {...oldObj, ...obj}
 
   charge.progress = obj.time_left < 0 ? 1 : 1 - obj.time_left / obj.time
   charge.time = minutesToTime(obj.time)
   charge.timeLeft = minutesToTime(obj.time_left)
 
-  charge.expanded = false
   charge.displayUrl = ['/satspay/', obj.id].join('')
-  charge.expanded = oldObj.expanded
+  charge.expanded = oldObj.expanded || false
   charge.pendingBalance = oldObj.pendingBalance || 0
   return charge
 }

--- a/lnbits/extensions/satspay/tasks.py
+++ b/lnbits/extensions/satspay/tasks.py
@@ -8,7 +8,7 @@ from lnbits.extensions.satspay.crud import check_address_balance, get_charge
 from lnbits.helpers import get_current_extension_name
 from lnbits.tasks import register_invoice_listener
 
-from .helpers import compact_charge
+from .helpers import public_charge
 from .models import Charges
 
 
@@ -43,7 +43,7 @@ async def call_webhook(charge: Charges):
         try:
             r = await client.post(
                 charge.webhook,
-                json=compact_charge(charge),
+                json=public_charge(charge),
                 timeout=40,
             )
         except AssertionError:

--- a/lnbits/extensions/satspay/templates/satspay/display.html
+++ b/lnbits/extensions/satspay/templates/satspay/display.html
@@ -109,7 +109,7 @@
               <q-btn
                 flat
                 disable
-                v-if="!charge.lnbitswallet || charge.time_elapsed"
+                v-if="!charge.payment_request || charge.time_elapsed"
                 style="color: primary; width: 100%"
                 label="lightning⚡"
               >
@@ -131,7 +131,7 @@
               <q-btn
                 flat
                 disable
-                v-if="!charge.onchainwallet || charge.time_elapsed"
+                v-if="!charge.onchainaddress || charge.time_elapsed"
                 style="color: primary; width: 100%"
                 label="onchain⛓️"
               >
@@ -222,7 +222,7 @@
           <div class="col text-center">
             <a
               style="color: unset"
-              :href="mempoolEndpoint + '/address/' + charge.onchainaddress"
+              :href="'https://' + mempoolHostname + '/address/' + charge.onchainaddress"
               target="_blank"
               ><span
                 class="text-subtitle1"
@@ -336,7 +336,7 @@
     },
     methods: {
       checkBalances: async function () {
-        if (!this.charge.lnbitswallet && this.charge.hasOnchainStaleBalance)
+        if (!this.charge.payment_request && this.charge.hasOnchainStaleBalance)
           return
         try {
           const {data} = await LNbits.api.request(
@@ -438,7 +438,7 @@
       }
     },
     created: async function () {
-      if (this.charge.lnbitswallet) this.payInvoice()
+      if (this.charge.payment_request) this.payInvoice()
       else this.payOnchain()
 
       await this.checkBalances()

--- a/lnbits/extensions/satspay/templates/satspay/display.html
+++ b/lnbits/extensions/satspay/templates/satspay/display.html
@@ -317,16 +317,6 @@
       }
     },
     methods: {
-      startPaymentNotifier() {
-        this.cancelListener()
-        if (!this.lnbitswallet) return
-        this.cancelListener = LNbits.events.onInvoicePaid(
-          this.wallet,
-          payment => {
-            this.checkInvoiceBalance()
-          }
-        )
-      },
       checkBalances: async function () {
         if (this.charge.hasStaleBalance) return
         try {
@@ -431,10 +421,6 @@
       if (this.charge.lnbitswallet) this.payInvoice()
       else this.payOnchain()
       await this.checkBalances()
-
-      // empty for onchain
-      this.wallet.inkey = '{{ wallet_inkey }}'
-      this.startPaymentNotifier()
 
       if (!this.charge.paid) {
         this.loopRefresh()

--- a/lnbits/extensions/satspay/templates/satspay/display.html
+++ b/lnbits/extensions/satspay/templates/satspay/display.html
@@ -218,7 +218,7 @@
           <div class="col text-center">
             <a
               style="color: unset"
-              :href="mempool_endpoint + '/address/' + charge.onchainaddress"
+              :href="mempoolEndpoint + '/address/' + charge.onchainaddress"
               target="_blank"
               ><span
                 class="text-subtitle1"
@@ -303,7 +303,8 @@
     data() {
       return {
         charge: JSON.parse('{{charge_data | tojson}}'),
-        mempool_endpoint: '{{mempool_endpoint}}',
+        mempoolEndpoint: '{{mempool_endpoint}}',
+        network: '{{network}}',
         pendingFunds: 0,
         ws: null,
         newProgress: 0.4,
@@ -314,6 +315,15 @@
           inkey: ''
         },
         cancelListener: () => {}
+      }
+    },
+    computed: {
+      mempoolHostname: function () {
+        let hostname = new URL(this.mempoolEndpoint).hostname
+        if (this.network === 'Testnet') {
+          hostname += '/testnet'
+        }
+        return hostname
       }
     },
     methods: {
@@ -335,7 +345,7 @@
         const {
           bitcoin: {addresses: addressesAPI}
         } = mempoolJS({
-          hostname: new URL(this.mempool_endpoint).hostname
+          hostname: new URL(this.mempoolEndpoint).hostname
         })
 
         try {
@@ -378,10 +388,10 @@
         const {
           bitcoin: {websocket}
         } = mempoolJS({
-          hostname: new URL(this.mempool_endpoint).hostname
+          hostname: new URL(this.mempoolEndpoint).hostname
         })
 
-        this.ws = new WebSocket('wss://mempool.space/api/v1/ws')
+        this.ws = new WebSocket(`wss://${this.mempoolHostname}/api/v1/ws`)
         this.ws.addEventListener('open', x => {
           if (this.charge.onchainaddress) {
             this.trackAddress(this.charge.onchainaddress)

--- a/lnbits/extensions/satspay/templates/satspay/display.html
+++ b/lnbits/extensions/satspay/templates/satspay/display.html
@@ -170,13 +170,17 @@
                 name="check"
                 style="color: green; font-size: 21.4em"
               ></q-icon>
-              <q-btn
-                outline
-                v-if="charge.webhook"
-                type="a"
-                :href="charge.completelink"
-                :label="charge.completelinktext"
-              ></q-btn>
+              <div class="row text-center q-mt-lg">
+                <div class="col text-center">
+                  <q-btn
+                    outline
+                    v-if="charge.webhook"
+                    type="a"
+                    :href="charge.completelink"
+                    :label="charge.completelinktext"
+                  ></q-btn>
+                </div>
+              </div>
             </div>
             <div v-else>
               <div class="row text-center q-mb-sm">
@@ -241,13 +245,17 @@
                 name="check"
                 style="color: green; font-size: 21.4em"
               ></q-icon>
-              <q-btn
-                outline
-                v-if="charge.webhook"
-                type="a"
-                :href="charge.completelink"
-                :label="charge.completelinktext"
-              ></q-btn>
+              <div class="row text-center q-mt-lg">
+                <div class="col text-center">
+                  <q-btn
+                    outline
+                    v-if="charge.webhook"
+                    type="a"
+                    :href="charge.completelink"
+                    :label="charge.completelinktext"
+                  ></q-btn>
+                </div>
+              </div>
             </div>
             <div v-else>
               <div class="row items-center q-mb-sm">
@@ -354,7 +362,8 @@
             address: this.charge.onchainaddress
           })
           const newBalance = utxos.reduce((t, u) => t + u.value, 0)
-          this.charge.hasOnchainStaleBalance = this.charge.balance === newBalance
+          this.charge.hasOnchainStaleBalance =
+            this.charge.balance === newBalance
 
           this.pendingFunds = utxos
             .filter(u => !u.status.confirmed)

--- a/lnbits/extensions/satspay/templates/satspay/display.html
+++ b/lnbits/extensions/satspay/templates/satspay/display.html
@@ -328,7 +328,8 @@
     },
     methods: {
       checkBalances: async function () {
-        if (this.charge.hasStaleBalance) return
+        if (!this.charge.lnbitswallet && this.charge.hasOnchainStaleBalance)
+          return
         try {
           const {data} = await LNbits.api.request(
             'GET',
@@ -353,7 +354,7 @@
             address: this.charge.onchainaddress
           })
           const newBalance = utxos.reduce((t, u) => t + u.value, 0)
-          this.charge.hasStaleBalance = this.charge.balance === newBalance
+          this.charge.hasOnchainStaleBalance = this.charge.balance === newBalance
 
           this.pendingFunds = utxos
             .filter(u => !u.status.confirmed)
@@ -430,6 +431,7 @@
     created: async function () {
       if (this.charge.lnbitswallet) this.payInvoice()
       else this.payOnchain()
+
       await this.checkBalances()
 
       if (!this.charge.paid) {

--- a/lnbits/extensions/satspay/templates/satspay/index.html
+++ b/lnbits/extensions/satspay/templates/satspay/index.html
@@ -539,7 +539,6 @@
             '/watchonly/api/v1/config',
             this.g.user.wallets[0].inkey
           )
-          console.log('### data', data)
           this.mempool.endpoint = data.mempool_endpoint
           this.mempool.network = data.network || 'Mainnet'
           const url = new URL(this.mempool.endpoint)

--- a/lnbits/extensions/satspay/templates/satspay/index.html
+++ b/lnbits/extensions/satspay/templates/satspay/index.html
@@ -412,7 +412,8 @@
         onchainwallet: null,
         rescanning: false,
         mempool: {
-          endpoint: ''
+          endpoint: '',
+          network: 'Mainnet'
         },
 
         chargesTable: {
@@ -519,7 +520,7 @@
         try {
           const {data} = await LNbits.api.request(
             'GET',
-            '/watchonly/api/v1/wallet',
+            `/watchonly/api/v1/wallet?network=${this.mempool.network}`,
             this.g.user.wallets[0].inkey
           )
           this.walletLinks = data.map(w => ({
@@ -538,7 +539,9 @@
             '/watchonly/api/v1/config',
             this.g.user.wallets[0].inkey
           )
+          console.log('### data', data)
           this.mempool.endpoint = data.mempool_endpoint
+          this.mempool.network = data.network || 'Mainnet'
           const url = new URL(this.mempool.endpoint)
           this.mempool.hostname = url.hostname
         } catch (error) {
@@ -697,8 +700,8 @@
     },
     created: async function () {
       await this.getCharges()
-      await this.getWalletLinks()
       await this.getWalletConfig()
+      await this.getWalletLinks()
       setInterval(() => this.refreshActiveChargesBalance(), 10 * 2000)
       await this.rescanOnchainAddresses()
       setInterval(() => this.rescanOnchainAddresses(), 10 * 1000)

--- a/lnbits/extensions/satspay/templates/satspay/index.html
+++ b/lnbits/extensions/satspay/templates/satspay/index.html
@@ -203,8 +203,13 @@
                       :href="props.row.webhook"
                       target="_blank"
                       style="color: unset; text-decoration: none"
-                      >{{props.row.webhook || props.row.webhook}}</a
+                      >{{props.row.webhook}}</a
                     >
+                  </div>
+                  <div class="col-4 q-pr-lg">
+                    <q-badge v-if="props.row.webhook_message" color="blue">
+                      {{props.row.webhook_message }}
+                    </q-badge>
                   </div>
                 </div>
                 <div class="row items-center q-mt-md q-mb-lg">

--- a/lnbits/extensions/satspay/templates/satspay/index.html
+++ b/lnbits/extensions/satspay/templates/satspay/index.html
@@ -578,7 +578,7 @@
         const data = this.formDialogCharge.data
         data.amount = parseInt(data.amount)
         data.time = parseInt(data.time)
-        data.lnbitswallet = data.lnbits ? this.lnbitswallet : null
+        data.lnbitswallet = data.lnbits ? data.lnbitswallet : null
         data.onchainwallet = data.onchain ? this.onchainwallet?.id : null
         this.createCharge(wallet, data)
       },

--- a/lnbits/extensions/satspay/templates/satspay/index.html
+++ b/lnbits/extensions/satspay/templates/satspay/index.html
@@ -409,7 +409,7 @@
         balance: null,
         walletLinks: [],
         chargeLinks: [],
-        onchainwallet: '',
+        onchainwallet: null,
         rescanning: false,
         mempool: {
           endpoint: ''
@@ -505,6 +505,7 @@
     methods: {
       cancelCharge: function (data) {
         this.formDialogCharge.data.description = ''
+        this.formDialogCharge.data.onchain = false
         this.formDialogCharge.data.onchainwallet = ''
         this.formDialogCharge.data.lnbitswallet = ''
         this.formDialogCharge.data.time = null
@@ -577,7 +578,8 @@
         const data = this.formDialogCharge.data
         data.amount = parseInt(data.amount)
         data.time = parseInt(data.time)
-        data.onchainwallet = this.onchainwallet?.id
+        data.lnbitswallet = data.lnbits ? this.lnbitswallet : null
+        data.onchainwallet = data.onchain ? this.onchainwallet?.id : null
         this.createCharge(wallet, data)
       },
       refreshActiveChargesBalance: async function () {

--- a/lnbits/extensions/satspay/views.py
+++ b/lnbits/extensions/satspay/views.py
@@ -30,17 +30,17 @@ async def display(request: Request, charge_id: str):
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="Charge link does not exist."
         )
-    wallet = await get_wallet(charge.lnbitswallet)
+
     onchainwallet_config = await get_charge_config(charge_id)
-    inkey = wallet.inkey if wallet else None
-    mempool_endpoint = (
-        onchainwallet_config.mempool_endpoint if onchainwallet_config else None
-    )
+    if onchainwallet_config:
+        mempool_endpoint = onchainwallet_config.mempool_endpoint
+        network = onchainwallet_config.network
     return satspay_renderer().TemplateResponse(
         "satspay/display.html",
         {
             "request": request,
             "charge_data": charge.dict(),
             "mempool_endpoint": mempool_endpoint,
+            "network": network,
         },
     )

--- a/lnbits/extensions/satspay/views.py
+++ b/lnbits/extensions/satspay/views.py
@@ -34,10 +34,9 @@ async def display(request: Request, charge_id: str):
     view_data = {
         "request": request,
         "charge_data": public_charge(charge),
+        "mempool_endpoint": charge.config.mempool_endpoint,
+        "network": charge.config.network
     }
-    if "mempool_endpoint" in charge.config:
-        view_data["mempool_endpoint"] = charge.config["mempool_endpoint"]
-        view_data["network"] = charge.config["network"]
 
     return satspay_renderer().TemplateResponse(
         "satspay/display.html",

--- a/lnbits/extensions/satspay/views.py
+++ b/lnbits/extensions/satspay/views.py
@@ -31,14 +31,12 @@ async def display(request: Request, charge_id: str):
             status_code=HTTPStatus.NOT_FOUND, detail="Charge link does not exist."
         )
 
-    view_data = {
-        "request": request,
-        "charge_data": public_charge(charge),
-        "mempool_endpoint": charge.config.mempool_endpoint,
-        "network": charge.config.network,
-    }
-
     return satspay_renderer().TemplateResponse(
         "satspay/display.html",
-        view_data,
+        {
+            "request": request,
+            "charge_data": public_charge(charge),
+            "mempool_endpoint": charge.config.mempool_endpoint,
+            "network": charge.config.network,
+        },
     )

--- a/lnbits/extensions/satspay/views.py
+++ b/lnbits/extensions/satspay/views.py
@@ -35,7 +35,7 @@ async def display(request: Request, charge_id: str):
         "request": request,
         "charge_data": public_charge(charge),
         "mempool_endpoint": charge.config.mempool_endpoint,
-        "network": charge.config.network
+        "network": charge.config.network,
     }
 
     return satspay_renderer().TemplateResponse(

--- a/lnbits/extensions/satspay/views.py
+++ b/lnbits/extensions/satspay/views.py
@@ -41,7 +41,6 @@ async def display(request: Request, charge_id: str):
         {
             "request": request,
             "charge_data": charge.dict(),
-            "wallet_inkey": inkey,
             "mempool_endpoint": mempool_endpoint,
         },
     )

--- a/lnbits/extensions/satspay/views_api.py
+++ b/lnbits/extensions/satspay/views_api.py
@@ -19,7 +19,7 @@ from .crud import (
     get_charges,
     update_charge,
 )
-from .helpers import compact_charge
+from .helpers import public_charge
 from .models import CreateCharge
 
 #############################CHARGES##########################
@@ -118,9 +118,4 @@ async def api_charge_balance(charge_id):
             status_code=HTTPStatus.NOT_FOUND, detail="Charge does not exist."
         )
 
-    return {
-        **compact_charge(charge),
-        **{"time_elapsed": charge.time_elapsed},
-        **{"time_left": charge.time_left},
-        **{"paid": charge.paid},
-    }
+    return {**public_charge(charge)}

--- a/lnbits/extensions/satspay/views_api.py
+++ b/lnbits/extensions/satspay/views_api.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 
-import httpx
 from fastapi.params import Depends
 from starlette.exceptions import HTTPException
 
@@ -119,16 +118,6 @@ async def api_charge_balance(charge_id):
             status_code=HTTPStatus.NOT_FOUND, detail="Charge does not exist."
         )
 
-    if charge.paid and charge.webhook:
-        async with httpx.AsyncClient() as client:
-            try:
-                r = await client.post(
-                    charge.webhook,
-                    json=compact_charge(charge),
-                    timeout=40,
-                )
-            except AssertionError:
-                charge.webhook = None
     return {
         **compact_charge(charge),
         **{"time_elapsed": charge.time_elapsed},

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -124,7 +124,7 @@ async def check_pending_payments():
 
     while True:
         async with db.connect() as conn:
-            logger.debug(
+            logger.info(
                 f"Task: checking all pending payments (incoming={incoming}, outgoing={outgoing}) of last 15 days"
             )
             start_time: float = time.time()
@@ -140,15 +140,15 @@ async def check_pending_payments():
             for payment in pending_payments:
                 await payment.check_status(conn=conn)
 
-            logger.debug(
+            logger.info(
                 f"Task: pending check finished for {len(pending_payments)} payments (took {time.time() - start_time:0.3f} s)"
             )
             # we delete expired invoices once upon the first pending check
             if incoming:
-                logger.debug("Task: deleting all expired invoices")
+                logger.info("Task: deleting all expired invoices")
                 start_time: float = time.time()
                 await delete_expired_invoices(conn=conn)
-                logger.debug(
+                logger.info(
                     f"Task: expired invoice deletion finished (took {time.time() - start_time:0.3f} s)"
                 )
 


### PR DESCRIPTION
### Summary
This PR contains several fixes and improvements.

- **fix**: on Charge page the tabs are disabled and a tool tip is shown (`...Payment Not Available`) even if the Charge is still active
- **fix**: the green checkmark is not shown after the payment is made (a page refresh was required)
- **fix**: `Webhook` not called by `task.py`
  - now the `webhook` is called when the invoice is paid
  - the status of the `webhook` call is persisted and shown to the user (see screenshot 1)
  - if the `webhook` call is successful, then it is now assured that it will not be called a second time
  - if the `webhook` call has failed, then it can be called again if the `Charge` page is refreshed
- **feat**: each charge persists its wallet config (mempool url, network) at the time of creation (for onchain charges)
  - charges should not be affected if the (creator) user changes its WatchOnly configs
  - added new column: `extra`
- **fix**: reduce the amount of info exposed to the public page
- **refactor**: extract business logic from `crud` into `helper`
- **chore**: increase log level for `lnbits/tasks.py`. Useful for noticing delays.

### Screenshots

1. webhook status
![image](https://user-images.githubusercontent.com/2951406/203985566-23907b67-54ac-4568-ac0f-e1ba8eaa426d.png)
