### PR TITLE
refactor extension_manager to use `pathlib.Path` instead of `os.path.join`

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -202,7 +202,7 @@ def check_installed_extension(ext: InstallableExtension) -> bool:
         os.path.join(settings.lnbits_data_folder, "extensions", "*.zip")
     )
 
-    if ext.zip_path not in zip_files:
+    if f"./{str(ext.zip_path)}" not in zip_files:
         ext.download_archive()
     ext.extract_archive()
 

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -201,18 +201,18 @@ class InstallableExtension(BaseModel):
         return "not-installed"
 
     @property
-    def zip_path(self) -> str:
-        extensions_data_dir = os.path.join(settings.lnbits_data_folder, "extensions")
+    def zip_path(self) -> Path:
+        extensions_data_dir = Path(settings.lnbits_data_folder, "extensions")
         os.makedirs(extensions_data_dir, exist_ok=True)
-        return os.path.join(extensions_data_dir, f"{self.id}.zip")
+        return Path(extensions_data_dir, f"{self.id}.zip")
 
     @property
-    def ext_dir(self) -> str:
-        return os.path.join("lnbits", "extensions", self.id)
+    def ext_dir(self) -> Path:
+        return Path(settings.lnbits_path, "extensions", self.id)
 
     @property
-    def ext_upgrade_dir(self) -> str:
-        return os.path.join("lnbits", "upgrades", f"{self.id}-{self.hash}")
+    def ext_upgrade_dir(self) -> Path:
+        return Path("lnbits", "upgrades", f"{self.id}-{self.hash}")
 
     @property
     def module_name(self) -> str:
@@ -224,15 +224,19 @@ class InstallableExtension(BaseModel):
 
     @property
     def has_installed_version(self) -> bool:
-        if not Path(self.ext_dir).is_dir():
+        if not self.ext_dir.is_dir():
             return False
-        config_file = os.path.join(self.ext_dir, "config.json")
-        return Path(config_file).is_file()
+        config_file = Path(self.ext_dir, "config.json")
+        if not config_file.is_file():
+            return False
+        with open(config_file, "r") as json_file:
+            config_json = json.load(json_file)
+            return config_json.get("is_installed") is True
 
     def download_archive(self):
         logger.info(f"Downloading extension {self.name}.")
         ext_zip_file = self.zip_path
-        if os.path.isfile(ext_zip_file):
+        if ext_zip_file.isfile():
             os.remove(ext_zip_file)
         try:
             download_url(self.installed_release.archive, ext_zip_file)
@@ -246,7 +250,7 @@ class InstallableExtension(BaseModel):
         archive_hash = file_hash(ext_zip_file)
         if self.installed_release.hash and self.installed_release.hash != archive_hash:
             # remove downloaded archive
-            if os.path.isfile(ext_zip_file):
+            if ext_zip_file.isfile():
                 os.remove(ext_zip_file)
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND,
@@ -255,20 +259,20 @@ class InstallableExtension(BaseModel):
 
     def extract_archive(self):
         logger.info(f"Extracting extension {self.name}.")
-        os.makedirs(os.path.join("lnbits", "upgrades"), exist_ok=True)
+        os.makedirs(Path("lnbits", "upgrades"), exist_ok=True)
         shutil.rmtree(self.ext_upgrade_dir, True)
         with zipfile.ZipFile(self.zip_path, "r") as zip_ref:
             zip_ref.extractall(self.ext_upgrade_dir)
         generated_dir_name = os.listdir(self.ext_upgrade_dir)[0]
         os.rename(
-            os.path.join(self.ext_upgrade_dir, generated_dir_name),
-            os.path.join(self.ext_upgrade_dir, self.id),
+            Path(self.ext_upgrade_dir, generated_dir_name),
+            Path(self.ext_upgrade_dir, self.id),
         )
 
         # Pre-packed extensions can be upgraded
         # Mark the extension as installed so we know it is not the pre-packed version
         with open(
-            os.path.join(self.ext_upgrade_dir, self.id, "config.json"), "r+"
+            Path(self.ext_upgrade_dir, self.id, "config.json"), "r+"
         ) as json_file:
             config_json = json.load(json_file)
 
@@ -286,8 +290,8 @@ class InstallableExtension(BaseModel):
 
         shutil.rmtree(self.ext_dir, True)
         shutil.copytree(
-            os.path.join(self.ext_upgrade_dir, self.id),
-            os.path.join("lnbits", "extensions", self.id),
+            Path(self.ext_upgrade_dir, self.id),
+            Path(settings.lnbits_path, "extensions", self.id),
         )
         logger.success(f"Extension {self.name} installed.")
 
@@ -306,7 +310,7 @@ class InstallableExtension(BaseModel):
 
     def clean_extension_files(self):
         # remove downloaded archive
-        if os.path.isfile(self.zip_path):
+        if self.zip_path.isfile():
             os.remove(self.zip_path)
 
         # remove module from extensions

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -226,17 +226,12 @@ class InstallableExtension(BaseModel):
     def has_installed_version(self) -> bool:
         if not self.ext_dir.is_dir():
             return False
-        config_file = Path(self.ext_dir, "config.json")
-        if not config_file.is_file():
-            return False
-        with open(config_file, "r") as json_file:
-            config_json = json.load(json_file)
-            return config_json.get("is_installed") is True
+        return Path(self.ext_dir, "config.json").is_file()
 
     def download_archive(self):
         logger.info(f"Downloading extension {self.name}.")
         ext_zip_file = self.zip_path
-        if ext_zip_file.isfile():
+        if ext_zip_file.is_file():
             os.remove(ext_zip_file)
         try:
             download_url(self.installed_release.archive, ext_zip_file)
@@ -250,7 +245,7 @@ class InstallableExtension(BaseModel):
         archive_hash = file_hash(ext_zip_file)
         if self.installed_release.hash and self.installed_release.hash != archive_hash:
             # remove downloaded archive
-            if ext_zip_file.isfile():
+            if ext_zip_file.is_file():
                 os.remove(ext_zip_file)
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND,
@@ -310,7 +305,7 @@ class InstallableExtension(BaseModel):
 
     def clean_extension_files(self):
         # remove downloaded archive
-        if self.zip_path.isfile():
+        if self.zip_path.is_file():
             os.remove(self.zip_path)
 
         # remove module from extensions


### PR DESCRIPTION
While digging around issue https://github.com/lnbits/lnbits/issues/1579 I found out that the extension manager mixes usage of `os.path.join` and `pathlib.Path`

This PR tries to use only the latter.

Draft PR, since this is untested yet.