### PR TITLE
TEST: depend all tests on single regtest

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           poetry install
 
-  LndRestWallet:
-    runs-on: ubuntu-latest
-    needs: [regtest]
-    steps:
+  # LndRestWallet:
+  #   runs-on: ubuntu-latest
+  #   needs: [regtest]
+  #   steps:
       - name: Run LndRestWallet
         env:
           PYTHONUNBUFFERED: 1
@@ -50,10 +50,10 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-  LndWallet:
-    runs-on: ubuntu-latest
-    needs: [regtest]
-    steps:
+  # LndWallet:
+  #   runs-on: ubuntu-latest
+  #   needs: [regtest]
+  #   steps:
       - name: Run LndWallet tests
         env:
           PYTHONUNBUFFERED: 1
@@ -68,10 +68,10 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-  CoreLightningWallet:
-    runs-on: ubuntu-latest
-    needs: [regtest]
-    steps:
+  # CoreLightningWallet:
+  #   runs-on: ubuntu-latest
+  #   needs: [regtest]
+  #   steps:
       - name: Run CoreLightningWallet tests
         env:
           PYTHONUNBUFFERED: 1
@@ -83,10 +83,10 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-  LNbitsWallet:
-    runs-on: ubuntu-latest
-    needs: [regtest]
-    steps:
+  # LNbitsWallet:
+  #   runs-on: ubuntu-latest
+  #   needs: [regtest]
+  #   steps:
       - name: Run LNbitsWallet tests
         env:
           PYTHONUNBUFFERED: 1
@@ -99,10 +99,10 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-  EclairWallet:
-    runs-on: ubuntu-latest
-    needs: ["regtest"]
-    steps:
+#   EclairWallet:
+#     runs-on: ubuntu-latest
+#     needs: ["regtest"]
+#     steps:
       - name: Run EclairWallet tests
         env:
           PYTHONUNBUFFERED: 1
@@ -115,10 +115,10 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-  coverage:
-    runs-on: ubuntu-latest
-    needs: ["CoreLightningWallet", "LndWallet", "LndRestWallet", "EclairWallet"]
-    steps:
+  # coverage:
+  #   runs-on: ubuntu-latest
+  #   needs: ["CoreLightningWallet", "LndWallet", "LndRestWallet", "EclairWallet"]
+  #   steps:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -12,15 +12,22 @@ jobs:
         poetry-version: ["1.3.1"]
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Poetry ${{ matrix.poetry-version }}
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: ${{ matrix.poetry-version }}
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
+
+      - name: Install python dependencies
+        run: |
+          poetry install
+
       - name: Setup Regtest
         run: |
           docker build -t lnbitsdocker/lnbits-legend .
@@ -29,14 +36,7 @@ jobs:
           chmod +x ./tests
           ./tests
           sudo chmod -R a+rwx .
-      - name: Install python dependencies
-        run: |
-          poetry install
 
-  # LndRestWallet:
-  #   runs-on: ubuntu-latest
-  #   needs: [regtest]
-  #   steps:
       - name: Run LndRestWallet
         env:
           PYTHONUNBUFFERED: 1
@@ -50,10 +50,6 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-  # LndWallet:
-  #   runs-on: ubuntu-latest
-  #   needs: [regtest]
-  #   steps:
       - name: Run LndWallet tests
         env:
           PYTHONUNBUFFERED: 1
@@ -68,10 +64,6 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-  # CoreLightningWallet:
-  #   runs-on: ubuntu-latest
-  #   needs: [regtest]
-  #   steps:
       - name: Run CoreLightningWallet tests
         env:
           PYTHONUNBUFFERED: 1
@@ -83,10 +75,6 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-  # LNbitsWallet:
-  #   runs-on: ubuntu-latest
-  #   needs: [regtest]
-  #   steps:
       - name: Run LNbitsWallet tests
         env:
           PYTHONUNBUFFERED: 1
@@ -99,10 +87,6 @@ jobs:
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
 
-#   EclairWallet:
-#     runs-on: ubuntu-latest
-#     needs: ["regtest"]
-#     steps:
       - name: Run EclairWallet tests
         env:
           PYTHONUNBUFFERED: 1
@@ -114,12 +98,3 @@ jobs:
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
-
-  # coverage:
-  #   runs-on: ubuntu-latest
-  #   needs: ["CoreLightningWallet", "LndWallet", "LndRestWallet", "EclairWallet"]
-  #   steps:
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -3,7 +3,8 @@ name: regtest
 on: [push, pull_request]
 
 jobs:
-  LndRestWallet:
+
+  regest:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,10 +29,14 @@ jobs:
           chmod +x ./tests
           ./tests
           sudo chmod -R a+rwx .
-      - name: Install dependencies
+      - name: Install python dependencies
         run: |
           poetry install
-      - name: Run tests
+
+  LndRestWallet:
+    needs: [regtest]
+    steps:
+      - name: Run LndRestWallet
         env:
           PYTHONUNBUFFERED: 1
           PORT: 5123
@@ -43,39 +48,11 @@ jobs:
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
+
   LndWallet:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-        poetry-version: ["1.3.1"]
+    needs: [regtest]
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Poetry ${{ matrix.poetry-version }}
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry"
-      - name: Setup Regtest
-        run: |
-          docker build -t lnbitsdocker/lnbits-legend .
-          git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
-          cd docker
-          chmod +x ./tests
-          ./tests
-          sudo chmod -R a+rwx .
-      - name: Install dependencies
-        run: |
-          poetry install
-      - name: Run tests
+      - name: Run LndWallet tests
         env:
           PYTHONUNBUFFERED: 1
           PORT: 5123
@@ -88,39 +65,11 @@ jobs:
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
+
   CoreLightningWallet:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-        poetry-version: ["1.3.1"]
+    needs: [regtest]
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Poetry ${{ matrix.poetry-version }}
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry"
-      - name: Setup Regtest
-        run: |
-          docker build -t lnbitsdocker/lnbits-legend .
-          git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
-          cd docker
-          chmod +x ./tests
-          ./tests
-          sudo chmod -R a+rwx .
-      - name: Install dependencies
-        run: |
-          poetry install
-      - name: Run tests
+      - name: Run CoreLightningWallet tests
         env:
           PYTHONUNBUFFERED: 1
           PORT: 5123
@@ -130,40 +79,11 @@ jobs:
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
+
   LNbitsWallet:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-        poetry-version: ["1.3.1"]
+    needs: [regtest]
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Poetry ${{ matrix.poetry-version }}
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry"
-      - name: Setup Regtest
-        run: |
-          docker build -t lnbitsdocker/lnbits-legend .
-          git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
-          cd docker
-          chmod +x ./tests
-          ./tests
-          sudo chmod -R a+rwx .
-          docker exec lnbits-legend-lnbits-1 /bin/bash -c "poetry run python tools/create_fake_admin.py"
-      - name: Install dependencies
-        run: |
-          poetry install
-      - name: Run tests
+      - name: Run LNbitsWallet tests
         env:
           PYTHONUNBUFFERED: 1
           PORT: 5123
@@ -174,39 +94,11 @@ jobs:
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
+
   EclairWallet:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-        poetry-version: ["1.3.1"]
+    needs: [regtest]
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Poetry ${{ matrix.poetry-version }}
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "poetry"
-      - name: Setup Regtest
-        run: |
-          docker build -t lnbitsdocker/lnbits-legend .
-          git clone https://github.com/lnbits/legend-regtest-enviroment.git docker
-          cd docker
-          chmod +x ./tests
-          ./tests
-          sudo chmod -R a+rwx .
-      - name: Install dependencies
-        run: |
-          poetry install
-      - name: Run tests
+      - name: Run EclairWallet tests
         env:
           PYTHONUNBUFFERED: 1
           PORT: 5123
@@ -217,6 +109,10 @@ jobs:
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
+
+  coverage:
+    needs: ["CoreLightningWallet", "LndWallet", "LndRestWallet", "EclairWallet"]
+    steps:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -34,6 +34,7 @@ jobs:
           poetry install
 
   LndRestWallet:
+    runs-on: ubuntu-latest
     needs: [regtest]
     steps:
       - name: Run LndRestWallet
@@ -50,6 +51,7 @@ jobs:
           make test-real-wallet
 
   LndWallet:
+    runs-on: ubuntu-latest
     needs: [regtest]
     steps:
       - name: Run LndWallet tests
@@ -67,6 +69,7 @@ jobs:
           make test-real-wallet
 
   CoreLightningWallet:
+    runs-on: ubuntu-latest
     needs: [regtest]
     steps:
       - name: Run CoreLightningWallet tests
@@ -81,6 +84,7 @@ jobs:
           make test-real-wallet
 
   LNbitsWallet:
+    runs-on: ubuntu-latest
     needs: [regtest]
     steps:
       - name: Run LNbitsWallet tests
@@ -96,7 +100,8 @@ jobs:
           make test-real-wallet
 
   EclairWallet:
-    needs: [regtest]
+    runs-on: ubuntu-latest
+    needs: ["regtest"]
     steps:
       - name: Run EclairWallet tests
         env:
@@ -111,6 +116,7 @@ jobs:
           make test-real-wallet
 
   coverage:
+    runs-on: ubuntu-latest
     needs: ["CoreLightningWallet", "LndWallet", "LndRestWallet", "EclairWallet"]
     steps:
       - name: Upload coverage to Codecov


### PR DESCRIPTION
run all the regtest sequentially instead of in parallel

pro:
* saves github action time
* fails faster
* cleaner workflow file
* less jobs that run

con:
* harder to see which wallet fails
* fails on the first issue