### PR TITLE
fix: mypy - constrain `ignore_missing_imports = "True"`

### DIFF
--- a/lnbits/bolt11.py
+++ b/lnbits/bolt11.py
@@ -4,12 +4,12 @@ import time
 from decimal import Decimal
 from typing import List, NamedTuple, Optional
 
-import bitstring  # type: ignore
+import bitstring
 import embit
 import secp256k1
 from bech32 import CHARSET, bech32_decode, bech32_encode
-from ecdsa import SECP256k1, VerifyingKey  # type: ignore
-from ecdsa.util import sigdecode_string  # type: ignore
+from ecdsa import SECP256k1, VerifyingKey
+from ecdsa.util import sigdecode_string
 
 
 class Route(NamedTuple):

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -1,7 +1,7 @@
 import datetime
 
 from loguru import logger
-from sqlalchemy.exc import OperationalError  # type: ignore
+from sqlalchemy.exc import OperationalError
 
 from lnbits import bolt11
 

--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -6,9 +6,9 @@ import time
 from sqlite3 import Row
 from typing import Dict, List, Optional
 
-from ecdsa import SECP256k1, SigningKey  # type: ignore
+from ecdsa import SECP256k1, SigningKey
 from fastapi import Query
-from lnurl import encode as lnurl_encode  # type: ignore
+from lnurl import encode as lnurl_encode
 from loguru import logger
 from pydantic import BaseModel
 

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -7,7 +7,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 from fastapi import Depends, WebSocket
 from lnurl import LnurlErrorResponse
-from lnurl import decode as decode_lnurl  # type: ignore
+from lnurl import decode as decode_lnurl
 from loguru import logger
 
 from lnbits import bolt11
@@ -44,7 +44,7 @@ from .crud import (
 from .models import Payment
 
 try:
-    from typing import TypedDict  # type: ignore
+    from typing import TypedDict
 except ImportError:  # pragma: nocover
     from typing_extensions import TypedDict
 

--- a/lnbits/core/views/public_api.py
+++ b/lnbits/core/views/public_api.py
@@ -16,7 +16,7 @@ from ..tasks import api_invoice_listeners
 
 @core_app.get("/.well-known/lnurlp/{username}")
 async def lnaddress(username: str, request: Request):
-    from lnbits.extensions.lnaddress.lnurl import lnurl_response
+    from lnbits.extensions.lnaddress.lnurl import lnurl_response  # type: ignore
 
     domain = urlparse(str(request.url)).netloc
     return await lnurl_response(username, domain, request)

--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -9,7 +9,7 @@ from typing import Optional
 from loguru import logger
 from sqlalchemy import create_engine
 from sqlalchemy_aio.base import AsyncConnection
-from sqlalchemy_aio.strategy import ASYNCIO_STRATEGY  # type: ignore
+from sqlalchemy_aio.strategy import ASYNCIO_STRATEGY
 
 from lnbits.settings import settings
 
@@ -129,7 +129,7 @@ class Database(Compat):
             else:
                 self.type = POSTGRES
 
-            import psycopg2  # type: ignore
+            import psycopg2
 
             def _parse_timestamp(value, _):
                 if value is None:

--- a/lnbits/extensions/boltz/models.py
+++ b/lnbits/extensions/boltz/models.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 
 from fastapi.params import Query
 from pydantic.main import BaseModel
-from sqlalchemy.engine import base  # type: ignore
+from sqlalchemy.engine import base
 
 
 class SubmarineSwap(BaseModel):
@@ -24,9 +24,9 @@ class SubmarineSwap(BaseModel):
 
 
 class CreateSubmarineSwap(BaseModel):
-    wallet: str = Query(...)  # type: ignore
-    refund_address: str = Query(...)  # type: ignore
-    amount: int = Query(...)  # type: ignore
+    wallet: str = Query(...)
+    refund_address: str = Query(...)
+    amount: int = Query(...)
 
 
 class ReverseSubmarineSwap(BaseModel):
@@ -48,13 +48,13 @@ class ReverseSubmarineSwap(BaseModel):
 
 
 class CreateReverseSubmarineSwap(BaseModel):
-    wallet: str = Query(...)  # type: ignore
-    amount: int = Query(...)  # type: ignore
-    instant_settlement: bool = Query(...)  # type: ignore
+    wallet: str = Query(...)
+    amount: int = Query(...)
+    instant_settlement: bool = Query(...)
     # validate on-address, bcrt1 for regtest addresses
     onchain_address: str = Query(
         ..., regex="^(bcrt1|bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$"
-    )  # type: ignore
+    )
 
 
 class SwapStatus(BaseModel):

--- a/lnbits/extensions/boltz/views_api.py
+++ b/lnbits/extensions/boltz/views_api.py
@@ -111,7 +111,7 @@ async def api_submarineswap(
 )
 async def api_submarineswap_refund(
     swap_id: str,
-    g: WalletTypeInfo = Depends(require_admin_key),  # type: ignore
+    g: WalletTypeInfo = Depends(require_admin_key),
 ):
     if swap_id == None:
         raise HTTPException(
@@ -160,7 +160,7 @@ async def api_submarineswap_refund(
 )
 async def api_submarineswap_create(
     data: CreateSubmarineSwap,
-    wallet: WalletTypeInfo = Depends(require_admin_key),  # type: ignore
+    wallet: WalletTypeInfo = Depends(require_admin_key),
 ):
     try:
         swap_data = await create_swap(data)
@@ -257,7 +257,7 @@ async def api_reverse_submarineswap_create(
     },
 )
 async def api_swap_status(
-    swap_id: str, wallet: WalletTypeInfo = Depends(require_admin_key)  # type: ignore
+    swap_id: str, wallet: WalletTypeInfo = Depends(require_admin_key)
 ):
     swap = await get_submarine_swap(swap_id) or await get_reverse_submarine_swap(
         swap_id
@@ -290,7 +290,7 @@ async def api_swap_status(
     response_description="list of pending swaps",
 )
 async def api_check_swaps(
-    g: WalletTypeInfo = Depends(require_admin_key),  # type: ignore
+    g: WalletTypeInfo = Depends(require_admin_key),
     all_wallets: bool = Query(False),
 ):
     wallet_ids = [g.wallet.id]

--- a/lnbits/extensions/cashu/__init__.py
+++ b/lnbits/extensions/cashu/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from environs import Env  # type: ignore
+from environs import Env
 from fastapi import APIRouter
 from fastapi.staticfiles import StaticFiles
 

--- a/lnbits/extensions/copilot/lnurl.py
+++ b/lnbits/extensions/copilot/lnurl.py
@@ -6,7 +6,7 @@ from fastapi import Request
 from fastapi.param_functions import Query
 from lnurl.types import LnurlPayMetadata
 from starlette.exceptions import HTTPException
-from starlette.responses import HTMLResponse  # type: ignore
+from starlette.responses import HTMLResponse
 
 from lnbits.core.services import create_invoice
 

--- a/lnbits/extensions/copilot/models.py
+++ b/lnbits/extensions/copilot/models.py
@@ -4,11 +4,11 @@ from typing import Dict, Optional
 from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, urlunparse
 
 from fastapi.param_functions import Query
-from lnurl.types import LnurlPayMetadata  # type: ignore
+from lnurl.types import LnurlPayMetadata
 from pydantic import BaseModel
 from starlette.requests import Request
 
-from lnbits.lnurl import encode as lnurl_encode  # type: ignore
+from lnbits.lnurl import encode as lnurl_encode
 
 
 class CreateCopilotData(BaseModel):

--- a/lnbits/extensions/copilot/views.py
+++ b/lnbits/extensions/copilot/views.py
@@ -2,7 +2,7 @@ from typing import List
 
 from fastapi import Depends, Request
 from fastapi.templating import Jinja2Templates
-from starlette.responses import HTMLResponse  # type: ignore
+from starlette.responses import HTMLResponse
 
 from lnbits.core.models import User
 from lnbits.decorators import check_user_exists

--- a/lnbits/extensions/events/tasks.py
+++ b/lnbits/extensions/events/tasks.py
@@ -1,10 +1,10 @@
 import asyncio
 
 from lnbits.core.models import Payment
-from lnbits.extensions.events.models import CreateTicket
 from lnbits.helpers import get_current_extension_name
 from lnbits.tasks import register_invoice_listener
 
+from .models import CreateTicket
 from .views_api import api_ticket_send_ticket
 
 

--- a/lnbits/extensions/events/views_api.py
+++ b/lnbits/extensions/events/views_api.py
@@ -7,7 +7,6 @@ from lnbits.core.crud import get_user
 from lnbits.core.services import create_invoice
 from lnbits.core.views.api import api_payment
 from lnbits.decorators import WalletTypeInfo, get_key_type
-from lnbits.extensions.events.models import CreateEvent, CreateTicket
 
 from . import events_ext
 from .crud import (
@@ -24,6 +23,7 @@ from .crud import (
     reg_ticket,
     update_event,
 )
+from .models import CreateEvent, CreateTicket
 
 # Events
 

--- a/lnbits/extensions/lnaddress/cloudflare.py
+++ b/lnbits/extensions/lnaddress/cloudflare.py
@@ -2,7 +2,7 @@ import json
 
 import httpx
 
-from lnbits.extensions.lnaddress.models import Domains
+from .models import Domains
 
 
 async def cloudflare_create_record(domain: Domains, ip: str):

--- a/lnbits/extensions/lnaddress/views_api.py
+++ b/lnbits/extensions/lnaddress/views_api.py
@@ -6,7 +6,6 @@ from fastapi import Depends, HTTPException, Query, Request
 from lnbits.core.crud import get_user
 from lnbits.core.services import check_transaction_status, create_invoice
 from lnbits.decorators import WalletTypeInfo, get_key_type
-from lnbits.extensions.lnaddress.models import CreateAddress, CreateDomain
 
 from . import lnaddress_ext
 from .cloudflare import cloudflare_create_record
@@ -23,6 +22,7 @@ from .crud import (
     get_domains,
     update_domain,
 )
+from .models import CreateAddress, CreateDomain
 
 
 # DOMAINS

--- a/lnbits/extensions/lndhub/decorators.py
+++ b/lnbits/extensions/lndhub/decorators.py
@@ -5,7 +5,7 @@ from fastapi.param_functions import Security
 from fastapi.security.api_key import APIKeyHeader
 from starlette.exceptions import HTTPException
 
-from lnbits.decorators import WalletTypeInfo, get_key_type  # type: ignore
+from lnbits.decorators import WalletTypeInfo, get_key_type
 
 api_key_header_auth = APIKeyHeader(
     name="AUTHORIZATION",

--- a/lnbits/extensions/lnticket/views_api.py
+++ b/lnbits/extensions/lnticket/views_api.py
@@ -8,7 +8,6 @@ from lnbits.core.crud import get_user
 from lnbits.core.services import create_invoice
 from lnbits.core.views.api import api_payment
 from lnbits.decorators import WalletTypeInfo, get_key_type
-from lnbits.extensions.lnticket.models import CreateFormData, CreateTicketData
 
 from . import lnticket_ext
 from .crud import (
@@ -23,6 +22,7 @@ from .crud import (
     set_ticket_paid,
     update_form,
 )
+from .models import CreateFormData, CreateTicketData
 
 # FORMS
 

--- a/lnbits/extensions/lnurldevice/views_api.py
+++ b/lnbits/extensions/lnurldevice/views_api.py
@@ -4,7 +4,6 @@ from fastapi import Depends, HTTPException, Query, Request
 
 from lnbits.core.crud import get_user
 from lnbits.decorators import WalletTypeInfo, get_key_type, require_admin_key
-from lnbits.extensions.lnurldevice import lnurldevice_ext
 from lnbits.utils.exchange_rates import currencies
 
 from . import lnurldevice_ext

--- a/lnbits/extensions/lnurlp/lnurl.py
+++ b/lnbits/extensions/lnurlp/lnurl.py
@@ -3,11 +3,7 @@ import math
 from http import HTTPStatus
 
 from fastapi import Request
-from lnurl import (  # type: ignore
-    LnurlErrorResponse,
-    LnurlPayActionResponse,
-    LnurlPayResponse,
-)
+from lnurl import LnurlErrorResponse, LnurlPayActionResponse, LnurlPayResponse
 from starlette.exceptions import HTTPException
 
 from lnbits.core.services import create_invoice

--- a/lnbits/extensions/lnurlp/models.py
+++ b/lnbits/extensions/lnurlp/models.py
@@ -4,11 +4,11 @@ from typing import Dict, Optional
 from urllib.parse import ParseResult, parse_qs, urlencode, urlparse, urlunparse
 
 from fastapi.param_functions import Query
-from lnurl.types import LnurlPayMetadata  # type: ignore
+from lnurl.types import LnurlPayMetadata
 from pydantic import BaseModel
 from starlette.requests import Request
 
-from lnbits.lnurl import encode as lnurl_encode  # type: ignore
+from lnbits.lnurl import encode as lnurl_encode
 
 
 class CreatePayLinkData(BaseModel):

--- a/lnbits/extensions/lnurlp/views_api.py
+++ b/lnbits/extensions/lnurlp/views_api.py
@@ -2,7 +2,7 @@ import json
 from http import HTTPStatus
 
 from fastapi import Depends, Query, Request
-from lnurl.exceptions import InvalidUrl as LnurlInvalidUrl  # type: ignore
+from lnurl.exceptions import InvalidUrl as LnurlInvalidUrl
 from starlette.exceptions import HTTPException
 
 from lnbits.core.crud import get_user

--- a/lnbits/extensions/market/notifier.py
+++ b/lnbits/extensions/market/notifier.py
@@ -10,8 +10,8 @@ from collections import defaultdict
 from fastapi import WebSocket
 from loguru import logger
 
-from lnbits.extensions.market.crud import create_chat_message
-from lnbits.extensions.market.models import CreateChatMessage
+from .crud import create_chat_message
+from .models import CreateChatMessage
 
 
 class Notifier:

--- a/lnbits/extensions/market/views.py
+++ b/lnbits/extensions/market/views.py
@@ -17,10 +17,8 @@ from starlette.responses import HTMLResponse
 
 from lnbits.core.models import User
 from lnbits.decorators import check_user_exists  # type: ignore
-from lnbits.extensions.market import market_ext, market_renderer
-from lnbits.extensions.market.models import CreateChatMessage, SetSettings
-from lnbits.extensions.market.notifier import Notifier
 
+from . import market_ext, market_renderer
 from .crud import (
     create_chat_message,
     create_market_settings,
@@ -35,6 +33,8 @@ from .crud import (
     get_market_zones,
     update_market_product_stock,
 )
+from .models import CreateChatMessage, SetSettings
+from .notifier import Notifier
 
 templates = Jinja2Templates(directory="templates")
 

--- a/lnbits/extensions/market/views.py
+++ b/lnbits/extensions/market/views.py
@@ -16,7 +16,7 @@ from starlette.exceptions import HTTPException
 from starlette.responses import HTMLResponse
 
 from lnbits.core.models import User
-from lnbits.decorators import check_user_exists  # type: ignore
+from lnbits.decorators import check_user_exists
 
 from . import market_ext, market_renderer
 from .crud import (

--- a/lnbits/extensions/ngrok/views.py
+++ b/lnbits/extensions/ngrok/views.py
@@ -1,4 +1,3 @@
-# type: ignore
 from os import getenv
 
 from fastapi import Depends, Request
@@ -36,5 +35,5 @@ ngrok_tunnel = ngrok.connect(port)
 @ngrok_ext.get("/")
 async def index(request: Request, user: User = Depends(check_user_exists)):
     return ngrok_renderer().TemplateResponse(
-        "ngrok/index.html", {"request": request, "ngrok": string5, "user": user.dict()}
+        "ngrok/index.html", {"request": request, "ngrok": string5, "user": user.dict()}  # type: ignore
     )

--- a/lnbits/extensions/satsdice/lnurl.py
+++ b/lnbits/extensions/satsdice/lnurl.py
@@ -5,7 +5,7 @@ from http import HTTPStatus
 from fastapi import Request
 from fastapi.param_functions import Query
 from starlette.exceptions import HTTPException
-from starlette.responses import HTMLResponse  # type: ignore
+from starlette.responses import HTMLResponse
 
 from lnbits.core.services import create_invoice, pay_invoice
 

--- a/lnbits/extensions/satsdice/models.py
+++ b/lnbits/extensions/satsdice/models.py
@@ -5,8 +5,8 @@ from typing import Dict, Optional
 from fastapi import Request
 from fastapi.param_functions import Query
 from lnurl import Lnurl
-from lnurl import encode as lnurl_encode  # type: ignore
-from lnurl.types import LnurlPayMetadata  # type: ignore
+from lnurl import encode as lnurl_encode
+from lnurl.types import LnurlPayMetadata
 from pydantic import BaseModel
 from pydantic.main import BaseModel
 

--- a/lnbits/extensions/satsdice/views_api.py
+++ b/lnbits/extensions/satsdice/views_api.py
@@ -1,7 +1,7 @@
 from http import HTTPStatus
 
 from fastapi import Depends, Query, Request
-from lnurl.exceptions import InvalidUrl as LnurlInvalidUrl  # type: ignore
+from lnurl.exceptions import InvalidUrl as LnurlInvalidUrl
 from starlette.exceptions import HTTPException
 
 from lnbits.core.crud import get_user

--- a/lnbits/extensions/satspay/crud.py
+++ b/lnbits/extensions/satspay/crud.py
@@ -7,7 +7,7 @@ from lnbits.core.services import create_invoice
 from lnbits.core.views.api import api_payment
 from lnbits.helpers import urlsafe_short_hash
 
-from ..watchonly.crud import get_config, get_fresh_address
+from ..watchonly.crud import get_config, get_fresh_address  # type: ignore
 from . import db
 from .helpers import fetch_onchain_balance
 from .models import Charges, CreateCharge, SatsPayThemes

--- a/lnbits/extensions/satspay/tasks.py
+++ b/lnbits/extensions/satspay/tasks.py
@@ -4,11 +4,10 @@ import json
 from loguru import logger
 
 from lnbits.core.models import Payment
-from lnbits.extensions.satspay.crud import check_address_balance, get_charge
 from lnbits.helpers import get_current_extension_name
 from lnbits.tasks import register_invoice_listener
 
-from .crud import update_charge
+from .crud import check_address_balance, get_charge, update_charge
 from .helpers import call_webhook
 
 

--- a/lnbits/extensions/satspay/views.py
+++ b/lnbits/extensions/satspay/views.py
@@ -6,10 +6,10 @@ from starlette.responses import HTMLResponse
 
 from lnbits.core.models import User
 from lnbits.decorators import check_user_exists
-from lnbits.extensions.satspay.helpers import public_charge
 
 from . import satspay_ext, satspay_renderer
 from .crud import get_charge, get_theme
+from .helpers import public_charge
 
 templates = Jinja2Templates(directory="templates")
 

--- a/lnbits/extensions/satspay/views_api.py
+++ b/lnbits/extensions/satspay/views_api.py
@@ -11,8 +11,8 @@ from lnbits.decorators import (
     require_admin_key,
     require_invoice_key,
 )
-from lnbits.extensions.satspay import satspay_ext
 
+from . import satspay_ext
 from .crud import (
     check_address_balance,
     create_charge,

--- a/lnbits/extensions/scrub/models.py
+++ b/lnbits/extensions/scrub/models.py
@@ -3,7 +3,7 @@ from sqlite3 import Row
 from pydantic import BaseModel
 from starlette.requests import Request
 
-from lnbits.lnurl import encode as lnurl_encode  # type: ignore
+from lnbits.lnurl import encode as lnurl_encode
 
 
 class CreateScrubLink(BaseModel):

--- a/lnbits/extensions/smtp/views_api.py
+++ b/lnbits/extensions/smtp/views_api.py
@@ -5,7 +5,6 @@ from fastapi import Depends, HTTPException, Query
 from lnbits.core.crud import get_user
 from lnbits.core.services import check_transaction_status, create_invoice
 from lnbits.decorators import WalletTypeInfo, get_key_type
-from lnbits.extensions.smtp.models import CreateEmail, CreateEmailaddress
 
 from . import smtp_ext
 from .crud import (
@@ -19,6 +18,7 @@ from .crud import (
     get_emails,
     update_emailaddress,
 )
+from .models import CreateEmail, CreateEmailaddress
 from .smtp import valid_email
 
 

--- a/lnbits/extensions/streamalerts/crud.py
+++ b/lnbits/extensions/streamalerts/crud.py
@@ -7,6 +7,7 @@ from lnbits.core.crud import get_wallet
 from lnbits.db import SQLITE
 from lnbits.helpers import urlsafe_short_hash
 
+# todo: use the API, not direct import
 from ..satspay.crud import delete_charge  # type: ignore
 from . import db
 from .models import CreateService, Donation, Service

--- a/lnbits/extensions/streamalerts/views_api.py
+++ b/lnbits/extensions/streamalerts/views_api.py
@@ -7,10 +7,13 @@ from starlette.responses import RedirectResponse
 
 from lnbits.core.crud import get_user
 from lnbits.decorators import WalletTypeInfo, get_key_type
-from lnbits.extensions.satspay.models import CreateCharge
+
+# todo: use the API, not direct import
+from lnbits.extensions.satspay.models import CreateCharge  # type: ignore
 from lnbits.utils.exchange_rates import btc_price
 
-from ..satspay.crud import create_charge, get_charge
+# todo: use the API, not direct import
+from ..satspay.crud import create_charge, get_charge  # type: ignore
 from . import streamalerts_ext
 from .crud import (
     authenticate_service,

--- a/lnbits/extensions/streamalerts/views_api.py
+++ b/lnbits/extensions/streamalerts/views_api.py
@@ -8,11 +8,6 @@ from starlette.responses import RedirectResponse
 from lnbits.core.crud import get_user
 from lnbits.decorators import WalletTypeInfo, get_key_type
 from lnbits.extensions.satspay.models import CreateCharge
-from lnbits.extensions.streamalerts.models import (
-    CreateDonation,
-    CreateService,
-    ValidateDonation,
-)
 from lnbits.utils.exchange_rates import btc_price
 
 from ..satspay.crud import create_charge, get_charge
@@ -33,6 +28,7 @@ from .crud import (
     update_donation,
     update_service,
 )
+from .models import CreateDonation, CreateService, ValidateDonation
 
 
 @streamalerts_ext.post("/api/v1/services")

--- a/lnbits/extensions/subdomains/cloudflare.py
+++ b/lnbits/extensions/subdomains/cloudflare.py
@@ -2,7 +2,7 @@ import json
 
 import httpx
 
-from lnbits.extensions.subdomains.models import Domains
+from .models import Domains
 
 
 async def cloudflare_create_subdomain(

--- a/lnbits/extensions/subdomains/tasks.py
+++ b/lnbits/extensions/subdomains/tasks.py
@@ -30,7 +30,7 @@ async def on_invoice_paid(payment: Payment) -> None:
 
     ### Create subdomain
     cf_response = await cloudflare_create_subdomain(
-        domain=domain,
+        domain=domain,  # type: ignore
         subdomain=subdomain.subdomain,
         record_type=subdomain.record_type,
         ip=subdomain.ip,

--- a/lnbits/extensions/subdomains/views_api.py
+++ b/lnbits/extensions/subdomains/views_api.py
@@ -6,7 +6,6 @@ from starlette.exceptions import HTTPException
 from lnbits.core.crud import get_user
 from lnbits.core.services import check_transaction_status, create_invoice
 from lnbits.decorators import WalletTypeInfo, get_key_type
-from lnbits.extensions.subdomains.models import CreateDomain, CreateSubdomain
 
 from . import subdomains_ext
 from .cloudflare import cloudflare_create_subdomain, cloudflare_deletesubdomain
@@ -22,6 +21,7 @@ from .crud import (
     get_subdomains,
     update_domain,
 )
+from .models import CreateDomain, CreateSubdomain
 
 # domainS
 

--- a/lnbits/extensions/tipjar/crud.py
+++ b/lnbits/extensions/tipjar/crud.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from lnbits.db import SQLITE
 
+# todo: use the API, not direct import
 from ..satspay.crud import delete_charge  # type: ignore
 from . import db
 from .models import Tip, TipJar, createTipJar

--- a/lnbits/extensions/tipjar/views_api.py
+++ b/lnbits/extensions/tipjar/views_api.py
@@ -6,8 +6,9 @@ from starlette.exceptions import HTTPException
 from lnbits.core.crud import get_user
 from lnbits.decorators import WalletTypeInfo, get_key_type
 
-from ..satspay.crud import create_charge
-from ..satspay.models import CreateCharge
+# todo: use the API, not direct import
+from ..satspay.crud import create_charge  # type: ignore
+from ..satspay.models import CreateCharge  # type: ignore
 from . import tipjar_ext
 from .crud import (
     create_tip,

--- a/lnbits/extensions/watchonly/views_api.py
+++ b/lnbits/extensions/watchonly/views_api.py
@@ -11,8 +11,8 @@ from embit.transaction import Transaction, TransactionInput, TransactionOutput
 from fastapi import Depends, HTTPException, Query, Request
 
 from lnbits.decorators import WalletTypeInfo, get_key_type, require_admin_key
-from lnbits.extensions.watchonly import watchonly_ext
 
+from . import watchonly_ext
 from .crud import (
     create_config,
     create_fresh_addresses,

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -4,7 +4,7 @@ import os
 from typing import Any, List, NamedTuple, Optional
 
 import jinja2
-import shortuuid  # type: ignore
+import shortuuid
 
 from lnbits.jinja2_templating import Jinja2Templates
 from lnbits.requestvars import g

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,21 +97,7 @@ exclude = """(?x)(
 [[tool.mypy.overrides]]
 module = [
   "embit.*",
-  "secp256k1.*",
-  "uvicorn.*",
-  "sqlalchemy.*",
-  "sqlalchemy_aio.*",
-  "websocket.*",
-  "websockets.*",
-  "pyqrcode.*",
-  "cashu.*",
-  "shortuuid.*",
-  "grpc.*",
-  "lnurl.*",
-  "bitstring.*",
-  "ecdsa.*",
-  "psycopg2.*",
-  "pyngrok.*"
+  "cashu.*"
 ]
 ignore_missing_imports = "True"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,24 @@ exclude = """(?x)(
 )"""
 
 [[tool.mypy.overrides]]
-module = "embit.*,secp256k1.*,uvicorn.*,sqlalchemy.*,sqlalchemy_aio.*,websocket.*,websockets.*,pyqrcode.*,cashu.*,shortuuid.*,grpc.*,lnurl.*,bitstring.*,ecdsa.*,psycopg2.*,pyngrok.*"
+module = [
+  "embit.*",
+  "secp256k1.*",
+  "uvicorn.*",
+  "sqlalchemy.*",
+  "sqlalchemy_aio.*",
+  "websocket.*",
+  "websockets.*",
+  "pyqrcode.*",
+  "cashu.*",
+  "shortuuid.*",
+  "grpc.*",
+  "lnurl.*",
+  "bitstring.*",
+  "ecdsa.*",
+  "psycopg2.*",
+  "pyngrok.*"
+]
 ignore_missing_imports = "True"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,21 @@ exclude = """(?x)(
 [[tool.mypy.overrides]]
 module = [
   "embit.*",
-  "cashu.*"
+  "secp256k1.*",
+  "uvicorn.*",
+  "sqlalchemy.*",
+  "sqlalchemy_aio.*",
+  "websocket.*",
+  "websockets.*",
+  "pyqrcode.*",
+  "cashu.*",
+  "shortuuid.*",
+  "grpc.*",
+  "lnurl.*",
+  "bitstring.*",
+  "ecdsa.*",
+  "psycopg2.*",
+  "pyngrok.*"
 ]
 ignore_missing_imports = "True"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ lnbits = "lnbits.server:main"
 profile = "black"
 
 [tool.mypy]
-ignore_missing_imports = "True"
 files = "lnbits"
 exclude = """(?x)(
     ^lnbits/extensions/bleskomat.
@@ -94,6 +93,10 @@ exclude = """(?x)(
     | ^lnbits/extensions/livestream.
     | ^lnbits/wallets/lnd_grpc_files.
 )"""
+
+[[tool.mypy.overrides]]
+module = "embit.*,secp256k1.*,uvicorn.*,sqlalchemy.*,sqlalchemy_aio.*,websocket.*,pyqrcode.*,cashu.*,shortuuid.*,grpc.*,lnurl.*"
+ignore_missing_imports = "True"
 
 [tool.pytest.ini_options]
 addopts = "--durations=1 -s --cov=lnbits --cov-report=xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ exclude = """(?x)(
 )"""
 
 [[tool.mypy.overrides]]
-module = "embit.*,secp256k1.*,uvicorn.*,sqlalchemy.*,sqlalchemy_aio.*,websocket.*,pyqrcode.*,cashu.*,shortuuid.*,grpc.*,lnurl.*"
+module = "embit.*,secp256k1.*,uvicorn.*,sqlalchemy.*,sqlalchemy_aio.*,websocket.*,websockets.*,pyqrcode.*,cashu.*,shortuuid.*,grpc.*,lnurl.*,bitstring.*,ecdsa.*,psycopg2.*,pyngrok.*"
 ignore_missing_imports = "True"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### Summary
 - `pyproject.toml` had the flag `ignore_missing_imports = "True"`. It was too relaxed so all missing imports were ignored.
 - this PR narrows down what is ignored, enforces stricter rules and cleans-up redundant `# type: ignore`
 
### Changes

- [x] Explicitly specify the modules for which missing imports should be ignored:
  - there is a new config in `pyproject.toml` that specifies for which modules to ignore the imports
  - the global `mypy` `ignore_missing_imports = "True"` has been removed

- [x] use relative imports inside the extension module
  - this is enforced by `mypy` after the "explicit ignore" change
  - this is required for https://github.com/lnbits/lnbits/pull/1231
     - no absolute import of own modules:
        - **NOK**: `from lnbits.extensions.satspay.crud import check_address_balance, get_charge`
        - **OK**:    `from .crud import check_address_balance, get_charge, update_charge` 

- [x] remove redundant `# type: ignore`
  - there are now fewer ignores in the code
  - many of the remaining ones can be a source of bugs and should be handled
     - passing an `Optional` to a mandatory input param
     - importing from one extension from another (hard dependency, should use API calls) 
  - the bulk of the changed files are caused by this change.