### PR TITLE
Don't Multiply Sat Price by 100 for NIP-5 Verification

### DIFF
--- a/lnbits/extensions/nostrnip5/crud.py
+++ b/lnbits/extensions/nostrnip5/crud.py
@@ -177,7 +177,7 @@ async def create_domain_internal(wallet_id: str, data: CreateDomainData) -> Doma
         amount = data.amount * 100
     else:
         amount = data.amount
-        
+
     await db.execute(
         """
         INSERT INTO nostrnip5.domains (id, wallet, currency, amount, domain)

--- a/lnbits/extensions/nostrnip5/crud.py
+++ b/lnbits/extensions/nostrnip5/crud.py
@@ -173,12 +173,17 @@ async def create_address_internal(domain_id: str, data: CreateAddressData) -> Ad
 async def create_domain_internal(wallet_id: str, data: CreateDomainData) -> Domain:
     domain_id = urlsafe_short_hash()
 
+    if data.currency != "Satoshis":
+        amount = data.amount * 100
+    else:
+        amount = data.amount
+        
     await db.execute(
         """
         INSERT INTO nostrnip5.domains (id, wallet, currency, amount, domain)
         VALUES (?, ?, ?, ?, ?)
         """,
-        (domain_id, wallet_id, data.currency, int(data.amount * 100), data.domain),
+        (domain_id, wallet_id, data.currency, int(amount), data.domain),
     )
 
     domain = await get_domain(domain_id)

--- a/lnbits/extensions/nostrnip5/templates/nostrnip5/signup.html
+++ b/lnbits/extensions/nostrnip5/templates/nostrnip5/signup.html
@@ -37,9 +37,15 @@ context %} {% block page %}
       </p>
       <p>
         The current price is
+        {% if domain.currency != "Satoshis" %}
         <b
           >{{ "{:0,.2f}".format(domain.amount / 100) }} {{ domain.currency }}</b
         >
+        {% else %}
+        <b
+          >{{ "{}".format(domain.amount) }} {{ domain.currency }}</b
+        >   
+        {% endif %}
         for an account (if you do not own the domain, the service provider can
         disable at any time).
       </p>

--- a/lnbits/extensions/nostrnip5/templates/nostrnip5/signup.html
+++ b/lnbits/extensions/nostrnip5/templates/nostrnip5/signup.html
@@ -36,18 +36,14 @@ context %} {% block page %}
         the {{ domain.domain }} domain.
       </p>
       <p>
-        The current price is
-        {% if domain.currency != "Satoshis" %}
+        The current price is {% if domain.currency != "Satoshis" %}
         <b
           >{{ "{:0,.2f}".format(domain.amount / 100) }} {{ domain.currency }}</b
         >
         {% else %}
-        <b
-          >{{ "{}".format(domain.amount) }} {{ domain.currency }}</b
-        >   
-        {% endif %}
-        for an account (if you do not own the domain, the service provider can
-        disable at any time).
+        <b>{{ "{}".format(domain.amount) }} {{ domain.currency }}</b>
+        {% endif %} for an account (if you do not own the domain, the service
+        provider can disable at any time).
       </p>
 
       <p>After submitting payment, your address will be</p>


### PR DESCRIPTION
The price in sats is being multiplied by 100, should only be done for fiat currencies. 

I input a price of 999 sats and got an invoice for 99900:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/264977/211343165-f21abd15-8552-467f-b8f5-48a71a992413.png">
