### PR TITLE
respect https setting in admin ui link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,7 @@ LNBITS_DISABLED_EXTENSIONS="amilk"
 LNBITS_DATA_FOLDER="./data"
 # LNBITS_DATABASE_URL="postgres://user:password@host:port/databasename"
 
-LNBITS_FORCE_HTTPS=true
+LNBITS_FORCE_HTTPS=false
 LNBITS_SERVICE_FEE="0.0"
 # value in millisats
 LNBITS_RESERVE_FEE_MIN=2000

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -435,7 +435,7 @@ async def check_admin_settings():
             logger.debug(f"{key}: {value}")
 
         admin_url = (
-            f"http://{settings.host}:{settings.port}/wallet?usr={settings.super_user}"
+            f"{'https' if settings.lnbits_force_https else 'http'}://{settings.host}:{settings.port}/wallet?usr={settings.super_user}"
         )
         logger.success(f"✔️ Access super user account at: {admin_url}")
 

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -434,9 +434,7 @@ async def check_admin_settings():
         for key, value in settings.dict(exclude_none=True).items():
             logger.debug(f"{key}: {value}")
 
-        admin_url = (
-            f"{'https' if settings.lnbits_force_https else 'http'}://{settings.host}:{settings.port}/wallet?usr={settings.super_user}"
-        )
+        admin_url = f"{'https' if settings.lnbits_force_https else 'http'}://{settings.host}:{settings.port}/wallet?usr={settings.super_user}"
         logger.success(f"✔️ Access super user account at: {admin_url}")
 
         # callback for saas


### PR DESCRIPTION
Changes `LNBITS_FORCE_HTTPS` in `.env.example` to `False` to reflect the same default as in `settings.py`.

Respects the setting when printing admin UI link.