### PR TITLE
Additional information in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
+#For more information on .env files, their content and format: https://pypi.org/project/python-dotenv/
+
 HOST=127.0.0.1
 PORT=5000
 
-# uvicorn variable, allow https behind a proxy
+# uvicorn variable, uncomment to allow https behind a proxy
 # FORWARDED_ALLOW_IPS="*"
 
 DEBUG=false


### PR DESCRIPTION
1. Link to details on what and how to include information in a .env file
2. Clarify how to activate the FORWARDED_ALLOW_IPS environment variable for those situations where the proxy is not at the default 127.0.0.1 (most often this is required when running inside a Docker container.)