### PR TITLE
Withdraw webhook improvements

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -467,17 +467,15 @@ async def update_payment_extra(
     )
     if not row:
         return
-    existing_extra = json.loads(row["extra"] if row["extra"] else "{}")
-    new_extra = {
-        **existing_extra,
-        **extra,
-    }
+    db_extra = json.loads(row["extra"] if row["extra"] else "{}")
+    db_extra.update(extra)
+
     await (conn or db).execute(
         """
         UPDATE apipayments SET extra = ?
         WHERE hash = ?
         """,
-        (json.dumps(new_extra), payment_hash),
+        (json.dumps(db_extra), payment_hash),
     )
 
 

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -463,7 +463,7 @@ async def update_payment_extra(
 
     row = await (conn or db).fetchone(
         "SELECT hash, extra from apipayments WHERE hash = ?",
-        (payment_hash),
+        (payment_hash,),
     )
     if not row:
         return

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -214,7 +214,8 @@ async def api_payments_create_invoice(data: CreateInvoiceData, wallet: Wallet):
                         lnurl_response = resp["reason"]
                     else:
                         lnurl_response = True
-            except (httpx.ConnectError, httpx.RequestError):
+            except (httpx.ConnectError, httpx.RequestError) as ex:
+                logger.error(ex)
                 lnurl_response = False
 
     return {

--- a/lnbits/extensions/lnurlp/tasks.py
+++ b/lnbits/extensions/lnurlp/tasks.py
@@ -5,6 +5,7 @@ import httpx
 from loguru import logger
 
 from lnbits.core import db as core_db
+from lnbits.core.crud import update_payment_extra
 from lnbits.core.models import Payment
 from lnbits.helpers import get_current_extension_name
 from lnbits.tasks import register_invoice_listener
@@ -66,10 +67,4 @@ async def mark_webhook_sent(
     payment.extra["wh_message"] = reason_phrase
     payment.extra["wh_response"] = text
 
-    await core_db.execute(
-        """
-        UPDATE apipayments SET extra = ?
-        WHERE hash = ?
-        """,
-        (json.dumps(payment.extra), payment.payment_hash),
-    )
+    await update_payment_extra(payment.payment_hash, payment.extra)

--- a/lnbits/extensions/withdraw/crud.py
+++ b/lnbits/extensions/withdraw/crud.py
@@ -27,9 +27,11 @@ async def create_withdraw_link(
             open_time,
             usescsv,
             webhook_url,
+            webhook_headers,
+            webhook_body,
             custom_url
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             link_id,
@@ -45,6 +47,8 @@ async def create_withdraw_link(
             int(datetime.now().timestamp()) + data.wait_time,
             usescsv,
             data.webhook_url,
+            data.webhook_headers,
+            data.webhook_body,
             data.custom_url,
         ),
     )

--- a/lnbits/extensions/withdraw/lnurl.py
+++ b/lnbits/extensions/withdraw/lnurl.py
@@ -164,13 +164,11 @@ async def api_lnurl_callback(
                     r: httpx.Response = await client.post(link.webhook_url, **kwargs)
                     await update_payment_extra(
                         payment_hash,
-                        dict(
-                            {
-                                "wh_success": r.is_success,
-                                "wh_message": r.reason_phrase,
-                                "wh_response": r.text,
-                            }
-                        ),
+                        {
+                            "wh_success": r.is_success,
+                            "wh_message": r.reason_phrase,
+                            "wh_response": r.text,
+                        },
                     )
                 except Exception as exc:
                     # webhook fails shouldn't cause the lnurlw to fail since invoice is already paid
@@ -179,7 +177,7 @@ async def api_lnurl_callback(
                     )
                     await update_payment_extra(
                         payment_hash,
-                        dict({"wh_success": False, "wh_message": str(exc)}),
+                        {"wh_success": False, "wh_message": str(exc)},
                     )
 
         return {"status": "OK"}

--- a/lnbits/extensions/withdraw/migrations.py
+++ b/lnbits/extensions/withdraw/migrations.py
@@ -122,3 +122,13 @@ async def m005_add_custom_print_design(db):
     Adds custom print design
     """
     await db.execute("ALTER TABLE withdraw.withdraw_link ADD COLUMN custom_url TEXT;")
+
+
+async def m006_webhook_headers_and_body(db):
+    """
+    Add headers and body to webhooks
+    """
+    await db.execute(
+        "ALTER TABLE withdraw.withdraw_link ADD COLUMN webhook_headers TEXT;"
+    )
+    await db.execute("ALTER TABLE withdraw.withdraw_link ADD COLUMN webhook_body TEXT;")

--- a/lnbits/extensions/withdraw/models.py
+++ b/lnbits/extensions/withdraw/models.py
@@ -16,6 +16,8 @@ class CreateWithdrawData(BaseModel):
     wait_time: int = Query(..., ge=1)
     is_unique: bool
     webhook_url: str = Query(None)
+    webhook_headers: str = Query(None)
+    webhook_body: str = Query(None)
     custom_url: str = Query(None)
 
 
@@ -35,6 +37,8 @@ class WithdrawLink(BaseModel):
     usescsv: str = Query(None)
     number: int = Query(0)
     webhook_url: str = Query(None)
+    webhook_headers: str = Query(None)
+    webhook_body: str = Query(None)
     custom_url: str = Query(None)
 
     @property

--- a/lnbits/extensions/withdraw/static/js/index.js
+++ b/lnbits/extensions/withdraw/static/js/index.js
@@ -63,7 +63,8 @@ new Vue({
         secondMultiplierOptions: ['seconds', 'minutes', 'hours'],
         data: {
           is_unique: false,
-          use_custom: false
+          use_custom: false,
+          has_webhook: false
         }
       },
       simpleformDialog: {
@@ -188,23 +189,35 @@ new Vue({
     },
     updateWithdrawLink: function (wallet, data) {
       var self = this
+      const body = _.pick(
+        data,
+        'title',
+        'min_withdrawable',
+        'max_withdrawable',
+        'uses',
+        'wait_time',
+        'is_unique',
+        'webhook_url',
+        'webhook_headers',
+        'webhook_body',
+        'custom_url'
+      )
+
+      if (data.has_webhook) {
+        body = {
+          ...body,
+          webhook_url: data.webhook_url,
+          webhook_headers: data.webhook_headers,
+          webhook_body: data.webhook_body
+        }
+      }
 
       LNbits.api
         .request(
           'PUT',
           '/withdraw/api/v1/links/' + data.id,
           wallet.adminkey,
-          _.pick(
-            data,
-            'title',
-            'min_withdrawable',
-            'max_withdrawable',
-            'uses',
-            'wait_time',
-            'is_unique',
-            'webhook_url',
-            'custom_url'
-          )
+          body
         )
         .then(function (response) {
           self.withdrawLinks = _.reject(self.withdrawLinks, function (obj) {

--- a/lnbits/extensions/withdraw/templates/withdraw/index.html
+++ b/lnbits/extensions/withdraw/templates/withdraw/index.html
@@ -209,13 +209,37 @@
             </q-select>
           </div>
         </div>
+        <q-toggle
+          label="Webhook"
+          color="secodary"
+          v-model="formDialog.data.has_webhook"
+        ></q-toggle>
         <q-input
+          v-if="formDialog.data.has_webhook"
           filled
           dense
           v-model="formDialog.data.webhook_url"
           type="text"
           label="Webhook URL (optional)"
           hint="A URL to be called whenever this link gets used."
+        ></q-input>
+        <q-input
+          v-if="formDialog.data.has_webhook"
+          filled
+          dense
+          v-model="formDialog.data.webhook_headers"
+          type="text"
+          label="Webhook Headers (optional)"
+          hint="Custom data as JSON string, send headers along with the webhook."
+        ></q-input>
+        <q-input
+          v-if="formDialog.data.has_webhook"
+          filled
+          dense
+          v-model="formDialog.data.webhook_body"
+          type="text"
+          label="Webhook custom data (optional)"
+          hint="Custom data as JSON string, will get posted along with webhook 'body' field."
         ></q-input>
         <q-list>
           <q-item tag="label" class="rounded-borders">


### PR DESCRIPTION
### Summary
- add `webhook_body` and `webhook_headers` for `withdraw` callbacks
- store the the `webhook` response in `apipayments`.`extra` column

![image](https://user-images.githubusercontent.com/2951406/208914065-2a6789ad-1796-4d7c-a1c5-c4d101850a8b.png)
