### PR TITLE
increment cache version for service-worker.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,6 @@ bundle:
 	npm run vendor_minify_css
 	npm run vendor_bundle_js
 	npm run vendor_minify_js
+	# increment serviceworker version
+	sed -i -e "s/CACHE_VERSION =.*/CACHE_VERSION = $$(awk '/CACHE_VERSION =/ { print 1+$$4 }' lnbits/core/static/js/service-worker.js)/" \
+		lnbits/core/static/js/service-worker.js

--- a/lnbits/core/static/js/service-worker.js
+++ b/lnbits/core/static/js/service-worker.js
@@ -1,5 +1,6 @@
-// the cache version gets updated every time there is a new deployment
-const CACHE_VERSION = 1
+// update cache version every time there is a new deployment
+// so the service worker reinitializes the cache
+const CACHE_VERSION = 2
 const CURRENT_CACHE = `lnbits-${CACHE_VERSION}-`
 
 const getApiKey = request => {


### PR DESCRIPTION
should should fix current problems with PWA.

https://stackoverflow.com/questions/30523843/service-worker-how-to-update-the-cache-when-files-changed-on-the-server

CACHE_VERSION needs in increment when files changed so it will recache everything.
* added a automatic increment script to run on `make bundle`
