### PR TITLE
Extension Upgrade - stop background work

### DIFF
--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -48,8 +48,9 @@ async def run_migration(db: Connection, migrations_module: Any, current_version:
 
 async def stop_extension_background_work(ext_id: str, user: str):
     """
-    Stop background workk for extension (like asyncio.Tasks, WebSockets, etc)
-    It tries first to call the endpoint using `http` and if ti fails it tries using `https`
+    Stop background work for extension (like asyncio.Tasks, WebSockets, etc)
+    Extensions SHOULD expoze a DELETE enpoint at the root level of their API.
+    This function tries first to call the endpoint using `http` and if if fails it tries using `https`.
     """
     async with httpx.AsyncClient() as client:
         try:

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -2,6 +2,7 @@ import importlib
 import re
 from typing import Any
 
+import httpx
 from loguru import logger
 
 from lnbits.db import Connection
@@ -42,3 +43,12 @@ async def run_migration(db: Connection, migrations_module: Any, current_version:
                 else:
                     async with core_db.connect() as conn:
                         await update_migration_version(conn, db_name, version)
+
+
+async def stop_extension_work(ext_id: str, user: str):
+    """Stop background workk for extension (like asyncio.Tasks, WebSockets, etc)"""
+    async with httpx.AsyncClient() as client:
+        try:
+            await client.delete(url=f"/{ext_id}/api/v1?usr={user}")
+        except Exception as ex:
+            logger.warning(ex)

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -48,8 +48,8 @@ async def run_migration(db: Connection, migrations_module: Any, current_version:
 
 async def stop_extension_background_work(ext_id: str, user: str):
     """
-    Stop background work for extension (like asyncio.Tasks, WebSockets, etc)
-    Extensions SHOULD expoze a DELETE enpoint at the root level of their API.
+    Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
+    Extensions SHOULD expose a DELETE enpoint at the root level of their API.
     This function tries first to call the endpoint using `http` and if if fails it tries using `https`.
     """
     async with httpx.AsyncClient() as client:

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -29,7 +29,10 @@ from sse_starlette.sse import EventSourceResponse
 from starlette.responses import RedirectResponse, StreamingResponse
 
 from lnbits import bolt11, lnurl
-from lnbits.core.helpers import migrate_extension_database, stop_extension_work
+from lnbits.core.helpers import (
+    migrate_extension_database,
+    stop_extension_background_work,
+)
 from lnbits.core.models import Payment, User, Wallet
 from lnbits.decorators import (
     WalletTypeInfo,
@@ -729,7 +732,6 @@ async def websocket_update_get(item_id: str, data: str):
 async def api_install_extension(
     data: CreateExtension, user: User = Depends(check_admin)
 ):
-
     release = await InstallableExtension.get_extension_release(
         data.ext_id, data.source_repo, data.archive
     )
@@ -752,11 +754,13 @@ async def api_install_extension(
         await migrate_extension_database(extension, db_version)
 
         await add_installed_extension(ext_info)
+
+        # call stop while the old routes are still active
+        await stop_extension_background_work(data.ext_id, user.id)
+
         if data.ext_id not in settings.lnbits_deactivated_extensions:
             settings.lnbits_deactivated_extensions += [data.ext_id]
 
-        # call stop while the old routes are still active
-        await stop_extension_work(data.ext_id, settings.super_user)
         # mount routes for the new version
         core_app_extra.register_new_ext_routes(extension)
 
@@ -801,7 +805,7 @@ async def api_uninstall_extension(ext_id: str, user: User = Depends(check_admin)
 
     try:
         # call stop while the old routes are still active
-        await stop_extension_work(ext_id, settings.super_user)
+        await stop_extension_background_work(ext_id, user.id)
 
         if ext_id not in settings.lnbits_deactivated_extensions:
             settings.lnbits_deactivated_extensions += [ext_id]

--- a/lnbits/extensions/lnurlp/__init__.py
+++ b/lnbits/extensions/lnurlp/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import List
 
 from fastapi import APIRouter
 from fastapi.staticfiles import StaticFiles
@@ -16,6 +17,7 @@ lnurlp_static_files = [
         "name": "lnurlp_static",
     }
 ]
+scheduled_tasks: List[asyncio.Task] = []
 
 lnurlp_ext: APIRouter = APIRouter(prefix="/lnurlp", tags=["lnurlp"])
 
@@ -32,4 +34,5 @@ from .views_api import *  # noqa: F401,F403
 
 def lnurlp_start():
     loop = asyncio.get_event_loop()
-    loop.create_task(catch_everything_and_restart(wait_for_paid_invoices))
+    task = loop.create_task(catch_everything_and_restart(wait_for_paid_invoices))
+    scheduled_tasks.append(task)

--- a/lnbits/extensions/lnurlp/models.py
+++ b/lnbits/extensions/lnurlp/models.py
@@ -61,9 +61,9 @@ class PayLink(BaseModel):
     def success_action(self, payment_hash: str) -> Optional[Dict]:
         if self.success_url:
             url: ParseResult = urlparse(self.success_url)
-            #qs = parse_qs(url.query)
-            #setattr(qs, "payment_hash", payment_hash)
-            #url = url._replace(query=urlencode(qs, doseq=True))
+            # qs = parse_qs(url.query)
+            # setattr(qs, "payment_hash", payment_hash)
+            # url = url._replace(query=urlencode(qs, doseq=True))
             return {
                 "tag": "url",
                 "description": self.success_text or "~",


### PR DESCRIPTION
**Summary**
- some extensions are performing background work (like `asyncio.Task` or `WebSockets`)
- when an extension is upgraded or uninstalled the background work has to stop
   -  no longer listen for invoices, closes `WebSockets`, etc

**Solution**
 - each extension SHOULD expose a clean-up endpoint IF it has background work to be stopped
 - by convention the clean-up `HTTP` method is `DELETE` and the endpoint is the root of the extension API
    - eg: `DELETE http://localhost:5000/lnurlp/api/v1`
    - MUST be restricted to admin users

> **Note** directly calling the clean-up logic from `python` is not possible


**Test**
 - add a log statement to `on_invoice_paid` (of `task.py`) for an extension
 - create 3 different releases, each with a different log statement (example [here](https://github.com/motorina0/lnbits-extensions/blob/main/extensions.json))
 - upgrade the extension
 - only the latest release should handle the invoice (and print its corresponding log statement)