### PR TITLE
TEST: LNbits as fundingsource in regtest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ docker
 docs
 tests
 venv
-tools
 
 lnbits/static/css/*
 lnbits/static/bundle.js

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -134,3 +134,45 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
+  LNbitsWallet:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+        poetry-version: ["1.3.1"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up Poetry ${{ matrix.poetry-version }}
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
+      - name: Setup Regtest
+        run: |
+          docker build -t lnbitsdocker/lnbits-legend .
+          git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
+          cd docker
+          chmod +x ./tests
+          ./tests
+          sudo chmod -R a+rwx .
+      - name: Install dependencies
+        run: |
+          poetry install
+      - name: Run tests
+        env:
+          PYTHONUNBUFFERED: 1
+          PORT: 5123
+          LNBITS_DATA_FOLDER: ./data
+          LNBITS_BACKEND_WALLET_CLASS: LNbitsWallet
+          LNBITS_ENDPOINT: http://localhost:5001
+          LNBITS_KEY: "d08a3313322a4514af75d488bcc27eee"
+        run: |
+          sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
+          make test-real-wallet
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -158,7 +158,7 @@ jobs:
           chmod +x ./tests
           ./tests
           sudo chmod -R a+rwx .
-          docker exec -it lnbits-legend-lnbits-1 /bin/bash -c "poetry run python tools/create_fake_admin.py"
+          docker exec -it lnbits-legend-lnbits-1 /bin/bash -c 'poetry run python tools/create_fake_admin.py'
       - name: Install dependencies
         run: |
           poetry install

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -158,7 +158,7 @@ jobs:
           chmod +x ./tests
           ./tests
           sudo chmod -R a+rwx .
-          docker exec -it lnbits-legend-lnbits-1 /bin/bash -c 'poetry run python tools/create_fake_admin.py'
+          docker exec lnbits-legend-lnbits-1 /bin/bash -c "poetry run python tools/create_fake_admin.py"
       - name: Install dependencies
         run: |
           poetry install

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -158,6 +158,7 @@ jobs:
           chmod +x ./tests
           ./tests
           sudo chmod -R a+rwx .
+          docker exec -it lnbits-legend-lnbits-1 /bin/bash -c "poetry run python tools/create_fake_admin.py"
       - name: Install dependencies
         run: |
           poetry install

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p lnbits/data
 COPY . .
 
 RUN poetry config virtualenvs.create false
-RUN poetry install --only main --no-root
+RUN poetry install --only main
 RUN poetry run python build.py
 
 ENV LNBITS_PORT="5000"

--- a/tools/create_fake_admin.py
+++ b/tools/create_fake_admin.py
@@ -1,0 +1,81 @@
+# Python script to create a fake admin user for sqlite3,
+# for regtest setup as LNbits funding source
+
+import os
+import sqlite3
+import sys
+import time
+from uuid import uuid4
+
+from lnbits.helpers import urlsafe_short_hash
+from lnbits.settings import settings
+
+adminkey = "d08a3313322a4514af75d488bcc27eee"
+sqfolder = settings.lnbits_data_folder
+
+if not sqfolder or not os.path.isdir(sqfolder):
+    print("missing LNBITS_DATA_FOLDER")
+    sys.exit(1)
+
+file = os.path.join(sqfolder, "database.sqlite3")
+conn = sqlite3.connect(file)
+cursor = conn.cursor()
+
+old_account = cursor.execute(
+    "SELECT * FROM accounts WHERE id = ?", (adminkey,)
+).fetchone()
+if old_account:
+    print("fake admin does already exist")
+    sys.exit(1)
+
+
+cursor.execute("INSERT INTO accounts (id) VALUES (?)", (adminkey,))
+
+wallet_id = uuid4().hex
+cursor.execute(
+    """
+    INSERT INTO wallets (id, name, "user", adminkey, inkey)
+    VALUES (?, ?, ?, ?, ?)
+    """,
+    (
+        wallet_id,
+        "TEST WALLET",
+        adminkey,
+        adminkey,
+        uuid4().hex,  # invoice key is not important
+    ),
+)
+
+expiration_date = time.time() + 420
+
+# 1 btc in sats
+amount = 100_000_000
+internal_id = f"internal_{urlsafe_short_hash()}"
+
+cursor.execute(
+    """
+    INSERT INTO apipayments
+      (wallet, checking_id, bolt11, hash, preimage,
+       amount, pending, memo, fee, extra, webhook, expiry)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """,
+    (
+        wallet_id,
+        internal_id,
+        "test_admin_internal",
+        "test_admin_internal",
+        None,
+        amount * 1000,
+        False,
+        "test_admin_internal",
+        0,
+        None,
+        "",
+        expiration_date,
+    ),
+)
+
+print(f"created test admin: {adminkey} with {amount} sats")
+
+conn.commit()
+cursor.close()

--- a/tools/create_fake_admin.py
+++ b/tools/create_fake_admin.py
@@ -6,12 +6,10 @@ import sqlite3
 import sys
 import time
 from uuid import uuid4
-
-from lnbits.helpers import urlsafe_short_hash
-from lnbits.settings import settings
+import shortuuid
 
 adminkey = "d08a3313322a4514af75d488bcc27eee"
-sqfolder = settings.lnbits_data_folder
+sqfolder = "./data"
 
 if not sqfolder or not os.path.isdir(sqfolder):
     print("missing LNBITS_DATA_FOLDER")
@@ -50,7 +48,7 @@ expiration_date = time.time() + 420
 
 # 1 btc in sats
 amount = 100_000_000
-internal_id = f"internal_{urlsafe_short_hash()}"
+internal_id = f"internal_{shortuuid.uuid()}"
 
 cursor.execute(
     """

--- a/tools/create_fake_admin.py
+++ b/tools/create_fake_admin.py
@@ -6,6 +6,7 @@ import sqlite3
 import sys
 import time
 from uuid import uuid4
+
 import shortuuid
 
 adminkey = "d08a3313322a4514af75d488bcc27eee"


### PR DESCRIPTION
this pr adds a tool to create a user with predefined ID. so we can use it to test LNbits as fundingsource inside regtest.

-   github workflow
-   tools/create_fake_user.py
-   changes in Dockerfile so we can run the tools/\*.py
-   changes in .dockerignore so tools are available inside docker aswell
