### PR TITLE
fix: assume no pre-installed extensions

### DIFF
--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -235,7 +235,6 @@ class InstallableExtension(BaseModel):
             return False
         config_file = os.path.join(self.ext_dir, "config.json")
         return Path(config_file).is_file()
-        
 
     def download_archive(self):
         logger.info(f"Downloading extension {self.name}.")

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -234,11 +234,8 @@ class InstallableExtension(BaseModel):
         if not Path(self.ext_dir).is_dir():
             return False
         config_file = os.path.join(self.ext_dir, "config.json")
-        if not Path(config_file).is_file():
-            return False
-        with open(config_file, "r") as json_file:
-            config_json = json.load(json_file)
-            return config_json.get("is_installed") is True
+        return Path(config_file).is_file()
+        
 
     def download_archive(self):
         logger.info(f"Downloading extension {self.name}.")
@@ -282,10 +279,6 @@ class InstallableExtension(BaseModel):
             os.path.join(self.ext_upgrade_dir, self.id, "config.json"), "r+"
         ) as json_file:
             config_json = json.load(json_file)
-            config_json["is_installed"] = True
-            json_file.seek(0)
-            json.dump(config_json, json_file)
-            json_file.truncate()
 
             self.name = config_json.get("name")
             self.short_description = config_json.get("short_description")


### PR DESCRIPTION
### Summary
**Initial Requirements**:
- we have assumed that `LNbits` will be shipped with a small set of basic extensions (lnurlp, lnurlw, ...)
- but the user can update these extensions (eg `lnurlp`)
- so (in case of container re-create) what you have in `/extensions/lnurlp` it is not necessarily the version you have installed (might be the old pre-packaged one)
- if the extension is found in `installed_extensions` and the releases is different from what you have, then it will re-install it

**New Requirements**
 - no extension will be pre-packaged
 - if there is an `extensions/{ext_id}/config.json` file then assume the extension is already installed