### PR TITLE
TPOS identifies itself via user-agent

### DIFF
--- a/lnbits/extensions/tpos/views_api.py
+++ b/lnbits/extensions/tpos/views_api.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 import httpx
 from fastapi import Query
 from fastapi.params import Depends
+from lnbits.settings import LNBITS_COMMIT
 from lnurl import decode as decode_lnurl
 from loguru import logger
 from starlette.exceptions import HTTPException
@@ -134,7 +135,8 @@ async def api_tpos_pay_invoice(
 
     async with httpx.AsyncClient() as client:
         try:
-            r = await client.get(lnurl, follow_redirects=True)
+            headers = {"user-agent": f"lnbits/tpos commit {LNBITS_COMMIT[:7]}"}
+            r = await client.get(lnurl, follow_redirects=True, headers=headers)
             if r.is_error:
                 lnurl_response = {"success": False, "detail": "Error loading"}
             else:
@@ -145,6 +147,7 @@ async def api_tpos_pay_invoice(
                     r2 = await client.get(
                         resp["callback"],
                         follow_redirects=True,
+                        headers=headers,
                         params={
                             "k1": resp["k1"],
                             "pr": payment_request,

--- a/lnbits/extensions/tpos/views_api.py
+++ b/lnbits/extensions/tpos/views_api.py
@@ -3,7 +3,6 @@ from http import HTTPStatus
 import httpx
 from fastapi import Query
 from fastapi.params import Depends
-from lnbits.settings import LNBITS_COMMIT
 from lnurl import decode as decode_lnurl
 from loguru import logger
 from starlette.exceptions import HTTPException
@@ -13,6 +12,7 @@ from lnbits.core.models import Payment
 from lnbits.core.services import create_invoice
 from lnbits.core.views.api import api_payment
 from lnbits.decorators import WalletTypeInfo, get_key_type, require_admin_key
+from lnbits.settings import LNBITS_COMMIT
 
 from . import tpos_ext
 from .crud import create_tpos, delete_tpos, get_tpos, get_tposs


### PR DESCRIPTION
When TPOS is getting a lnurl response, it identifies itself via user-agent header. This identification can be then displayed (not only) in the boltcard extension. 

So let me know if this is a good idea or a bad idea.