### PR TITLE
introduce baseurl and remove force_https

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,6 @@ PORT=5000
 
 DEBUG=false
 
-# Baseurl for creating urls via the backend
-LNBITS_BASEURL="http://0.0.0.0/"
-
 # Allow users and admins by user IDs (comma separated list)
 LNBITS_ALLOWED_USERS=""
 LNBITS_ADMIN_USERS=""

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ PORT=5000
 
 DEBUG=false
 
+# Baseurl for creating urls via the backend
+LNBITS_BASEURL="http://0.0.0.0/"
+
 # Allow users and admins by user IDs (comma separated list)
 LNBITS_ALLOWED_USERS=""
 LNBITS_ADMIN_USERS=""
@@ -48,7 +51,6 @@ LNBITS_EXTENSIONS_DEFAULT_INSTALL="tpos"
 LNBITS_DATA_FOLDER="./data"
 # LNBITS_DATABASE_URL="postgres://user:password@host:port/databasename"
 
-LNBITS_FORCE_HTTPS=false
 LNBITS_SERVICE_FEE="0.0"
 # value in millisats
 LNBITS_RESERVE_FEE_MIN=2000

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -174,8 +174,8 @@ kill_timeout = 30
 [env]
   HOST="127.0.0.1"
   PORT=5000
-  LNBITS_FORCE_HTTPS=true
   FORWARDED_ALLOW_IPS="*"
+  LNBITS_BASEURL="https://mylnbits.lnbits.org/"
   LNBITS_DATA_FOLDER="/data"
 
   ${PUT_YOUR_LNBITS_ENV_VARS_HERE}

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -283,6 +283,7 @@ def register_startup(app: FastAPI):
 
 def log_server_info():
     logger.info("Starting LNbits")
+    logger.info(f"Baseurl: {settings.lnbits_baseurl}")
     logger.info(f"Host: {settings.host}")
     logger.info(f"Port: {settings.port}")
     logger.info(f"Debug: {settings.debug}")

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -437,7 +437,7 @@ async def check_admin_settings():
         for key, value in settings.dict(exclude_none=True).items():
             logger.debug(f"{key}: {value}")
 
-        admin_url = f"{'https' if settings.lnbits_force_https else 'http'}://{settings.host}:{settings.port}/wallet?usr={settings.super_user}"
+        admin_url = f"{settings.lnbits_baseurl}wallet?usr={settings.super_user}"
         logger.success(f"✔️ Access super user account at: {admin_url}")
 
         # callback for saas

--- a/lnbits/core/templates/admin/_tab_server.html
+++ b/lnbits/core/templates/admin/_tab_server.html
@@ -33,22 +33,7 @@
           <br />
         </div>
         <div class="col-12 col-md-6">
-          <p>Miscelaneous</p>
-          <q-item tag="label" v-ripple>
-            <q-item-section>
-              <q-item-label>Force HTTPS</q-item-label>
-              <q-item-label caption>Prefer secure URLs</q-item-label>
-            </q-item-section>
-            <q-item-section avatar>
-              <q-toggle
-                size="md"
-                v-model="formData.lnbits_force_https"
-                checked-icon="check"
-                color="green"
-                unchecked-icon="clear"
-              />
-            </q-item-section>
-          </q-item>
+          <p>Miscellaneous</p>
           <q-item tag="label" v-ripple>
             <q-item-section>
               <q-item-label>Hide API</q-item-label>

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -88,7 +88,7 @@ class ThemesSettings(LNbitsSettings):
 
 
 class OpsSettings(LNbitsSettings):
-    lnbits_force_https: bool = Field(default=False)
+    lnbits_baseurl: str = Field(default="http://0.0.0.0/")
     lnbits_reserve_fee_min: int = Field(default=2000)
     lnbits_reserve_fee_percent: float = Field(default=1.0)
     lnbits_service_fee: float = Field(default=0)

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -88,7 +88,7 @@ class ThemesSettings(LNbitsSettings):
 
 
 class OpsSettings(LNbitsSettings):
-    lnbits_baseurl: str = Field(default="http://0.0.0.0/")
+    lnbits_baseurl: str = Field(default="http://127.0.0.1/")
     lnbits_reserve_fee_min: int = Field(default=2000)
     lnbits_reserve_fee_percent: float = Field(default=1.0)
     lnbits_service_fee: float = Field(default=0)


### PR DESCRIPTION
IDEA: introduce BASEURL variable like other webapplications also have

this PR introduces the settings variable `LNBITS_BASEURL`

this makes generating URLs on the serverside much easier for developers.
you do not need to rely on a request object anymore to create an absolute URL,
for example for all the lnurl stuff, server startup log/superuser urls, etc...

the obvious downside is that users need to introduce a new variable if they are behind a proxy.

but i think it is tradeoff worth taking, because this will reduce the overall complexity of the code
and also simplyfies generating proper url for other developers aswell.

also gets rid of `LNBITS_FORCE_HTTPS` variable, because it is not used anymore.
