### PR TITLE
fix: onchain wallet deleted for charge

### DIFF
--- a/lnbits/extensions/satspay/crud.py
+++ b/lnbits/extensions/satspay/crud.py
@@ -24,6 +24,8 @@ async def create_charge(user: str, data: CreateCharge) -> Charges:
             {"mempool_endpoint": config.mempool_endpoint, "network": config.network}
         )
         onchain = await get_fresh_address(data.onchainwallet)
+        if not onchain:
+            raise Exception(f"Wallet '{data.onchainwallet}' can no longer be accessed.")
         onchainaddress = onchain.address
     else:
         onchainaddress = None

--- a/lnbits/extensions/satspay/views_api.py
+++ b/lnbits/extensions/satspay/views_api.py
@@ -46,6 +46,7 @@ async def api_charge_create(
             **{"paid": charge.paid},
         }
     except Exception as ex:
+        logger.debug(ex)
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(ex)
         )

--- a/lnbits/extensions/satspay/views_api.py
+++ b/lnbits/extensions/satspay/views_api.py
@@ -37,13 +37,18 @@ from .models import CreateCharge, SatsPayThemes
 async def api_charge_create(
     data: CreateCharge, wallet: WalletTypeInfo = Depends(require_invoice_key)
 ):
-    charge = await create_charge(user=wallet.wallet.user, data=data)
-    return {
-        **charge.dict(),
-        **{"time_elapsed": charge.time_elapsed},
-        **{"time_left": charge.time_left},
-        **{"paid": charge.paid},
-    }
+    try:
+        charge = await create_charge(user=wallet.wallet.user, data=data)
+        return {
+            **charge.dict(),
+            **{"time_elapsed": charge.time_elapsed},
+            **{"time_left": charge.time_left},
+            **{"paid": charge.paid},
+        }
+    except Exception as ex:
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(ex)
+        )
 
 
 @satspay_ext.put("/api/v1/charge/{charge_id}")

--- a/lnbits/extensions/satspay/views_api.py
+++ b/lnbits/extensions/satspay/views_api.py
@@ -46,7 +46,7 @@ async def api_charge_create(
             **{"paid": charge.paid},
         }
     except Exception as ex:
-        logger.debug(ex)
+        logger.debug(f"Satspay error: {str}")
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(ex)
         )


### PR DESCRIPTION
**Steps**:
 - go to `satspay` extension
 - open `New Charge` dialog
 - select `onchain` wallet (do NOT click `Create Charge` yet)
 - in new tab:
    - go to `watchonly` extension
    - delete the account that the charge was pointing to
 - back in the `satspay`  tab click `Create Charge`

**Actual Result**
 - a technical error is shown: `NoneType' object has no attribute 'address'`
 - there is an error stacktrace

**Expected Result**
 - it fails with a user-friendly message: `Wallet '{onchainwallet}' can no longer be accessed.`
 - no stacktrace