### PR TITLE
Add troubleshooting note for Poetry errors on OSX install

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -12,8 +12,6 @@ By default, LNbits will use SQLite as its database. You can also use PostgreSQL 
 
 ## Option 1 (recommended): poetry
 
-If you have problems installing LNbits using these instructions, please have a look at the [Troubleshooting](#troubleshooting) section.
-
 Mininum poetry version has is ^1.2, but it is recommended to use latest poetry. (including OSX)
 
 ```sh

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -194,6 +194,10 @@ poetry add setuptools wheel
 
 If your Poetry version is older than 1.2, for `poetry install`, ignore the `--only main` flag.
 
+If you are on OSX, running ``` poetry env use python3.9``` may give errors, in pyproject.toml 
+remove the "[tool.poetry.group.dev.dependencies]" line before running ```poetry install```
+
+
 ### Optional: PostgreSQL database
 
 If you want to use LNbits at scale, we recommend using PostgreSQL as the backend database. Install Postgres and setup a database for LNbits:

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -14,6 +14,8 @@ By default, LNbits will use SQLite as its database. You can also use PostgreSQL 
 
 If you have problems installing LNbits using these instructions, please have a look at the [Troubleshooting](#troubleshooting) section.
 
+Mininum poetry version has is ^1.2, but it is recommended to use latest poetry. (including OSX)
+
 ```sh
 git clone https://github.com/lnbits/lnbits.git
 cd lnbits
@@ -189,13 +191,6 @@ sudo apt install python3.9-dev gcc build-essential
 # if you used poetry
 poetry add setuptools wheel
 ```
-
-#### Poetry
-
-If you are on OSX, try make sure your version of poetry is at least 1.4 or poetry will not install properly.
-
-If your Poetry version is older than 1.2, for `poetry install`, ignore the `--only main` flag.
-
 
 ### Optional: PostgreSQL database
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -192,10 +192,9 @@ poetry add setuptools wheel
 
 #### Poetry
 
-If your Poetry version is older than 1.2, for `poetry install`, ignore the `--only main` flag.
+If you are on OSX, try make sure your version of poetry is at least 1.4 or poetry will not install properly.
 
-If you are on OSX, running ``` poetry env use python3.9``` may give errors, in pyproject.toml 
-remove the "[tool.poetry.group.dev.dependencies]" line before running ```poetry install```
+If your Poetry version is older than 1.2, for `poetry install`, ignore the `--only main` flag.
 
 
 ### Optional: PostgreSQL database


### PR DESCRIPTION
poetry errors on OSX, added troubleshooting note on how to bypass the error on installation.

```
 The Poetry configuration is invalid:
    - Additional properties are not allowed ('group' was unexpected)
    - 
  at ~/.poetry/lib/poetry/_vendor/py3.9/poetry/core/factory.py:43 in create_poetry
       39│             message = ""
       40│             for error in check_result["errors"]:
       41│                 message += "  - {}\n".format(error)
       42│
    →  43│             raise RuntimeError("The Poetry configuration is invalid:\n" + message)
       44│
       45│         # Load package
       46│         name = local_config["name"]
       47│         version = local_config["version"]

```