### PR TITLE
feat: store & show `webhook` response body for charges

### DIFF
--- a/lnbits/extensions/satspay/helpers.py
+++ b/lnbits/extensions/satspay/helpers.py
@@ -37,7 +37,11 @@ async def call_webhook(charge: Charges):
                 json=public_charge(charge),
                 timeout=40,
             )
-            return {"webhook_success": r.is_success, "webhook_message": r.reason_phrase}
+            return {
+                "webhook_success": r.is_success,
+                "webhook_message": r.reason_phrase,
+                "webhook_response": r.text,
+            }
         except Exception as e:
             logger.warning(f"Failed to call webhook for charge {charge.id}")
             logger.warning(e)

--- a/lnbits/extensions/satspay/static/js/utils.js
+++ b/lnbits/extensions/satspay/static/js/utils.js
@@ -23,6 +23,7 @@ const mapCharge = (obj, oldObj = {}) => {
   charge.displayUrl = ['/satspay/', obj.id].join('')
   charge.expanded = oldObj.expanded || false
   charge.pendingBalance = oldObj.pendingBalance || 0
+  charge.extra = charge.extra ? JSON.parse(charge.extra) : charge.extra
   return charge
 }
 

--- a/lnbits/extensions/satspay/templates/satspay/index.html
+++ b/lnbits/extensions/satspay/templates/satspay/index.html
@@ -227,7 +227,12 @@
                     >
                   </div>
                   <div class="col-4 q-pr-lg">
-                    <q-badge v-if="props.row.webhook_message" color="blue">
+                    <q-badge
+                      v-if="props.row.webhook_message"
+                      @click="showWebhookResponseDialog(props.row.extra.webhook_response)"
+                      color="blue"
+                      class="cursor-pointer"
+                    >
                       {{props.row.webhook_message }}
                     </q-badge>
                   </div>
@@ -528,6 +533,23 @@
       </q-form>
     </q-card>
   </q-dialog>
+
+  <q-dialog v-model="showWebhookResponse" position="top">
+    <q-card class="q-pa-lg q-pt-xl lnbits__dialog-card">
+      <q-input
+        filled
+        dense
+        readonly
+        v-model.trim="webhookResponse"
+        type="textarea"
+        label="Response"
+      ></q-input>
+
+      <div class="row q-mt-lg">
+        <q-btn flat v-close-popup color="grey" class="q-ml-auto">Close</q-btn>
+      </div>
+    </q-card>
+  </q-dialog>
 </div>
 {% endblock %} {% block scripts %} {{ window_vars(user) }}
 <!-- lnbits/static/vendor
@@ -669,7 +691,9 @@
           data: {
             custom_css: ''
           }
-        }
+        },
+        showWebhookResponse: false,
+        webhookResponse: ''
       }
     },
     methods: {
@@ -757,7 +781,6 @@
             '/satspay/api/v1/themes',
             this.g.user.wallets[0].inkey
           )
-          console.log(data)
           this.themeLinks = data.map(c =>
             mapCSS(
               c,
@@ -852,14 +875,12 @@
       },
       updateformDialog: function (themeId) {
         const theme = _.findWhere(this.themeLinks, {css_id: themeId})
-        console.log(theme.css_id)
         this.formDialogThemes.data.css_id = theme.css_id
         this.formDialogThemes.data.title = theme.title
         this.formDialogThemes.data.custom_css = theme.custom_css
         this.formDialogThemes.show = true
       },
       createTheme: async function (wallet, data) {
-        console.log(data.css_id)
         try {
           if (data.css_id) {
             const resp = await LNbits.api.request(
@@ -887,7 +908,6 @@
             custom_css: ''
           }
         } catch (error) {
-          console.log('cun')
           LNbits.utils.notifyApiError(error)
         }
       },
@@ -954,6 +974,10 @@
               LNbits.utils.notifyApiError(error)
             }
           })
+      },
+      showWebhookResponseDialog(webhookResponse) {
+        this.webhookResponse = webhookResponse
+        this.showWebhookResponse = true
       },
       exportchargeCSV: function () {
         LNbits.utils.exportCSV(


### PR DESCRIPTION
### Summary
- store the response from the `webhook` call
- show the response to the user (click on the status badge)

Automatic tests can now check that the webhook call was made.

### Screenshots
![image](https://user-images.githubusercontent.com/2951406/207327931-66b3f737-1d96-47ae-8782-985480e26a42.png)
