### PR TITLE
Allow for scanning BIP21 QR codes

### DIFF
--- a/lnbits/core/static/js/wallet.js
+++ b/lnbits/core/static/js/wallet.js
@@ -466,12 +466,12 @@ new Vue({
         return
       }
 
-      // BIP-21 support 
-      if(this.parse.data.request.toLowerCase().includes('lightning')){
+      // BIP-21 support
+      if (this.parse.data.request.toLowerCase().includes('lightning')) {
         this.parse.data.request = this.parse.data.request.split('lightning=')[1]
-        
+
         // fail safe to check there's nothing after the lightning= part
-        if(this.parse.data.request.includes('&')){
+        if (this.parse.data.request.includes('&')) {
           this.parse.data.request = this.parse.data.request.split('&')[0]
         }
       }

--- a/lnbits/core/static/js/wallet.js
+++ b/lnbits/core/static/js/wallet.js
@@ -466,6 +466,16 @@ new Vue({
         return
       }
 
+      // BIP-21 support 
+      if(this.parse.data.request.toLowerCase().includes('lightning')){
+        this.parse.data.request = this.parse.data.request.split('lightning=')[1]
+        
+        // fail safe to check there's nothing after the lightning= part
+        if(this.parse.data.request.includes('&')){
+          this.parse.data.request = this.parse.data.request.split('&')[0]
+        }
+      }
+
       let invoice
       try {
         invoice = decode(this.parse.data.request)


### PR DESCRIPTION
Enable BIP21 URI's / QR codes to be used/scanned with the LNbits wallet

Fixes #1202