### PR TITLE
Fix: audit endpoint

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -686,7 +686,7 @@ async def img(request: Request, data):
     )
 
 
-@core_app.get("/api/v1/audit/")
+@core_app.get("/api/v1/audit")
 async def api_auditor(wallet: WalletTypeInfo = Depends(get_key_type)):
     if wallet.wallet.user not in LNBITS_ADMIN_USERS:
         raise HTTPException(


### PR DESCRIPTION
This PR fixes the audit endpoint route from `/api/v1/audit/` to `/api/v1/audit` (removing the trailing `/`).