### PR TITLE
shorten lnurlp endpoint URL for smaller QR codes

### DIFF
--- a/lnbits/extensions/lnurlp/lnurl.py
+++ b/lnbits/extensions/lnurlp/lnurl.py
@@ -18,9 +18,9 @@ from .crud import increment_pay_link
 
 
 @lnurlp_ext.get(
-    "/api/v1/lnurl/{link_id}",  # Backwards compatibility for old codes (with long URL)
+    "/api/v1/lnurl/{link_id}",  # Backwards compatibility for old LNURLs / QR codes (with long URL)
     status_code=HTTPStatus.OK,
-    name="lnurlp.api_lnurl_response",
+    name="lnurlp.api_lnurl_response.deprecated",
 )
 @lnurlp_ext.get(
     "/a/{link_id}",

--- a/lnbits/extensions/lnurlp/lnurl.py
+++ b/lnbits/extensions/lnurlp/lnurl.py
@@ -18,7 +18,12 @@ from .crud import increment_pay_link
 
 
 @lnurlp_ext.get(
-    "/api/v1/lnurl/{link_id}",
+    "/api/v1/lnurl/{link_id}",  # Backwards compatibility for old codes (with long URL)
+    status_code=HTTPStatus.OK,
+    name="lnurlp.api_lnurl_response",
+)
+@lnurlp_ext.get(
+    "/a/{link_id}",
     status_code=HTTPStatus.OK,
     name="lnurlp.api_lnurl_response",
 )

--- a/lnbits/extensions/lnurlp/lnurl.py
+++ b/lnbits/extensions/lnurlp/lnurl.py
@@ -23,7 +23,7 @@ from .crud import increment_pay_link
     name="lnurlp.api_lnurl_response.deprecated",
 )
 @lnurlp_ext.get(
-    "/a/{link_id}",
+    "/{link_id}",
     status_code=HTTPStatus.OK,
     name="lnurlp.api_lnurl_response",
 )

--- a/lnbits/extensions/lnurlp/static/js/index.js
+++ b/lnbits/extensions/lnurlp/static/js/index.js
@@ -17,7 +17,7 @@ var mapPayLink = obj => {
   )
   obj.amount = new Intl.NumberFormat(LOCALE).format(obj.amount)
   obj.print_url = [locationPath, 'print/', obj.id].join('')
-  obj.pay_url = [locationPath, obj.id].join('')
+  obj.pay_url = [locationPath, 'link/', obj.id].join('')
   return obj
 }
 

--- a/lnbits/extensions/lnurlp/views.py
+++ b/lnbits/extensions/lnurlp/views.py
@@ -21,7 +21,7 @@ async def index(request: Request, user: User = Depends(check_user_exists)):
     )
 
 
-@lnurlp_ext.get("/{link_id}", response_class=HTMLResponse)
+@lnurlp_ext.get("/link/{link_id}", response_class=HTMLResponse)
 async def display(request: Request, link_id):
     link = await get_pay_link(link_id)
     if not link:


### PR DESCRIPTION
LNURL page link changed from `host/lnurlp/{id}` to `host/lnurlp/link/{id}` (see Screenshot 1) to make room for

LNURL endpoint which changed from `host/lnurlp/api/v1/{id}` to `host/lnurlp/{id}` (see Screenshot 2). Backwards compatibility maintained so old QR codes and LNURLs that point to `lnurlp/api/v1/{id}` still work!

<img width="720" alt="image" src="https://user-images.githubusercontent.com/93376500/210782865-c5963843-7a0b-4b26-a25a-54b58188e827.png">


<img width="477" alt="image" src="https://user-images.githubusercontent.com/93376500/210783015-bd4920c9-3835-455e-a245-85d92acd9150.png">
