### PR TITLE
BUG: proper exception for paid interal invoices

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -590,18 +590,18 @@ async def delete_wallet_payment(
 
 async def check_internal(
     payment_hash: str, conn: Optional[Connection] = None
-) -> Optional[str]:
+) -> Optional[tuple[str, bool]]:
     row = await (conn or db).fetchone(
         """
-        SELECT checking_id FROM apipayments
-        WHERE hash = ? AND pending AND amount > 0
+        SELECT checking_id, pending FROM apipayments
+        WHERE hash = ? AND amount > 0
         """,
         (payment_hash,),
     )
     if not row:
         return None
     else:
-        return row["checking_id"]
+        return row["checking_id"], row["pending"]
 
 
 # balance_check


### PR DESCRIPTION
add better exception when internal invoice is paid twice.

debugging this issue https://github.com/lnbits/lnbits/issues/1425

i found that also the exception for internal payment was wrong:
before trying to pay twice:

`HTTPException 520: Payment failed: Only internal invoices can be used!`

now if you try to pay twice:
`HTTPException 520: Internal invoice already paid.`
