### PR TITLE
remove unnecessary argument encoding from bytes.decode() and str.encode()

### DIFF
--- a/lnbits/bolt11.py
+++ b/lnbits/bolt11.py
@@ -74,7 +74,7 @@ def decode(pr: str) -> Invoice:
         data_length = len(tagdata) / 5
 
         if tag == "d":
-            invoice.description = _trim_to_bytes(tagdata).decode("utf-8")
+            invoice.description = _trim_to_bytes(tagdata).decode()
         elif tag == "h" and data_length == 52:
             invoice.description_hash = _trim_to_bytes(tagdata).hex()
         elif tag == "p" and data_length == 52:
@@ -260,7 +260,7 @@ class LnAddr(object):
 
     def __str__(self):
         return "LnAddr[{}, amount={}{} tags=[{}]]".format(
-            bytes.hex(self.pubkey.serialize()).decode("utf-8"),
+            bytes.hex(self.pubkey.serialize()).decode(),
             self.amount,
             self.currency,
             ", ".join([k + "=" + str(v) for k, v in self.tags]),

--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -46,8 +46,8 @@ class Wallet(BaseModel):
             return ""
 
     def lnurlauth_key(self, domain: str) -> SigningKey:
-        hashing_key = hashlib.sha256(self.id.encode("utf-8")).digest()
-        linking_key = hmac.digest(hashing_key, domain.encode("utf-8"), "sha256")
+        hashing_key = hashlib.sha256(self.id.encode()).digest()
+        linking_key = hmac.digest(hashing_key, domain.encode(), "sha256")
 
         return SigningKey.from_string(
             linking_key, curve=SECP256k1, hashfunc=hashlib.sha256

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -536,7 +536,7 @@ async def api_lnurlscan(code: str, wallet: WalletTypeInfo = Depends(get_key_type
 
                 params.update(
                     description_hash=hashlib.sha256(
-                        data["metadata"].encode("utf-8")
+                        data["metadata"].encode()
                     ).hexdigest()
                 )
                 metadata = json.loads(data["metadata"])

--- a/lnbits/extensions/boltcards/lnurl.py
+++ b/lnbits/extensions/boltcards/lnurl.py
@@ -213,7 +213,7 @@ async def lnurlp_callback(
         memo=f"Refund {hit_id}",
         unhashed_description=LnurlPayMetadata(
             json.dumps([["text/plain", "Refund"]])
-        ).encode("utf-8"),
+        ).encode(),
         extra={"refund": hit_id},
     )
 

--- a/lnbits/extensions/boltz/boltz.py
+++ b/lnbits/extensions/boltz/boltz.py
@@ -55,7 +55,7 @@ async def create_swap(data: CreateSubmarineSwap) -> SubmarineSwap:
         raise
 
     refund_privkey = ec.PrivateKey(os.urandom(32), True, net)
-    refund_pubkey_hex = bytes.hex(refund_privkey.sec()).decode("UTF-8")
+    refund_pubkey_hex = bytes.hex(refund_privkey.sec()).decode()
 
     res = req_wrap(
         "post",
@@ -120,7 +120,7 @@ async def create_reverse_swap(
         return False
 
     claim_privkey = ec.PrivateKey(os.urandom(32), True, net)
-    claim_pubkey_hex = bytes.hex(claim_privkey.sec()).decode("UTF-8")
+    claim_pubkey_hex = bytes.hex(claim_privkey.sec()).decode()
     preimage = os.urandom(32)
     preimage_hash = sha256(preimage).hexdigest()
 

--- a/lnbits/extensions/copilot/lnurl.py
+++ b/lnbits/extensions/copilot/lnurl.py
@@ -75,7 +75,7 @@ async def lnurl_callback(
         memo=cp.lnurl_title,
         unhashed_description=(
             LnurlPayMetadata(json.dumps([["text/plain", str(cp.lnurl_title)]]))
-        ).encode("utf-8"),
+        ).encode(),
         extra={"tag": "copilot", "copilotid": cp.id, "comment": comment},
     )
     payResponse = {"pr": payment_request, "routes": []}

--- a/lnbits/extensions/livestream/lnurl.py
+++ b/lnbits/extensions/livestream/lnurl.py
@@ -90,7 +90,7 @@ async def lnurl_callback(
         wallet_id=ls.wallet,
         amount=int(amount_received / 1000),
         memo=await track.fullname(),
-        unhashed_description=(await track.lnurlpay_metadata()).encode("utf-8"),
+        unhashed_description=(await track.lnurlpay_metadata()).encode(),
         extra={"tag": "livestream", "track": track.id, "comment": comment},
     )
 

--- a/lnbits/extensions/lnaddress/lnurl.py
+++ b/lnbits/extensions/lnaddress/lnurl.py
@@ -72,7 +72,7 @@ async def lnurl_callback(address_id, amount: int = Query(...)):
                     "amount": int(amount_received / 1000),
                     "description_hash": (
                         await address.lnurlpay_metadata(domain=domain.domain)
-                    ).encode("utf-8"),
+                    ).encode(),
                     "extra": {"tag": f"Payment to {address.username}@{domain.domain}"},
                 },
                 timeout=40,

--- a/lnbits/extensions/lndhub/decorators.py
+++ b/lnbits/extensions/lndhub/decorators.py
@@ -23,7 +23,7 @@ async def check_wallet(
         )
 
     t = api_key_header_auth.split(" ")[1]
-    _, token = b64decode(t).decode("utf-8").split(":")
+    _, token = b64decode(t).decode().split(":")
 
     return await get_key_type(r, api_key_header=token)
 

--- a/lnbits/extensions/lndhub/views_api.py
+++ b/lnbits/extensions/lndhub/views_api.py
@@ -35,9 +35,9 @@ async def lndhub_auth(data: AuthData):
     token = (
         data.refresh_token
         if data.refresh_token
-        else urlsafe_b64encode(
-            (data.login + ":" + data.password).encode("utf-8")
-        ).decode("ascii")
+        else urlsafe_b64encode((data.login + ":" + data.password).encode()).decode(
+            "ascii"
+        )
     )
     return {"refresh_token": token, "access_token": token}
 

--- a/lnbits/extensions/lnurldevice/lnurl.py
+++ b/lnbits/extensions/lnurldevice/lnurl.py
@@ -246,7 +246,7 @@ async def lnurl_callback(
             wallet_id=device.wallet,
             amount=int(lnurldevicepayment.sats / 1000),
             memo=device.id + " PIN " + str(lnurldevicepayment.pin),
-            unhashed_description=device.lnurlpay_metadata.encode("utf-8"),
+            unhashed_description=device.lnurlpay_metadata.encode(),
             extra={
                 "tag": "Switch",
                 "pin": str(lnurldevicepayment.pin),
@@ -267,7 +267,7 @@ async def lnurl_callback(
         wallet_id=device.wallet,
         amount=int(lnurldevicepayment.sats / 1000),
         memo=device.title,
-        unhashed_description=device.lnurlpay_metadata.encode("utf-8"),
+        unhashed_description=device.lnurlpay_metadata.encode(),
         extra={"tag": "PoS"},
     )
     lnurldevicepayment = await update_lnurldevicepayment(

--- a/lnbits/extensions/lnurlp/lnurl.py
+++ b/lnbits/extensions/lnurlp/lnurl.py
@@ -87,7 +87,7 @@ async def api_lnurl_callback(request: Request, link_id):
         wallet_id=link.wallet,
         amount=int(amount_received / 1000),
         memo=link.description,
-        unhashed_description=link.lnurlpay_metadata.encode("utf-8"),
+        unhashed_description=link.lnurlpay_metadata.encode(),
         extra={
             "tag": "lnurlp",
             "link": link.id,

--- a/lnbits/extensions/offlineshop/lnurl.py
+++ b/lnbits/extensions/offlineshop/lnurl.py
@@ -73,7 +73,7 @@ async def lnurl_callback(request: Request, item_id: int):
             wallet_id=shop.wallet,
             amount=int(amount_received / 1000),
             memo=item.name,
-            unhashed_description=(await item.lnurlpay_metadata()).encode("utf-8"),
+            unhashed_description=(await item.lnurlpay_metadata()).encode(),
             extra={"tag": "offlineshop", "item": item.id},
         )
     except Exception as exc:

--- a/lnbits/extensions/satsdice/lnurl.py
+++ b/lnbits/extensions/satsdice/lnurl.py
@@ -76,7 +76,7 @@ async def api_lnurlp_callback(
         wallet_id=link.wallet,
         amount=int(amount_received / 1000),
         memo="Satsdice bet",
-        unhashed_description=link.lnurlpay_metadata.encode("utf-8"),
+        unhashed_description=link.lnurlpay_metadata.encode(),
         extra={"tag": "satsdice", "link": link.id, "comment": "comment"},
     )
 

--- a/lnbits/lnurl.py
+++ b/lnbits/lnurl.py
@@ -6,11 +6,11 @@ def decode(lnurl: str) -> str:
     assert data
     bech32_data = convertbits(data, 5, 8, False)
     assert bech32_data
-    return bytes(bech32_data).decode("utf-8")
+    return bytes(bech32_data).decode()
 
 
 def encode(url: str) -> str:
-    bech32_data = convertbits(url.encode("utf-8"), 8, 5, True)
+    bech32_data = convertbits(url.encode(), 8, 5, True)
     assert bech32_data
     lnurl = bech32_encode("lnurl", bech32_data)
     return lnurl.upper()

--- a/lnbits/wallets/cln.py
+++ b/lnbits/wallets/cln.py
@@ -96,7 +96,7 @@ class CoreLightningWallet(Wallet):
             r = self.ln.invoice(
                 msatoshi=msat,
                 label=label,
-                description=unhashed_description.decode("utf-8")
+                description=unhashed_description.decode()
                 if unhashed_description
                 else memo,
                 exposeprivatechannels=True,

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -44,7 +44,7 @@ class EclairWallet(Wallet):
         self.ws_url = f"ws://{urllib.parse.urlsplit(self.url).netloc}/ws"
 
         passw = settings.eclair_pass
-        encodedAuth = base64.b64encode(f":{passw}".encode("utf-8"))
+        encodedAuth = base64.b64encode(f":{passw}".encode())
         auth = str(encodedAuth, "utf-8")
         self.auth = {"Authorization": f"Basic {auth}"}
 

--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -23,8 +23,8 @@ class FakeWallet(Wallet):
     secret: str = settings.fake_wallet_secret
     privkey: str = hashlib.pbkdf2_hmac(
         "sha256",
-        secret.encode("utf-8"),
-        ("FakeWallet").encode("utf-8"),
+        secret.encode(),
+        ("FakeWallet").encode(),
         2048,
         32,
     ).hex()
@@ -68,9 +68,7 @@ class FakeWallet(Wallet):
             data["description"] = memo
         randomHash = (
             data["privkey"][:6]
-            + hashlib.sha256(str(random.getrandbits(256)).encode("utf-8")).hexdigest()[
-                6:
-            ]
+            + hashlib.sha256(str(random.getrandbits(256)).encode()).hexdigest()[6:]
         )
         data["paymenthash"] = randomHash
         payment_request = encode(data)

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -71,7 +71,7 @@ def b64_to_bytes(checking_id: str) -> bytes:
 
 
 def bytes_to_b64(r_hash: bytes) -> str:
-    return base64.b64encode(r_hash).decode("utf-8").replace("/", "_")
+    return base64.b64encode(r_hash).decode().replace("/", "_")
 
 
 def hex_to_b64(hex_str: str) -> str:

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -215,7 +215,7 @@ async def test_api_payment_with_key(invoice, inkey_headers_from):
 @pytest.mark.asyncio
 async def test_create_invoice_with_description_hash(client, inkey_headers_to):
     data = await get_random_invoice_data()
-    descr_hash = hashlib.sha256("asdasdasd".encode("utf-8")).hexdigest()
+    descr_hash = hashlib.sha256("asdasdasd".encode()).hexdigest()
     data["description_hash"] = descr_hash
 
     response = await client.post(
@@ -232,8 +232,8 @@ async def test_create_invoice_with_description_hash(client, inkey_headers_to):
 @pytest.mark.asyncio
 async def test_create_invoice_with_unhashed_description(client, inkey_headers_to):
     data = await get_random_invoice_data()
-    descr_hash = hashlib.sha256("asdasdasd".encode("utf-8")).hexdigest()
-    data["unhashed_description"] = "asdasdasd".encode("utf-8").hex()
+    descr_hash = hashlib.sha256("asdasdasd".encode()).hexdigest()
+    data["unhashed_description"] = "asdasdasd".encode().hex()
 
     response = await client.post(
         "/api/v1/payments", json=data, headers=inkey_headers_to


### PR DESCRIPTION
the encoding parameter defaults to `'utf-8'`, so it's not needed

reference:
* https://docs.python.org/3/library/stdtypes.html#str.encode
* https://docs.python.org/3/library/stdtypes.html#bytes.decode