### PR TITLE
remove lnbits_disabled_extensions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,6 @@ LNBITS_DEFAULT_WALLET_NAME="LNbits wallet"
 # Hides wallet api, extensions can choose to honor
 LNBITS_HIDE_API=false
 
-# Disable extensions for all users, use "all" to disable all extensions
-LNBITS_DISABLED_EXTENSIONS="amilk"
 # LNBITS_EXTENSIONS_MANIFESTS="https://raw.githubusercontent.com/lnbits/lnbits-extensions/main/extensions.json,https://raw.githubusercontent.com/lnbits/lnbits-extensions/main/extensions-trial.json"
 # GitHub has rate-limits for its APIs. The limit can be increased specifying a GITHUB_TOKEN
 # LNBITS_EXT_GITHUB_TOKEN=github_pat_xxxxxxxxxxxxxxxxxx

--- a/lnbits/core/templates/admin/_tab_server.html
+++ b/lnbits/core/templates/admin/_tab_server.html
@@ -67,18 +67,6 @@
           ></q-select>
           <br />
         </div>
-        <div class="col-12 col-md-6">
-          <p>Disabled Extensions</p>
-          <q-select
-            filled
-            v-model="formData.lnbits_disabled_extensions"
-            :options="g.extensions.map(e => e.name)"
-            multiple
-            hint="Disable extensions *amilk disabled by default as resource heavy"
-            label="Disable extensions"
-          ></q-select>
-          <br />
-        </div>
       </div>
 
       <div>

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -54,8 +54,6 @@ class Extension(NamedTuple):
 
 class ExtensionManager:
     def __init__(self):
-        self._disabled: List[str] = settings.lnbits_disabled_extensions
-        self._admin_only: List[str] = settings.lnbits_admin_extensions
         p = Path(settings.lnbits_path, "extensions")
         os.makedirs(p, exist_ok=True)
         self._extension_folders: List[Path] = [f for f in p.iterdir() if f.is_dir()]
@@ -64,23 +62,18 @@ class ExtensionManager:
     def extensions(self) -> List[Extension]:
         output: List[Extension] = []
 
-        if "all" in self._disabled:
-            return output
-
-        for extension in [
-            ext for ext in self._extension_folders if ext not in self._disabled
-        ]:
+        for extension_folder in self._extension_folders:
+            extension_code = extension_folder.parts[-1]
             try:
-                with open(extension / "config.json") as json_file:
+                with open(extension_folder / "config.json") as json_file:
                     config = json.load(json_file)
                 is_valid = True
-                is_admin_only = True if extension in self._admin_only else False
+                is_admin_only = extension_code in settings.lnbits_admin_extensions
             except Exception:
                 config = {}
                 is_valid = False
                 is_admin_only = False
 
-            *_, extension_code = extension.parts
             output.append(
                 Extension(
                     extension_code,

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -43,7 +43,6 @@ class UsersSettings(LNbitsSettings):
 
 class ExtensionsSettings(LNbitsSettings):
     lnbits_admin_extensions: List[str] = Field(default=[])
-    lnbits_disabled_extensions: List[str] = Field(default=[])
     lnbits_extensions_manifests: List[str] = Field(
         default=[
             "https://raw.githubusercontent.com/lnbits/lnbits-extensions/main/extensions.json"
@@ -212,7 +211,6 @@ class EditableSettings(
         "lnbits_allowed_users",
         "lnbits_theme_options",
         "lnbits_admin_extensions",
-        "lnbits_disabled_extensions",
         pre=True,
     )
     def validate_editable_settings(cls, val):


### PR DESCRIPTION
closes https://github.com/lnbits/lnbits/issues/1547 and corrects behaviour of `is_admin_only` (was previously checking with the folder path and not the extension code)