### PR TITLE
FEAT: add funding source fallback and VoidWallet warning for frontend

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -105,20 +105,42 @@ async def check_funding_source() -> None:
     signal.signal(signal.SIGINT, signal_handler)
 
     WALLET = get_wallet_class()
+
+    # fallback to void after 30 seconds of failures
+    sleep_time = 5
+    timeout = int(30 / sleep_time)
+
+    balance = 0
+    retry_counter = 0
+
     while True:
         try:
             error_message, balance = await WALLET.status()
             if not error_message:
+                retry_counter = 0
                 break
+
             logger.error(
                 f"The backend for {WALLET.__class__.__name__} isn't working properly: '{error_message}'",
                 RuntimeWarning,
             )
         except:
             pass
-        logger.info("Retrying connection to backend in 5 seconds...")
-        await asyncio.sleep(5)
+
+        if retry_counter == timeout:
+            logger.warning(
+                f"Fallback to VoidWallet, because the backend for {WALLET.__class__.__name__} isn't working properly"
+            )
+            set_wallet_class("VoidWallet")
+            WALLET = get_wallet_class()
+            break
+        else:
+            logger.warning(f"Retrying connection to backend in {sleep_time} seconds...")
+            retry_counter += 1
+            await asyncio.sleep(sleep_time)
+
     signal.signal(signal.SIGINT, original_sigint_handler)
+
     logger.info(
         f"✔️ Backend {WALLET.__class__.__name__} connected and with a balance of {balance} msat."
     )

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -127,7 +127,7 @@ async def check_funding_source() -> None:
         except:
             pass
 
-        if retry_counter == timeout:
+        if settings.lnbits_admin_ui and retry_counter == timeout:
             logger.warning(
                 f"Fallback to VoidWallet, because the backend for {WALLET.__class__.__name__} isn't working properly"
             )

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -100,6 +100,7 @@ def template_renderer(additional_folders: List = None) -> Jinja2Templates:
         t.env.globals["AD_SPACE"] = settings.lnbits_ad_space.split(",")
         t.env.globals["AD_SPACE_TITLE"] = settings.lnbits_ad_space_title
 
+    t.env.globals["VOIDWALLET"] = settings.lnbits_backend_wallet_class == "VoidWallet"
     t.env.globals["HIDE_API"] = settings.lnbits_hide_api
     t.env.globals["SITE_TITLE"] = settings.lnbits_site_title
     t.env.globals["LNBITS_DENOMINATION"] = settings.lnbits_denomination

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -317,8 +317,9 @@ def set_cli_settings(**kwargs):
 
 
 # set wallet class after settings are loaded
-def set_wallet_class():
-    wallet_class = getattr(wallets_module, settings.lnbits_backend_wallet_class)
+def set_wallet_class(class_name: Optional[str] = None):
+    backend_wallet_class = class_name or settings.lnbits_backend_wallet_class
+    wallet_class = getattr(wallets_module, backend_wallet_class)
     global WALLET
     WALLET = wallet_class()
 

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -44,8 +44,7 @@
               endblock %}
             </q-btn>
           </q-toolbar-title>
-          {% block beta %}
-          {% if VOIDWALLET %}
+          {% block beta %} {% if VOIDWALLET %}
           <q-badge color="red" text-color="black" class="q-mr-md">
             <span>VoidWallet is active! Payments disabled</span>
           </q-badge>

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -45,9 +45,11 @@
             </q-btn>
           </q-toolbar-title>
           {% block beta %}
+          {% if VOIDWALLET %}
           <q-badge color="red" text-color="black" class="q-mr-md">
             <span>VoidWallet is active! Payments disabled</span>
           </q-badge>
+          {%endif%}
           <q-badge color="yellow" text-color="black" class="q-mr-md">
             <span
               ><span v-show="$q.screen.gt.sm"

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -45,6 +45,9 @@
             </q-btn>
           </q-toolbar-title>
           {% block beta %}
+          <q-badge color="red" text-color="black" class="q-mr-md">
+            <span>VoidWallet is active! Payments disabled</span>
+          </q-badge>
           <q-badge color="yellow" text-color="black" class="q-mr-md">
             <span
               ><span v-show="$q.screen.gt.sm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,14 @@ exclude = [
   "lnbits/wallets",
   "lnbits/core",
   "lnbits/*.py",
+  "lnbits/extensions",
 ]
 
 [tool.mypy]
 files = "lnbits"
 exclude = """(?x)(
     ^lnbits/wallets/lnd_grpc_files.
+    | ^lnbits/extensions.
 )"""
 
 [[tool.mypy.overrides]]
@@ -90,7 +92,6 @@ module = [
   "websocket.*",
   "websockets.*",
   "pyqrcode.*",
-  "cashu.*",
   "shortuuid.*",
   "grpc.*",
   "lnurl.*",


### PR DESCRIPTION
introduces a fallback to VoidWallet if the funding source is not responding after 30s on startup

- only falls back if adminui is enabled!
- makes the api come up even if the fundingsource is not responding
- should not interfere with wallets that got disconnected after startup
