### PR TITLE
QR invoices and lnurls got prefix and uppercased

### DIFF
--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -231,7 +231,7 @@
                           <a :href="'lightning:' + props.row.bolt11">
                             <q-responsive :ratio="1" class="q-mx-xl">
                               <qrcode
-                                :value="props.row.bolt11"
+                                :value="'lightning:' + props.row.bolt11.toUpperCase()"
                                 :options="{width: 340}"
                                 class="rounded-borders"
                               ></qrcode>
@@ -325,7 +325,7 @@
                       </p>
                       <a href="lightning:{{wallet.lnurlwithdraw_full}}">
                         <qrcode
-                          value="{{wallet.lnurlwithdraw_full}}"
+                          value="lightning:{{wallet.lnurlwithdraw_full}}"
                           :options="{width:240}"
                         ></qrcode>
                       </a>
@@ -524,7 +524,7 @@
             <a :href="'lightning:' + receive.paymentReq">
               <q-responsive :ratio="1" class="q-mx-xl">
                 <qrcode
-                  :value="receive.paymentReq"
+                  :value="'lightning:' + receive.paymentReq.toUpperCase()"
                   :options="{width: 340}"
                   class="rounded-borders"
                 ></qrcode>

--- a/lnbits/extensions/cashu/templates/cashu/wallet.html
+++ b/lnbits/extensions/cashu/templates/cashu/wallet.html
@@ -619,7 +619,7 @@ page_container %}
             <a :href="'lightning:' + invoiceData.bolt11">
               <q-responsive :ratio="1" class="q-mx-xl">
                 <qrcode
-                  :value="invoiceData.bolt11"
+                  :value="'lightning:' + invoiceData.bolt11.toUpperCase()"
                   :options="{width: 340}"
                   class="rounded-borders"
                 >

--- a/lnbits/extensions/copilot/templates/copilot/compose.html
+++ b/lnbits/extensions/copilot/templates/copilot/compose.html
@@ -25,7 +25,7 @@
   >
     <div class="col">
       <qrcode
-        :value="copilot.lnurl"
+        :value="'lightning:' + copilot.lnurl"
         :options="{width:250}"
         class="rounded-borders"
       ></qrcode>

--- a/lnbits/extensions/events/templates/events/display.html
+++ b/lnbits/extensions/events/templates/events/display.html
@@ -67,7 +67,7 @@
         <a :href="'lightning:' + receive.paymentReq">
           <q-responsive :ratio="1" class="q-mx-xl">
             <qrcode
-              :value="paymentReq"
+              :value="'lightning:' + receive.paymentReq.toUpperCase()"
               :options="{width: 340}"
               class="rounded-borders"
             ></qrcode>

--- a/lnbits/extensions/invoices/templates/invoices/pay.html
+++ b/lnbits/extensions/invoices/templates/invoices/pay.html
@@ -254,7 +254,7 @@ block page %}
       <a :href="'lightning:' + qrCodeDialog.data.payment_request">
         <q-responsive :ratio="1" class="q-mx-xs">
           <qrcode
-            :value="qrCodeDialog.data.payment_request"
+            :value="'lightning:' + qrCodeDialog.data.payment_request.toUpperCase()"
             :options="{width: 400}"
             class="rounded-borders"
           ></qrcode>

--- a/lnbits/extensions/jukebox/templates/jukebox/jukebox.html
+++ b/lnbits/extensions/jukebox/templates/jukebox/jukebox.html
@@ -83,7 +83,7 @@
       <q-card class="q-pa-lg lnbits__dialog-card">
         <q-responsive :ratio="1" class="q-mx-xl q-mb-md">
           <qrcode
-            :value="'lightning:' + receive.paymentReq"
+            :value="'lightning:' + receive.paymentReq.toUpperCase()"
             :options="{width: 800}"
             class="rounded-borders"
           ></qrcode>

--- a/lnbits/extensions/livestream/templates/livestream/index.html
+++ b/lnbits/extensions/livestream/templates/livestream/index.html
@@ -238,7 +238,7 @@
         <a :href="'lightning:' + trackDialog.data.lnurl">
           <q-responsive :ratio="1" class="q-mx-sm">
             <qrcode
-              :value="trackDialog.data.lnurl"
+              :value="'lightning:' + trackDialog.data.lnurl.toUpperCase()"
               :options="{width: 800}"
               class="rounded-borders"
             ></qrcode>

--- a/lnbits/extensions/lnaddress/templates/lnaddress/display.html
+++ b/lnbits/extensions/lnaddress/templates/lnaddress/display.html
@@ -187,7 +187,7 @@
         <a :href="'lightning:' + receive.paymentReq">
           <q-responsive :ratio="1" class="q-mx-xl">
             <qrcode
-              :value="paymentReq"
+              :value="'lightning:' + paymentReq.toUpperCase()"
               :options="{width: 340}"
               class="rounded-borders"
             ></qrcode>

--- a/lnbits/extensions/lnticket/templates/lnticket/display.html
+++ b/lnbits/extensions/lnticket/templates/lnticket/display.html
@@ -67,7 +67,7 @@
         <a :href="'lightning:' + receive.paymentReq">
           <q-responsive :ratio="1" class="q-mx-xl">
             <qrcode
-              :value="paymentReq"
+              :value="'lightning:' + paymentReq.toUpperCase()"
               :options="{width: 340}"
               class="rounded-borders"
             ></qrcode>

--- a/lnbits/extensions/lnurldevice/templates/lnurldevice/index.html
+++ b/lnbits/extensions/lnurldevice/templates/lnurldevice/index.html
@@ -476,7 +476,7 @@
     <q-card v-if="qrCodeDialog.data" class="q-pa-lg lnbits__dialog-card">
       <q-responsive :ratio="1" class="q-mx-xl q-mb-md">
         <qrcode
-          :value="lnurlValue"
+          :value="'lightning:' + lnurlValue"
           :options="{width: 800}"
           class="rounded-borders"
         ></qrcode>

--- a/lnbits/extensions/lnurlp/templates/lnurlp/display.html
+++ b/lnbits/extensions/lnurlp/templates/lnurlp/display.html
@@ -7,7 +7,7 @@
           <a href="lightning:{{ lnurl }}">
             <q-responsive :ratio="1" class="q-mx-md">
               <qrcode
-                value="{{ lnurl }}"
+                value="lightning:{{ lnurl }}"
                 :options="{width: 800}"
                 class="rounded-borders"
               ></qrcode>

--- a/lnbits/extensions/lnurlp/templates/lnurlp/index.html
+++ b/lnbits/extensions/lnurlp/templates/lnurlp/index.html
@@ -284,7 +284,7 @@
       {% raw %}
       <q-responsive :ratio="1" class="q-mx-xl q-mb-md">
         <qrcode
-          :value="qrCodeDialog.data.lnurl"
+          :value="'lightning:' + qrCodeDialog.data.lnurl"
           :options="{width: 800}"
           class="rounded-borders"
         ></qrcode>

--- a/lnbits/extensions/lnurlp/templates/lnurlp/print_qr.html
+++ b/lnbits/extensions/lnurlp/templates/lnurlp/print_qr.html
@@ -1,7 +1,7 @@
 {% extends "print.html" %} {% block page %}
 <div class="row justify-center">
   <div class="qr">
-    <qrcode value="{{ lnurl }}" :options="{width}"></qrcode>
+    <qrcode value="lightning:{{ lnurl }}" :options="{width}"></qrcode>
   </div>
 </div>
 {% endblock %} {% block styles %}

--- a/lnbits/extensions/offlineshop/templates/offlineshop/index.html
+++ b/lnbits/extensions/offlineshop/templates/offlineshop/index.html
@@ -236,7 +236,7 @@
 
         <q-responsive v-if="itemDialog.data.id" :ratio="1">
           <qrcode
-            :value="itemDialog.data.lnurl"
+            :value="'lightning:' + itemDialog.data.lnurl"
             :options="{width: 800}"
             class="rounded-borders"
           ></qrcode>

--- a/lnbits/extensions/offlineshop/templates/offlineshop/print.html
+++ b/lnbits/extensions/offlineshop/templates/offlineshop/print.html
@@ -2,7 +2,10 @@
 <div class="row justify-center">
   <div v-for="item in items" class="q-my-sm q-mx-lg">
     <div class="text-center q-ma-none q-mb-sm">{{ item.name }}</div>
-    <qrcode :value="'lightning:' + item.lnurl" :options="{margin: 0, width: 250}"></qrcode>
+    <qrcode
+      :value="'lightning:' + item.lnurl"
+      :options="{margin: 0, width: 250}"
+    ></qrcode>
     <div class="text-center q-ma-none q-mt-sm">{{ item.price }}</div>
   </div>
 </div>

--- a/lnbits/extensions/offlineshop/templates/offlineshop/print.html
+++ b/lnbits/extensions/offlineshop/templates/offlineshop/print.html
@@ -2,7 +2,7 @@
 <div class="row justify-center">
   <div v-for="item in items" class="q-my-sm q-mx-lg">
     <div class="text-center q-ma-none q-mb-sm">{{ item.name }}</div>
-    <qrcode :value="item.lnurl" :options="{margin: 0, width: 250}"></qrcode>
+    <qrcode :value="'lightning:' + item.lnurl" :options="{margin: 0, width: 250}"></qrcode>
     <div class="text-center q-ma-none q-mt-sm">{{ item.price }}</div>
   </div>
 </div>

--- a/lnbits/extensions/paywall/templates/paywall/display.html
+++ b/lnbits/extensions/paywall/templates/paywall/display.html
@@ -33,7 +33,7 @@
             <a :href="'lightning:' + paymentReq">
               <q-responsive :ratio="1" class="q-mx-xl q-mb-md">
                 <qrcode
-                  :value="paymentReq"
+                  :value="'lightning:' + paymentReq.toUpperCase()"
                   :options="{width: 800}"
                   class="rounded-borders"
                 ></qrcode>

--- a/lnbits/extensions/satsdice/templates/satsdice/display.html
+++ b/lnbits/extensions/satsdice/templates/satsdice/display.html
@@ -7,7 +7,7 @@
           <a href="lightning:{{ lnurl }}">
             <q-responsive :ratio="1" class="q-mx-md">
               <qrcode
-                :value="'{{ lnurl }}'"
+                :value="'lightning:{{ lnurl }}'"
                 :options="{width: 800}"
                 class="rounded-borders"
               ></qrcode>

--- a/lnbits/extensions/satsdice/templates/satsdice/displaywin.html
+++ b/lnbits/extensions/satsdice/templates/satsdice/displaywin.html
@@ -7,7 +7,7 @@
           <a href="lightning:{{ lnurl }}">
             <q-responsive :ratio="1" class="q-mx-md">
               <qrcode
-                :value="'{{ lnurl }}'"
+                :value="'lightning:{{ lnurl }}'"
                 :options="{width: 800}"
                 class="rounded-borders"
               ></qrcode>

--- a/lnbits/extensions/satsdice/templates/satsdice/index.html
+++ b/lnbits/extensions/satsdice/templates/satsdice/index.html
@@ -202,7 +202,7 @@
     <q-card v-if="qrCodeDialog.data" class="q-pa-lg lnbits__dialog-card">
       <q-responsive :ratio="1" class="q-mx-xl q-mb-md">
         <qrcode
-          :value="qrCodeDialog.data.lnurl"
+          :value="'lightning:' + qrCodeDialog.data.lnurl"
           :options="{width: 800}"
           class="rounded-borders"
         ></qrcode>

--- a/lnbits/extensions/satspay/templates/satspay/display.html
+++ b/lnbits/extensions/satspay/templates/satspay/display.html
@@ -194,7 +194,7 @@
               <a :href="'lightning:'+charge.payment_request">
                 <q-responsive :ratio="1" class="q-mx-md">
                   <qrcode
-                    :value="charge.payment_request"
+                    :value="'lightning:' + charge.payment_request.toUpperCase()"
                     :options="{width: 800}"
                     class="rounded-borders"
                   ></qrcode>

--- a/lnbits/extensions/subdomains/templates/subdomains/display.html
+++ b/lnbits/extensions/subdomains/templates/subdomains/display.html
@@ -78,7 +78,7 @@
         <a :href="'lightning:' + receive.paymentReq">
           <q-responsive :ratio="1" class="q-mx-xl">
             <qrcode
-              :value="paymentReq"
+              :value="'lightning:' + paymentReq.toUpperCase()"
               :options="{width: 340}"
               class="rounded-borders"
             ></qrcode>

--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -167,7 +167,7 @@
       >
         <q-responsive :ratio="1" class="q-mx-xl q-mb-md">
           <qrcode
-            :value="invoiceDialog.data.payment_request"
+            :value="'lightning:' + invoiceDialog.data.payment_request.toUpperCase()"
             :options="{width: 800}"
             class="rounded-borders"
           ></qrcode>


### PR DESCRIPTION
This PR addresses the issue #1245 and adds 'lightning:' prefix into QRs containing payment requests and lnurls. Above that it makes payment requests upper cased to save some space (about from 65x65 px to 57x57 in my testing). 