### PR TITLE
diagon alley suggestions.

### DIFF
--- a/lnbits/extensions/market/README.md
+++ b/lnbits/extensions/market/README.md
@@ -6,24 +6,23 @@
 
 In Diagon Alley, `merchant` and `customer` communicate via NOSTR relays, so loss of money, product information, and reputation become far less likely if attacked.
 
-A `merchant` and `customer` both have a NOSTR key-pair that are used to sign notes and subscribe to events. 
+A `merchant` and `customer` both have a NOSTR key-pair that are used to sign notes and subscribe to events.
 
 #### For further information about NOSTR, see https://github.com/nostr-protocol/nostr
 
-
 ## Terms
 
-* `merchant` - seller of products with NOSTR key-pair
-* `customer` - buyer of products with NOSTR key-pair
-* `product` - item for sale by the `merchant`
-* `stall` - list of products controlled by `merchant` (a `merchant` can have multiple stalls)
-* `marketplace` - clientside software for searching `stalls` and purchasing `products`
+- `merchant` - seller of products with NOSTR key-pair
+- `customer` - buyer of products with NOSTR key-pair
+- `product` - item for sale by the `merchant`
+- `stall` - list of products controlled by `merchant` (a `merchant` can have multiple stalls)
+- `marketplace` - clientside software for searching `stalls` and purchasing `products`
 
 ## Diagon Alley Clients
 
 ### Merchant admin
 
-Where the `merchant` creates, updates and deletes `stalls` and `products`, as well as where they manage sales, payments and communication with `customers`. 
+Where the `merchant` creates, updates and deletes `stalls` and `products`, as well as where they manage sales, payments and communication with `customers`.
 
 The `merchant` admin software can be purely clientside, but for `convenience` and uptime, implementations will likely have a server listening for NOSTR events.
 
@@ -31,150 +30,71 @@ The `merchant` admin software can be purely clientside, but for `convenience` an
 
 `Marketplace` software should be entirely clientside, either as a stand-alone app, or as a purely frontend webpage. A `customer` subscribes to different merchant NOSTR public keys, and those `merchants` `stalls` and `products` become listed and searchable. The marketplace client is like any other ecommerce site, with basket and checkout. `Marketplaces` may also wish to include a `customer` support area for direct message communication with `merchants`.
 
-## `Merchant` publishing/updating products (event)
+## `Stall` event (publishing/updating products)
 
-NIP-01 https://github.com/nostr-protocol/nips/blob/master/01.md uses the basic NOSTR event type.
+This uses kind `30017`, which relies on NIP-33 to make it so old data is replaced by the new data. The full contents of the event are published every time.
 
-The `merchant` event that publishes and updates product lists
-
-The below json goes in `content` of NIP-01.
-
-Data from newer events should replace data from older events.  
-
-`action` types (used to indicate changes):
-* `update` element has changed
-* `delete` element should be deleted
-* `suspend` element is suspended
-* `unsuspend` element is unsuspended
-
+Each `merchant` can have multiple `stalls`, so this event uses the `d` tag with an arbitrary string to represent the identifier of this stall.
 
 ```
 {
     "name": <String, name of merchant>,
     "description": <String, description of merchant>,
     "currency": <Str, currency used>,
-    "action": <String, optional action>,
     "shipping": [
         {
-            "id": <String, UUID derived from stall ID>,
+            "id": <String>,
             "zones": <String, CSV of countries/zones>,
             "price": <int, cost>,
         },
         {
-            "id": <String, UUID derived from stall ID>,
+            "id": <String>,
             "zones": <String, CSV of countries/zones>,
             "price": <int, cost>,
         },
         {
-            "id": <String, UUID derived from stall ID>,
+            "id": <String>,
             "zones": <String, CSV of countries/zones>,
             "price": <int, cost>,
         }
     ],
-    "stalls": [
+    "products": [
         {
-            "id": <UUID derived from merchant public-key>,
-            "name": <String, stall name>,
-            "description": <String, stall description>,
+            "id": <String>,
+            "name": <String, name of product>,
+            "description": <String, product description>,
             "categories": <String, CSV of voluntary categories>,
-            "shipping": <String, CSV of shipping ids>,
-            "action": <String, optional action>,
-            "products": [
+            "amount": <Int, number of units>,
+            "price": <Int, cost per unit>,
+            "images": [
                 {
-                    "id": <String, UUID derived from stall ID>,
-                    "name": <String, name of product>,
-                    "description": <String, product description>,
-                    "categories": <String, CSV of voluntary categories>,
-                    "amount": <Int, number of units>,
-                    "price": <Int, cost per unit>,
-                    "images": [
-                        {
-                            "id": <String, UUID derived from product ID>,
-                            "name": <String, image name>,
-                            "link": <String, URL or BASE64>
-                        }
-                    ],
-                    "action": <String, optional action>,
-                },
-                {
-                    "id": <String, UUID derived from stall ID>,
-                    "name": <String, name of product>,
-                    "description": <String, product description>,
-                    "categories": <String, CSV of voluntary categories>,
-                    "amount": <Int, number of units>,
-                    "price": <Int, cost per unit>,
-                    "images": [
-                        {
-                            "id": <String, UUID derived from product ID>,
-                            "name": <String, image name>,
-                            "link": <String, URL or BASE64>
-                        },
-                        {
-                            "id": <String, UUID derived from product ID>,
-                            "name": <String, image name>,
-                            "link": <String, URL or BASE64>
-                        }
-                    ],
-                    "action": <String, optional action>,
-                },
-            ]
+                    "label": <String, image name>,
+                    "link": <String, URL>
+                }
+            ],
         },
         {
-            "id": <UUID derived from merchant public_key>,
-            "name": <String, stall name>,
-            "description": <String, stall description>,
+            "id": <String>,
+            "name": <String, name of product>,
+            "description": <String, product description>,
             "categories": <String, CSV of voluntary categories>,
-            "shipping": <String, CSV of shipping ids>,
-            "action": <String, optional action>,
-            "products": [
+            "amount": <Int, number of units>,
+            "price": <Int, cost per unit>,
+            "images": [
                 {
-                    "id": <String, UUID derived from stall ID>,
-                    "name": <String, name of product>,
-                    "categories": <String, CSV of voluntary categories>,
-                    "amount": <Int, number of units>,
-                    "price": <Int, cost per unit>,
-                    "images": [
-                        {
-                            "id": <String, UUID derived from product ID>,
-                            "name": <String, image name>,
-                            "link": <String, URL or BASE64>
-                        }
-                    ],
-                    "action": <String, optional action>,
-                }
-            ]
-        }
-    ]
-}
-
-```
-
-As all elements are optional, an `update` `action` to a `product` `image`, may look as simple as:
-
-```
-{
-    "stalls": [
-        {
-            "id": <UUID derived from merchant public-key>,
-            "products": [
-                {
-                    "id": <String, UUID derived from stall ID>,
-                    "images": [
-                        {
-                            "id": <String, UUID derived from product ID>,
-                            "name": <String, image name>,
-                            "link": <String, URL or BASE64>
-                        }
-                    ],
-                    "action": <String, optional action>,
+                    "label": <String, image label>,
+                    "url": <String, URL>
                 },
-            ]
-        }
+                {
+                    "label": <String, image label>,
+                    "url": <String, URL>
+                }
+            ],
+        },
     ]
 }
 
 ```
-
 
 ## Checkout events
 
@@ -183,7 +103,6 @@ NIP-04 https://github.com/nostr-protocol/nips/blob/master/04.md, all checkout ev
 The below json goes in `content` of NIP-04.
 
 ### Step 1: `customer` order (event)
-
 
 ```
 {
@@ -213,7 +132,7 @@ The below json goes in `content` of NIP-04.
             "quantity": <String, stall name>,
             "message": <String, special request>
         }
-    
+    ]
 }
 
 ```
@@ -227,10 +146,11 @@ Sent back from the merchant for payment. Any payment option is valid that the me
 The below json goes in `content` of NIP-04.
 
 `payment_options`/`type` include:
-* `url` URL to a payment page, stripe, paypal, btcpayserver, etc
-* `btc` onchain bitcoin address
-* `ln` bitcoin lightning invoice
-* `lnurl` bitcoin lnurl-pay  
+
+- `url` URL to a payment page, stripe, paypal, btcpayserver, etc
+- `btc` onchain bitcoin address
+- `ln` bitcoin lightning invoice
+- `lnurl` bitcoin lnurl-pay
 
 ```
 {
@@ -249,6 +169,7 @@ The below json goes in `content` of NIP-04.
             "type": <String, option type>,
             "link": <String, url, btc address, ln invoice, etc>
         }
+    ]
 }
 
 ```
@@ -276,6 +197,3 @@ Customer support is handle over whatever communication method was specified. If 
 ## Additional
 
 Standard data models can be found here <a href="models.json">here</a>
-
-
-


### PR DESCRIPTION
Use replaceable events instead of "update" actions. "update" actions are not reliable on Nostr since there is no guarantee you'll ever get all. It's better to use NIP-33 and just publish the same thing over and over.

Also allow each user to have multiple stalls and make them independent, with a different (replaceable) event for each.

One good thing about having stalls be separate events is that one can attach, for example, a `g` (geohash) tag to them that says more-or-less where they are so that can be filtered naturally by relays (see NIP-12 suggestions) if someone wants to query stalls only near them.