### PR TITLE
LNTips fix: payment lookup error handling

### DIFF
--- a/lnbits/wallets/lntips.py
+++ b/lnbits/wallets/lntips.py
@@ -113,31 +113,37 @@ class LnTipsWallet(Wallet):
         return PaymentResponse(True, checking_id, fee_msat, preimage, None)
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
-        async with httpx.AsyncClient() as client:
-            r = await client.post(
-                f"{self.endpoint}/api/v1/invoicestatus/{checking_id}",
-                headers=self.auth,
-            )
+        try:
+            async with httpx.AsyncClient() as client:
+                r = await client.post(
+                    f"{self.endpoint}/api/v1/invoicestatus/{checking_id}",
+                    headers=self.auth,
+                )
 
-        if r.is_error or len(r.text) == 0:
+            if r.is_error or len(r.text) == 0:
+                raise Exception
+
+            data = r.json()
+            return PaymentStatus(data["paid"])
+        except:
             return PaymentStatus(None)
-
-        data = r.json()
-        return PaymentStatus(data["paid"])
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
-        async with httpx.AsyncClient() as client:
-            r = await client.post(
-                url=f"{self.endpoint}/api/v1/paymentstatus/{checking_id}",
-                headers=self.auth,
-            )
+        try:
+            async with httpx.AsyncClient() as client:
+                r = await client.post(
+                    url=f"{self.endpoint}/api/v1/paymentstatus/{checking_id}",
+                    headers=self.auth,
+                )
 
-        if r.is_error:
+            if r.is_error:
+                raise Exception
+            data = r.json()
+
+            paid_to_status = {False: None, True: True}
+            return PaymentStatus(paid_to_status[data.get("paid")])
+        except:
             return PaymentStatus(None)
-        data = r.json()
-
-        paid_to_status = {False: None, True: True}
-        return PaymentStatus(paid_to_status[data.get("paid")])
 
     async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:
         last_connected = None


### PR DESCRIPTION
Handles error for non-existing outgoing payment checks.

Fixes: #1373