### PR TITLE
Fix admin ext access

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -62,7 +62,9 @@ async def get_user(user_id: str, conn: Optional[Connection] = None) -> Optional[
     return User(
         id=user["id"],
         email=user["email"],
-        extensions=[e[0] for e in extensions],
+        extensions=[
+            e[0] for e in extensions if User.is_extension_for_user(e[0], user["id"])
+        ],
         wallets=[Wallet(**w) for w in wallets],
         admin=user["id"] == settings.super_user
         or user["id"] in settings.lnbits_admin_users,

--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from lnbits.db import Connection
 from lnbits.helpers import url_for
-from lnbits.settings import get_wallet_class
+from lnbits.settings import get_wallet_class, settings
 from lnbits.wallets.base import PaymentStatus
 
 
@@ -74,6 +74,16 @@ class User(BaseModel):
     def get_wallet(self, wallet_id: str) -> Optional["Wallet"]:
         w = [wallet for wallet in self.wallets if wallet.id == wallet_id]
         return w[0] if w else None
+
+    @classmethod
+    def is_extension_for_user(cls, ext: str, user: str) -> bool:
+        if ext not in settings.lnbits_admin_extensions:
+            return True
+        if user == settings.super_user:
+            return True
+        if user in settings.lnbits_admin_users:
+            return True
+        return False
 
 
 class Payment(BaseModel):

--- a/lnbits/core/templates/admin/_tab_server.html
+++ b/lnbits/core/templates/admin/_tab_server.html
@@ -63,7 +63,7 @@
             multiple
             hint="Extensions only user with admin privileges can use"
             label="Admin extensions"
-            :options="g.extensions.map(e => e.name)"
+            :options="g.extensions.map(e => e.code)"
           ></q-select>
           <br />
         </div>

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -67,6 +67,7 @@ class InstalledExtensionMiddleware:
         if "query_string" not in scope:
             return True
 
+        # parse the URL query string into a `dict`
         q = parse_qs(scope["query_string"].decode("UTF-8"))
         user = q.get("usr", [""])[0]
         if not user:
@@ -80,6 +81,11 @@ class InstalledExtensionMiddleware:
     def _response_by_accepted_type(
         self, headers: List[Any], msg: str, status_code: HTTPStatus
     ) -> Union[HTMLResponse, JSONResponse]:
+        """
+        Build an HTTP response containing the `msg` as HTTP body and the `status_code` as HTTP code.
+        If the `accept` HTTP header is present int the request and contains the value of `text/html`
+        then return an `HTMLResponse`, otherwise return an `JSONResponse`.
+        """
         accept_header: str = next(
             (
                 h[1].decode("UTF-8")

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -68,7 +68,7 @@ class InstalledExtensionMiddleware:
             return True
 
         q = parse_qs(scope["query_string"].decode("UTF-8"))
-        user = q.get("usr", [None])[0]
+        user = q.get("usr", [""])[0]
         if not user:
             return True
 

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import List, Tuple
+from typing import Any, List, Tuple, Union
 from urllib.parse import parse_qs
 
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -29,23 +29,19 @@ class InstalledExtensionMiddleware:
             _, path_name = path_elements
             path_type = None
 
+        headers = scope.get("headers", [])
+
         # block path for all users if the extension is disabled
         if path_name in settings.lnbits_deactivated_extensions:
-            response = JSONResponse(
-                status_code=HTTPStatus.NOT_FOUND,
-                content={"detail": f"Extension '{path_name}' disabled"},
+            response = self._response_by_accepted_type(
+                headers, f"Extension '{path_name}' disabled", HTTPStatus.NOT_FOUND
             )
             await response(scope, receive, send)
             return
 
         if not self._user_allowed_to_extension(path_name, scope):
-            response = HTMLResponse(
-                status_code=HTTPStatus.FORBIDDEN,
-                content=template_renderer()
-                .TemplateResponse(
-                    "error.html", {"request": {}, "err": "User not authorized."}
-                )
-                .body,
+            response = self._response_by_accepted_type(
+                headers, "User not authorized.", HTTPStatus.FORBIDDEN
             )
             await response(scope, receive, send)
             return
@@ -80,6 +76,31 @@ class InstalledExtensionMiddleware:
             return True
 
         return False
+
+    def _response_by_accepted_type(
+        self, headers: List[Any], msg: str, status_code: HTTPStatus
+    ) -> Union[HTMLResponse, JSONResponse]:
+        accept_header: str = next(
+            (
+                h[1].decode("UTF-8")
+                for h in headers
+                if len(h) >= 2 and h[0].decode("UTF-8") == "accept"
+            ),
+            "",
+        )
+
+        if "text/html" in [a for a in accept_header.split(",")]:
+            return HTMLResponse(
+                status_code=status_code,
+                content=template_renderer()
+                .TemplateResponse("error.html", {"request": {}, "err": msg})
+                .body,
+            )
+
+        return JSONResponse(
+            status_code=status_code,
+            content={"detail": msg},
+        )
 
 
 class ExtensionsRedirectMiddleware:


### PR DESCRIPTION
### Summary
- the admin has the option of making some extensions `Admin Only`:
  - ![image](https://user-images.githubusercontent.com/2951406/230139646-d3ba2642-1d19-4998-9c99-774dc04668f7.png)

- when a non-admin tries to access one of these extensions, it will receive an error message:
  - ![image](https://user-images.githubusercontent.com/2951406/230139847-9fe69754-0966-456a-b3d4-e8e4fadf7bc5.png)

- access is also denied on the API level (but in JSON format):
  - ![image](https://user-images.githubusercontent.com/2951406/230140266-fb97d173-5e90-4ade-8537-76cea6aac4b3.png)

- the admin extension should not be visible on the `Extensions` page or on the left hand-side extension list

- this rule does not apply for public pages (where no `usr` is present)
  - for example, `nostrrelay` can be an admin extension, but the public page for paying for access should be accessible to all
