### PR TITLE
FIX: default baseurl should include port

### DIFF
--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -88,7 +88,7 @@ class ThemesSettings(LNbitsSettings):
 
 
 class OpsSettings(LNbitsSettings):
-    lnbits_baseurl: str = Field(default="http://127.0.0.1/")
+    lnbits_baseurl: str = Field(default="http://127.0.0.1:5000/")
     lnbits_reserve_fee_min: int = Field(default=2000)
     lnbits_reserve_fee_percent: float = Field(default=1.0)
     lnbits_service_fee: float = Field(default=0)


### PR DESCRIPTION
forgot the add port to baseurl default
