### PR TITLE
simplify exclude syntax for mypy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,10 +77,10 @@ exclude = [
 
 [tool.mypy]
 files = "lnbits"
-exclude = """(?x)(
-    ^lnbits/wallets/lnd_grpc_files.
-    | ^lnbits/extensions.
-)"""
+exclude = [
+  "^lnbits/wallets/lnd_grpc_files",
+  "^lnbits/extensions",
+]
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
we can use the toml syntax and don't have to resort to crazy cfg syntax