### PR TITLE
LNURLp - save `webhook` call details

### DIFF
--- a/lnbits/extensions/lnurlp/tasks.py
+++ b/lnbits/extensions/lnurlp/tasks.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 
 import httpx
+from loguru import logger
 
 from lnbits.core import db as core_db
 from lnbits.core.models import Payment
@@ -50,7 +51,8 @@ async def on_invoice_paid(payment: Payment) -> None:
 
                 r = await client.post(pay_link.webhook_url, **kwargs)
                 await mark_webhook_sent(payment, r.status_code)
-            except (httpx.ConnectError, httpx.RequestError):
+            except Exception as ex:
+                logger.error(ex)
                 await mark_webhook_sent(payment, -1)
 
 

--- a/lnbits/extensions/lnurlp/tasks.py
+++ b/lnbits/extensions/lnurlp/tasks.py
@@ -49,15 +49,22 @@ async def on_invoice_paid(payment: Payment) -> None:
                 if pay_link.webhook_headers:
                     kwargs["headers"] = json.loads(pay_link.webhook_headers)
 
-                r = await client.post(pay_link.webhook_url, **kwargs)
-                await mark_webhook_sent(payment, r.status_code)
+                r: httpx.Response = await client.post(pay_link.webhook_url, **kwargs)
+                await mark_webhook_sent(
+                    payment, r.status_code, r.is_success, r.reason_phrase, r.text
+                )
             except Exception as ex:
                 logger.error(ex)
-                await mark_webhook_sent(payment, -1)
+                await mark_webhook_sent(payment, -1, False, "Unexpected Error", str(ex))
 
 
-async def mark_webhook_sent(payment: Payment, status: int) -> None:
-    payment.extra["wh_status"] = status
+async def mark_webhook_sent(
+    payment: Payment, status: int, is_success: bool, reason_phrase="", text=""
+) -> None:
+    payment.extra["wh_status"] = status  # keep for backwards compability
+    payment.extra["wh_success"] = is_success
+    payment.extra["wh_message"] = reason_phrase
+    payment.extra["wh_response"] = text
 
     await core_db.execute(
         """


### PR DESCRIPTION
### Summary
- **fix**: catch any exception when a `webhook` call fails
  - for example adding a LNURLp callback invalid header (`{"h1": 1}`) was not caught 
  - headers can only have string values, not ints

- feat: store the response `code`, `message` and `body`
 - this can help later troubleshoot why the `webhook` call failed 