### PR TITLE
bugfix: 500 error if same wallet tries to pay an external invoice twice

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -169,12 +169,16 @@ async def pay_invoice(
             logger.debug(f"creating temporary payment with id {temp_id}")
             # create a temporary payment here so we can check if
             # the balance is enough in the next step
-            await create_payment(
-                checking_id=temp_id,
-                fee=-fee_reserve_msat,
-                conn=conn,
-                **payment_kwargs,
-            )
+            try:
+                await create_payment(
+                    checking_id=temp_id,
+                    fee=-fee_reserve_msat,
+                    conn=conn,
+                    **payment_kwargs,
+                )
+            except:
+                # happens if the same wallet tries to pay an invoice twice
+                raise PaymentFailure(f"Can not create payment.")
 
         # do the balance check
         wallet = await get_wallet(wallet_id, conn=conn)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -178,7 +178,7 @@ async def pay_invoice(
                 )
             except:
                 # happens if the same wallet tries to pay an invoice twice
-                raise PaymentFailure(f"Can not create payment.")
+                raise PaymentFailure("Can not create payment.")
 
         # do the balance check
         wallet = await get_wallet(wallet_id, conn=conn)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -176,9 +176,10 @@ async def pay_invoice(
                     conn=conn,
                     **payment_kwargs,
                 )
-            except:
+            except Exception as e:
+                logger.error(f"could not create temporary payment: {e}")
                 # happens if the same wallet tries to pay an invoice twice
-                raise PaymentFailure("Can not create payment.")
+                raise PaymentFailure("Could not make payment.")
 
         # do the balance check
         wallet = await get_wallet(wallet_id, conn=conn)


### PR DESCRIPTION
bugfix

related to: https://github.com/lnbits/lnbits/issues/1425

message if a different wallet tries to pay an already paid invoice.
![screenshot-1680038635](https://user-images.githubusercontent.com/1743657/228370593-9fa69714-9c03-4b26-9fcb-0611967ed867.jpg)

message if same wallet tries to pay same invoice:
![screenshot-1680038565](https://user-images.githubusercontent.com/1743657/228370659-1537df82-5858-4989-bc65-27e7f20e3bff.jpg)

before: 
![screenshot-1680037635](https://user-images.githubusercontent.com/1743657/228370719-206be6a2-5bac-45cc-854d-6dee00dd6205.jpg)


