### PR TITLE
Revert "fix gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,6 @@ docker
 # Nix
 *result*
 
+# Ignore extensions (post installable extension PR)
+extensions/
 upgrades/


### PR DESCRIPTION
Reverts lnbits/lnbits#1429
`extensions` folder must be ignored for the installable extensions pr we merged to work. If people want to update their extension this should no longer be done through the core repo. 