### PR TITLE
Fix: FastApi exception handling and logging

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -184,7 +184,7 @@ def register_exception_handlers(app: FastAPI):
             )
 
         return JSONResponse(
-            status_code=HTTPStatus.NO_CONTENT,
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             content={"detail": exc_str},
         )
 
@@ -192,6 +192,7 @@ def register_exception_handlers(app: FastAPI):
     async def validation_exception_handler(
         request: Request, exc: RequestValidationError
     ):
+        logger.error(str(exc))
         # Only the browser sends "text/html" request
         # not fail proof, but everything else get's a JSON response
 
@@ -206,7 +207,7 @@ def register_exception_handlers(app: FastAPI):
             )
 
         return JSONResponse(
-            status_code=HTTPStatus.NO_CONTENT,
+            status_code=HTTPStatus.BAD_REQUEST,
             content={"detail": exc.errors()},
         )
 

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -8,7 +8,7 @@ import warnings
 from http import HTTPStatus
 
 from fastapi import FastAPI, Request
-from fastapi.exceptions import RequestValidationError, HTTPException
+from fastapi.exceptions import HTTPException, RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -184,8 +184,30 @@ def register_exception_handlers(app: FastAPI):
             )
 
         return JSONResponse(
-            status_code=HTTPStatus.BAD_REQUEST,
+            status_code=HTTPStatus.NO_CONTENT,
             content={"detail": exc_str},
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(
+        request: Request, exc: RequestValidationError
+    ):
+        # Only the browser sends "text/html" request
+        # not fail proof, but everything else get's a JSON response
+
+        if (
+            request.headers
+            and "accept" in request.headers
+            and "text/html" in request.headers["accept"]
+        ):
+            return template_renderer().TemplateResponse(
+                "error.html",
+                {"request": request, "err": f"{exc.errors()} is not a valid UUID."},
+            )
+
+        return JSONResponse(
+            status_code=HTTPStatus.NO_CONTENT,
+            content={"detail": exc.errors()},
         )
 
 

--- a/tests/core/views/test_generic.py
+++ b/tests/core/views/test_generic.py
@@ -46,11 +46,11 @@ async def test_get_wallet_no_redirect(client):
         i += 1
 
 
-# check GET /wallet: wrong user, expect 204
+# check GET /wallet: wrong user, expect 400
 @pytest.mark.asyncio
 async def test_get_wallet_with_nonexistent_user(client):
     response = await client.get("wallet", params={"usr": "1"})
-    assert response.status_code == 204, (
+    assert response.status_code == 400, (
         str(response.url) + " " + str(response.status_code)
     )
 
@@ -91,11 +91,11 @@ async def test_get_wallet_with_user_and_wallet(client, to_user, to_wallet):
     )
 
 
-# check GET /wallet: wrong wallet and user, expect 204
+# check GET /wallet: wrong wallet and user, expect 400
 @pytest.mark.asyncio
 async def test_get_wallet_with_user_and_wrong_wallet(client, to_user):
     response = await client.get("wallet", params={"usr": to_user.id, "wal": "1"})
-    assert response.status_code == 204, (
+    assert response.status_code == 400, (
         str(response.url) + " " + str(response.status_code)
     )
 
@@ -109,20 +109,20 @@ async def test_get_extensions(client, to_user):
     )
 
 
-# check GET /extensions: extensions list wrong user, expect 204
+# check GET /extensions: extensions list wrong user, expect 400
 @pytest.mark.asyncio
 async def test_get_extensions_wrong_user(client, to_user):
     response = await client.get("extensions", params={"usr": "1"})
-    assert response.status_code == 204, (
+    assert response.status_code == 400, (
         str(response.url) + " " + str(response.status_code)
     )
 
 
-# check GET /extensions: no user given, expect code 204 no content
+# check GET /extensions: no user given, expect code 400 bad request
 @pytest.mark.asyncio
 async def test_get_extensions_no_user(client):
     response = await client.get("extensions")
-    assert response.status_code == 204, (  # no content
+    assert response.status_code == 400, (  # bad request
         str(response.url) + " " + str(response.status_code)
     )
 

--- a/tests/extensions/boltz/test_api.py
+++ b/tests/extensions/boltz/test_api.py
@@ -61,21 +61,21 @@ async def test_endpoints_inkey(client, inkey_headers_to):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(is_fake, reason="this test is only passes with regtest")
-async def test_endpoints_adminkey_nocontent(client, adminkey_headers_to):
+async def test_endpoints_adminkey_badrequest(client, adminkey_headers_to):
     response = await client.post("/boltz/api/v1/swap", headers=adminkey_headers_to)
-    assert response.status_code == 204
+    assert response.status_code == 400
     response = await client.post(
         "/boltz/api/v1/swap/reverse", headers=adminkey_headers_to
     )
-    assert response.status_code == 204
+    assert response.status_code == 400
     response = await client.post(
         "/boltz/api/v1/swap/refund", headers=adminkey_headers_to
     )
-    assert response.status_code == 204
+    assert response.status_code == 400
     response = await client.post(
         "/boltz/api/v1/swap/status", headers=adminkey_headers_to
     )
-    assert response.status_code == 204
+    assert response.status_code == 400
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Properly reports the last line of the exception in Error html (for browsers) and in the JSON response (for API calls) and prints the stack trace in the terminal.


Adds 3 FastApi error handlers:
* `Exception` for general exceptions
* `RequestValidationError` for Pydantic validation errors of input data
* `HTTPException` for any HTTP error we raise in the code via `raise HTTPException()`