### PR TITLE
Draft: Fix connection to cliche invoices stream

### DIFF
--- a/lnbits/wallets/cliche.py
+++ b/lnbits/wallets/cliche.py
@@ -5,6 +5,7 @@ from typing import AsyncGenerator, Optional
 
 from loguru import logger
 from websocket import create_connection
+from websockets import connect
 
 from lnbits.settings import settings
 
@@ -151,7 +152,7 @@ class ClicheWallet(Wallet):
     async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:
         while True:
             try:
-                ws = await create_connection(self.endpoint)
+                ws = await connect(self.endpoint)
                 while True:
                     r = await ws.recv()
                     data = json.loads(r)


### PR DESCRIPTION
Currently cliché's invoice stream is using `websocket` module, which is synchronous, and can't be use with `await`.

`2023-03-23 17:25:46.31 | ERROR | lnbits.wallets.cliche:paid_invoices_stream:165 | lost connection to cliche's invoices stream: 'object WebSocket can't be used in 'await' expression', retrying in 5 seconds
`
raised by `ws = await create_connection(self.endpoint)`

I suggest this fix using `websockets` module, which provides async coroutine, thus, it's possible to wait (`await`) for new messages from the cliche's websocket connection passively, without impact.