### PR TITLE
Serve `nostr` relay info

### DIFF
--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -42,7 +42,7 @@ async def favicon():
 @core_html_routes.get("/", response_class=HTMLResponse)
 async def home(request: Request, lightning: str = ""):
 
-    if request.headers.get("accept") == "application/json+nostr":
+    if request.headers.get("accept") == "application/nostr+json":
         return JSONResponse(
             content=settings.lnbits_relay_information,
             headers={

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -41,6 +41,17 @@ async def favicon():
 
 @core_html_routes.get("/", response_class=HTMLResponse)
 async def home(request: Request, lightning: str = ""):
+
+    if request.headers.get("accept") == "application/json+nostr":
+        return JSONResponse(
+            content=settings.lnbits_relay_information,
+            headers={
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Headers": "*",
+                "Access-Control-Allow-Methods": "GET",
+            },
+        )
+
     return template_renderer().TemplateResponse(
         "core/index.html", {"request": request, "lnurl": lightning}
     )

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -61,6 +61,10 @@ class InstalledExtensionsSettings(LNbitsSettings):
     lnbits_upgraded_extensions: List[str] = Field(default=[])
 
 
+class NostrRelaySettings(LNbitsSettings):
+    lnbits_relay_information: dict = Field(default={})
+
+
 class ThemesSettings(LNbitsSettings):
     lnbits_site_title: str = Field(default="LNbits")
     lnbits_site_tagline: str = Field(default="free and open-source lightning wallet")
@@ -253,7 +257,7 @@ class SuperUserSettings(LNbitsSettings):
     )
 
 
-class TransientSettings(InstalledExtensionsSettings):
+class TransientSettings(InstalledExtensionsSettings, NostrRelaySettings):
     # Transient Settings:
     #  - are initialized, updated and used at runtime
     #  - are not read from a file or from the `setings` table


### PR DESCRIPTION
According to **NIP 11**: https://github.com/nostr-protocol/nips/blob/master/11.md

Some nostr clients do not use the URL `path` for relay info (only the domain name):

- If the relay WS is: 
  - `wss://lnbits.link/nostrrelay/client`
- Then the relay info should be served at 
  - `https://lnbits.link/nostrrelay/client`
- However, some clients only check `https://lnbits.link`

This PR serves generic relay info at `https://lnbits.link`