### PR TITLE
fix: hide Admin UI if `LNBITS_ADMIN_UI` is `false`

### DIFF
--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -389,6 +389,9 @@ async def manifest(usr: str):
 
 @core_html_routes.get("/admin", response_class=HTMLResponse)
 async def index(request: Request, user: User = Depends(check_admin)):
+    if not settings.lnbits_admin_ui:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND)
+        
     WALLET = get_wallet_class()
     _, balance = await WALLET.status()
 

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -391,7 +391,7 @@ async def manifest(usr: str):
 async def index(request: Request, user: User = Depends(check_admin)):
     if not settings.lnbits_admin_ui:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND)
-        
+
     WALLET = get_wallet_class()
     _, balance = await WALLET.status()
 

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -107,6 +107,7 @@ def template_renderer(additional_folders: List = None) -> Jinja2Templates:
     t.env.globals["SITE_DESCRIPTION"] = settings.lnbits_site_description
     t.env.globals["LNBITS_THEME_OPTIONS"] = settings.lnbits_theme_options
     t.env.globals["LNBITS_VERSION"] = settings.lnbits_commit
+    t.env.globals["LNBITS_ADMIN_UI"] = settings.lnbits_admin_ui
     t.env.globals["EXTENSIONS"] = [
         e
         for e in get_valid_extensions()

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -185,7 +185,8 @@
         :elevated="$q.screen.lt.md"
       >
         <lnbits-wallet-list></lnbits-wallet-list>
-        <lnbits-admin-ui></lnbits-admin-ui>
+
+        <lnbits-admin-ui v-if="'{{LNBITS_ADMIN_UI}}' == 'True'"></lnbits-admin-ui>
         <lnbits-extension-list class="q-pb-xl"></lnbits-extension-list>
       </q-drawer>
       {% endblock %} {% block page_container %}

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -186,7 +186,9 @@
       >
         <lnbits-wallet-list></lnbits-wallet-list>
 
-        <lnbits-admin-ui v-if="'{{LNBITS_ADMIN_UI}}' == 'True'"></lnbits-admin-ui>
+        <lnbits-admin-ui
+          v-if="'{{LNBITS_ADMIN_UI}}' == 'True'"
+        ></lnbits-admin-ui>
         <lnbits-extension-list class="q-pb-xl"></lnbits-extension-list>
       </q-drawer>
       {% endblock %} {% block page_container %}


### PR DESCRIPTION
Hide the left hand-side Admin menu item if `LNBITS_ADMIN_UI` is set to `false`

![image](https://user-images.githubusercontent.com/2951406/220618707-ca31669b-0d08-4623-8354-6ea180ded429.png)
