### PR TITLE
fix: do not apply `list()` to `str` value

### DIFF
--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -86,7 +86,8 @@ class Connection(Compat):
                 return raw_html
 
         # tuple to list and back to tuple
-        values = tuple([cleanhtml(l) for l in list(values)])
+        value_list = [values] if isinstance(values, str) else list(values)
+        values = tuple([cleanhtml(l) for l in value_list])
         return values
 
     async def fetchall(self, query: str, values: tuple = ()) -> list:


### PR DESCRIPTION
if `values` is `str` then `list(values)` will create a tuple where each character is an item:

```
7qGBzeL8gSYeFSWTiiCrL  ->  ('B', '7', 'q', 'G', 'B', 'z', 'e', 'L', '8', 'g', 'S', 'Y', 'e', 'F', 'S', 'W', 'T', 'i', 'i', 'C', 'r', 'L')
```