### PR TITLE
remove python38 from pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -35,14 +35,14 @@ files = [
 
 [[package]]
 name = "astroid"
-version = "2.15.2"
+version = "2.15.3"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.15.2-py3-none-any.whl", hash = "sha256:dea89d9f99f491c66ac9c04ebddf91e4acf8bd711722175fe6245c0725cc19bb"},
-    {file = "astroid-2.15.2.tar.gz", hash = "sha256:6e61b85c891ec53b07471aec5878f4ac6446a41e590ede0f2ce095f39f7d49dd"},
+    {file = "astroid-2.15.3-py3-none-any.whl", hash = "sha256:f11e74658da0f2a14a8d19776a8647900870a63de71db83713a8e77a6af52662"},
+    {file = "astroid-2.15.3.tar.gz", hash = "sha256:44224ad27c54d770233751315fa7f74c46fa3ee0fab7beef1065f99f09897efe"},
 ]
 
 [package.dependencies]
@@ -2162,5 +2162,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10 | ^3.9 | ^3.8.1"
-content-hash = "d8cae4bcda9fcc8db58c08e1027d1e735dfe87e77584d7763348a6183c0fbad8"
+python-versions = "^3.10 | ^3.9"
+content-hash = "780be44d5f9abb4f5b4b1eb3ded16ff2762f49dfc990462c062b451a5f5220fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ generate-setup-file = false
 script = "tools/build.py"
 
 [tool.poetry.dependencies]
-python = "^3.10 | ^3.9 | ^3.8.1"
+python = "^3.10 | ^3.9"
 bech32 = "1.2.0"
 bitstring = "3.1.9"
 click = "8.0.4"


### PR DESCRIPTION
drop support for python 3.8
