### PR TITLE
fix: filter error on `Extensions` page

### DIFF
--- a/lnbits/core/static/js/extensions.js
+++ b/lnbits/core/static/js/extensions.js
@@ -3,7 +3,7 @@ new Vue({
   data: function () {
     return {
       searchTerm: '',
-      filteredExtensions: null,
+      filteredExtensions: [],
       maxStars: 5,
       user: null
     }


### PR DESCRIPTION
- init `filteredExtensions` with `[]`