### PR TITLE
Filter broke get_payments on extensions

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -352,6 +352,7 @@ async def get_payments(
     exclude_uncheckable: bool = False,
     filters: Optional[Filters[Payment]] = None,
     conn: Optional[Connection] = None,
+    **kwargs,
 ) -> List[Payment]:
     """
     Filters payments to be returned by complete | pending | outgoing | incoming.


### PR DESCRIPTION
added `**kwargs` to the function params