### PR TITLE
fix: handle `extra` updates for internal payments

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -452,7 +452,7 @@ async def update_payment_details(
 
 
 async def update_payment_extra(
-    hash: str,
+    payment_hash: str,
     extra: dict,
     outgoing: bool = False,
     incoming: bool = False,
@@ -472,7 +472,7 @@ async def update_payment_extra(
 
     row = await (conn or db).fetchone(
         f"SELECT hash, extra from apipayments WHERE hash = ? {amount_clause}",
-        (hash,),
+        (payment_hash,),
     )
     if not row:
         return
@@ -481,7 +481,7 @@ async def update_payment_extra(
 
     await (conn or db).execute(
         f"UPDATE apipayments SET extra = ? WHERE hash = ? {amount_clause} ",
-        (json.dumps(db_extra), hash),
+        (json.dumps(db_extra), payment_hash),
     )
 
 

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -455,20 +455,14 @@ async def update_payment_extra(
     payment_hash: str,
     extra: dict,
     outgoing: bool = False,
-    incoming: bool = False,
     conn: Optional[Connection] = None,
 ) -> None:
     """
     Only update the `extra` field for the payment.
     Old values in the `extra` JSON object will be kept unless the new `extra` overwrites them.
     """
-    amount_clause = ""
 
-    if outgoing != incoming:
-        if outgoing:
-            amount_clause = "AND amount < 0"
-        else:
-            amount_clause = "AND amount > 0"
+    amount_clause = "AND amount < 0" if outgoing else "AND amount > 0"
 
     row = await (conn or db).fetchone(
         f"SELECT hash, extra from apipayments WHERE hash = ? {amount_clause}",

--- a/lnbits/extensions/lnurlp/tasks.py
+++ b/lnbits/extensions/lnurlp/tasks.py
@@ -67,4 +67,6 @@ async def mark_webhook_sent(
     payment.extra["wh_message"] = reason_phrase
     payment.extra["wh_response"] = text
 
-    await update_payment_extra(payment.payment_hash, payment.extra)
+    await update_payment_extra(
+        payment_hash=payment.payment_hash, extra=payment.extra, incoming=True
+    )

--- a/lnbits/extensions/lnurlp/tasks.py
+++ b/lnbits/extensions/lnurlp/tasks.py
@@ -52,21 +52,29 @@ async def on_invoice_paid(payment: Payment) -> None:
 
                 r: httpx.Response = await client.post(pay_link.webhook_url, **kwargs)
                 await mark_webhook_sent(
-                    payment, r.status_code, r.is_success, r.reason_phrase, r.text
+                    payment.payment_hash,
+                    r.status_code,
+                    r.is_success,
+                    r.reason_phrase,
+                    r.text,
                 )
             except Exception as ex:
                 logger.error(ex)
-                await mark_webhook_sent(payment, -1, False, "Unexpected Error", str(ex))
+                await mark_webhook_sent(
+                    payment.payment_hash, -1, False, "Unexpected Error", str(ex)
+                )
 
 
 async def mark_webhook_sent(
-    payment: Payment, status: int, is_success: bool, reason_phrase="", text=""
+    payment_hash: str, status: int, is_success: bool, reason_phrase="", text=""
 ) -> None:
-    payment.extra["wh_status"] = status  # keep for backwards compability
-    payment.extra["wh_success"] = is_success
-    payment.extra["wh_message"] = reason_phrase
-    payment.extra["wh_response"] = text
 
     await update_payment_extra(
-        payment_hash=payment.payment_hash, extra=payment.extra, incoming=True
+        payment_hash,
+        {
+            "wh_status": status,  # keep for backwards compability
+            "wh_success": is_success,
+            "wh_message": reason_phrase,
+            "wh_response": text,
+        },
     )

--- a/lnbits/extensions/withdraw/lnurl.py
+++ b/lnbits/extensions/withdraw/lnurl.py
@@ -163,12 +163,13 @@ async def api_lnurl_callback(
 
                     r: httpx.Response = await client.post(link.webhook_url, **kwargs)
                     await update_payment_extra(
-                        payment_hash,
-                        {
+                        hash=payment_hash,
+                        extra={
                             "wh_success": r.is_success,
                             "wh_message": r.reason_phrase,
                             "wh_response": r.text,
                         },
+                        outgoing=True,
                     )
                 except Exception as exc:
                     # webhook fails shouldn't cause the lnurlw to fail since invoice is already paid

--- a/lnbits/extensions/withdraw/lnurl.py
+++ b/lnbits/extensions/withdraw/lnurl.py
@@ -163,7 +163,7 @@ async def api_lnurl_callback(
 
                     r: httpx.Response = await client.post(link.webhook_url, **kwargs)
                     await update_payment_extra(
-                        hash=payment_hash,
+                        payment_hash=payment_hash,
                         extra={
                             "wh_success": r.is_success,
                             "wh_message": r.reason_phrase,
@@ -177,8 +177,9 @@ async def api_lnurl_callback(
                         "Caught exception when dispatching webhook url: " + str(exc)
                     )
                     await update_payment_extra(
-                        payment_hash,
-                        {"wh_success": False, "wh_message": str(exc)},
+                        payment_hash=payment_hash,
+                        extra={"wh_success": False, "wh_message": str(exc)},
+                        outgoing=True,
                     )
 
         return {"status": "OK"}


### PR DESCRIPTION
For internal payments there are two entries with the same `hash` in `apipayments`.

This caused the updated of `extra` to loose the previous set values if the wrong payment came first for `fetchone`
![image](https://user-images.githubusercontent.com/2951406/209100607-b196a2db-d803-4462-8a2b-99abe86928d6.png)

The fix allows to specify if the `incoming` or `outgoing` payment should be updated.
