### PR TITLE
Track fiat amount in TPoS invoices.

### DIFF
--- a/lnbits/extensions/tpos/templates/tpos/tpos.html
+++ b/lnbits/extensions/tpos/templates/tpos/tpos.html
@@ -500,6 +500,7 @@
           .post('/tpos/api/v1/tposs/' + this.tposId + '/invoices', null, {
             params: {
               amount: this.sat,
+              memo: this.amountFormatted,
               tipAmount: this.tipAmountSat
             }
           })

--- a/lnbits/extensions/tpos/views_api.py
+++ b/lnbits/extensions/tpos/views_api.py
@@ -58,7 +58,7 @@ async def api_tpos_delete(
 
 @tpos_ext.post("/api/v1/tposs/{tpos_id}/invoices", status_code=HTTPStatus.CREATED)
 async def api_tpos_create_invoice(
-    tpos_id: str, amount: int = Query(..., ge=1), tipAmount: int = 0
+    tpos_id: str, amount: int = Query(..., ge=1), memo: str = "", tipAmount: int = 0
 ) -> dict:
 
     tpos = await get_tpos(tpos_id)
@@ -75,7 +75,7 @@ async def api_tpos_create_invoice(
         payment_hash, payment_request = await create_invoice(
             wallet_id=tpos.wallet,
             amount=amount,
-            memo=f"{tpos.name}",
+            memo=f"{memo} to {tpos.name}" if memo else f"{tpos.name}",
             extra={
                 "tag": "tpos",
                 "tipAmount": tipAmount,


### PR DESCRIPTION
Some merchants using TPoS need to capture the billed fiat amount for book keeping. This quick fix captures the fiat amount via invoice memo.
<img width="787" alt="image" src="https://user-images.githubusercontent.com/278556/213565755-9b05dc94-10d5-4409-ae2f-692b5c5c2d4d.png">
