### PR TITLE
Fix for Gerty mempool timestamp col on sqlite

### DIFF
--- a/lnbits/extensions/gerty/crud.py
+++ b/lnbits/extensions/gerty/crud.py
@@ -108,16 +108,14 @@ async def get_mempool_info(endPoint: str, gerty) -> dict:
                     id,
                     data,
                     endpoint,
-                    time,
                     mempool_endpoint
                 )
-                VALUES (?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?)
                 """,
                 (
                     mempool_id,
                     json.dumps(response.json()),
                     endPoint,
-                    db.timestamp_now,
                     gerty.mempool_endpoint,
                 ),
             )
@@ -126,10 +124,9 @@ async def get_mempool_info(endPoint: str, gerty) -> dict:
         async with httpx.AsyncClient() as client:
             response = await client.get(gerty.mempool_endpoint + url)
             await db.execute(
-                "UPDATE gerty.mempool SET data = ?, time = ? WHERE endpoint = ? AND mempool_endpoint = ?",
+                "UPDATE gerty.mempool SET data = ? WHERE endpoint = ? AND mempool_endpoint = ?",
                 (
                     json.dumps(response.json()),
-                    db.timestamp_now,
                     endPoint,
                     gerty.mempool_endpoint,
                 ),

--- a/lnbits/extensions/gerty/migrations.py
+++ b/lnbits/extensions/gerty/migrations.py
@@ -57,3 +57,22 @@ async def m005_add_gerty_model_col(db):
     support for Gerty model col
     """
     await db.execute("ALTER TABLE gerty.gertys ADD COLUMN urls TEXT;")
+
+
+async def m006_set_default_mempool_cache_timestamp(db):
+    """
+    Set default timestamp to current timestamp on time col
+    """
+    await db.execute(
+        "ALTER TABLE gerty.mempool DROP COLUMN time;"
+    )
+
+    await db.execute(
+        """
+        ALTER TABLE gerty.mempool
+        ADD COLUMN time TIMESTAMP NOT NULL DEFAULT """
+        + db.timestamp_now
+        + """ 
+        ;
+        """
+        )

--- a/lnbits/extensions/gerty/migrations.py
+++ b/lnbits/extensions/gerty/migrations.py
@@ -63,9 +63,7 @@ async def m006_set_default_mempool_cache_timestamp(db):
     """
     Set default timestamp to current timestamp on time col
     """
-    await db.execute(
-        "ALTER TABLE gerty.mempool DROP COLUMN time;"
-    )
+    await db.execute("ALTER TABLE gerty.mempool DROP COLUMN time;")
 
     await db.execute(
         """
@@ -75,4 +73,4 @@ async def m006_set_default_mempool_cache_timestamp(db):
         + """ 
         ;
         """
-        )
+    )


### PR DESCRIPTION
Changed how the Gerty mempool caching table sets timestamps for cached data.

Previous code worked on postgres but not sqlite.

This changes the migration to set a default timestamp value for the mempool time col to the current time stamp and the mempool INSERT and UPDATE code no longer sets a time value.