### PR TITLE
fix: ignore extra settings fields

### DIFF
--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -5,11 +5,10 @@ import subprocess
 from os import path
 from sqlite3 import Row
 from typing import List, Optional
-from pydantic import Extra
 
 import httpx
 from loguru import logger
-from pydantic import BaseSettings, Field, validator
+from pydantic import BaseSettings, Extra, Field, validator
 
 
 def list_parse_fallback(v):

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -5,6 +5,7 @@ import subprocess
 from os import path
 from sqlite3 import Row
 from typing import List, Optional
+from pydantic import Extra
 
 import httpx
 from loguru import logger
@@ -33,6 +34,7 @@ class LNbitsSettings(BaseSettings):
         env_file_encoding = "utf-8"
         case_sensitive = False
         json_loads = list_parse_fallback
+        extra = Extra.ignore
 
 
 class UsersSettings(LNbitsSettings):


### PR DESCRIPTION
Some `settings` fields can be removed over time, but the values in the DB still remain.

If extra fields are present then an exception is thrown:

```
2023-01-23 14:36:46.93 | ERROR | lnbits.app:lnbits_startup:155 | 2 validation errors for SuperSettings
lnbits_ext_github_token
  extra fields not permitted (type=value_error.extra)
lnbits_extensions_manifests
  extra fields not permitted (type=value_error.extra)
  
```

This PR ignores extra fields.