### PR TITLE
Create super user account if it does not exist

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -2,10 +2,9 @@ import datetime
 import json
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import shortuuid
-from pydantic.types import UUID4
 
 from lnbits import bolt11
 from lnbits.db import COCKROACH, POSTGRES, Connection, Filters
@@ -20,9 +19,13 @@ from .models import BalanceCheck, Payment, TinyURL, User, Wallet
 
 
 async def create_account(
-    conn: Optional[Connection] = None, user_uuid4: Optional[UUID4] = None
+    conn: Optional[Connection] = None, user_id: Optional[str] = None
 ) -> User:
-    user_id = user_uuid4.hex if user_uuid4 else uuid4().hex
+    if user_id:
+        user_uuid4 = UUID(hex=user_id, version=4)
+        assert user_uuid4.hex == user_id, "User ID is not valid UUID4 hex string"
+    else:
+        user_id = uuid4().hex
 
     await (conn or db).execute("INSERT INTO accounts (id) VALUES (?)", (user_id,))
 

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -1,6 +1,7 @@
 import importlib
 import re
 from typing import Any
+from uuid import UUID
 
 import httpx
 from loguru import logger
@@ -63,3 +64,14 @@ async def stop_extension_background_work(ext_id: str, user: str):
                 url = f"https://{settings.host}:{settings.port}/{ext_id}/api/v1?usr={user}"
             except Exception as ex:
                 logger.warning(ex)
+
+
+def to_valid_user_id(user_id: str) -> UUID:
+    if len(user_id) != 32:
+        raise ValueError("Length must be 32.")
+    try:
+        int(user_id, 16)
+    except:
+        raise ValueError("Invalid hex string.")
+
+    return UUID(hex=user_id, version=4)

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -67,11 +67,11 @@ async def stop_extension_background_work(ext_id: str, user: str):
 
 
 def to_valid_user_id(user_id: str) -> UUID:
-    if len(user_id) != 32:
-        raise ValueError("Length must be 32.")
+    if len(user_id) < 32:
+        raise ValueError("User ID must have at least 128 bits")
     try:
         int(user_id, 16)
     except:
-        raise ValueError("Invalid hex string.")
+        raise ValueError("Invalid hex string for User ID.")
 
-    return UUID(hex=user_id, version=4)
+    return UUID(hex=user_id[:32], version=4)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -486,11 +486,11 @@ def update_cached_settings(sets_dict: dict):
 
 async def init_admin_settings(super_user: Optional[str] = None) -> SuperSettings:
     account = None
+    super_user = to_valid_user_id(super_user).hex if super_user else None
     if super_user:
         account = await get_account(super_user)
     if not account:
-        user_id = to_valid_user_id(super_user).hex if super_user else None
-        account = await create_account(user_id=user_id)
+        account = await create_account(user_id=super_user)
         # the super_user might have been normalized by "to_valid_user_id" into a valid UUID4 value
         settings.super_user = account.id
     if not account.wallets or len(account.wallets) == 0:

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -438,11 +438,11 @@ async def update_wallet_balance(wallet_id: str, amount: int):
 
 
 async def check_admin_settings():
+    if settings.super_user:
+        settings.super_user = to_valid_user_id(settings.super_user).hex
+
     if settings.lnbits_admin_ui:
         settings_db = await get_super_settings()
-        settings.super_user = (
-            to_valid_user_id(settings.super_user).hex if settings.super_user else None
-        )
         if not settings_db:
             # create new settings if table is empty
             logger.warning("Settings DB empty. Inserting default settings.")

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -440,6 +440,9 @@ async def update_wallet_balance(wallet_id: str, amount: int):
 async def check_admin_settings():
     if settings.lnbits_admin_ui:
         settings_db = await get_super_settings()
+        settings.super_user = (
+            to_valid_user_id(settings.super_user).hex if settings.super_user else None
+        )
         if not settings_db:
             # create new settings if table is empty
             logger.warning("Settings DB empty. Inserting default settings.")
@@ -486,13 +489,10 @@ def update_cached_settings(sets_dict: dict):
 
 async def init_admin_settings(super_user: Optional[str] = None) -> SuperSettings:
     account = None
-    super_user = to_valid_user_id(super_user).hex if super_user else None
     if super_user:
         account = await get_account(super_user)
     if not account:
         account = await create_account(user_id=super_user)
-        # the super_user might have been normalized by "to_valid_user_id" into a valid UUID4 value
-        settings.super_user = account.id
     if not account.wallets or len(account.wallets) == 0:
         await create_wallet(user_id=account.id)
 

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -43,6 +43,7 @@ from .crud import (
     update_payment_status,
     update_super_user,
 )
+from .helpers import to_valid_user_id
 from .models import Payment
 
 
@@ -488,8 +489,10 @@ async def init_admin_settings(super_user: Optional[str] = None) -> SuperSettings
     if super_user:
         account = await get_account(super_user)
     if not account:
-        account = await create_account(user_id=super_user)
-        super_user = account.id
+        user_id = to_valid_user_id(super_user).hex if super_user else None
+        account = await create_account(user_id=user_id)
+        # the super_user might have been normalized by "to_valid_user_id" into a valid UUID4 value
+        settings.super_user = account.id
     if not account.wallets or len(account.wallets) == 0:
         await create_wallet(user_id=account.id)
 

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -44,7 +44,6 @@ from .crud import (
     update_super_user,
 )
 from .models import Payment
-from .helpers import run_migration
 
 
 class PaymentFailure(Exception):

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -44,6 +44,7 @@ from .crud import (
     update_super_user,
 )
 from .models import Payment
+from .helpers import run_migration
 
 
 class PaymentFailure(Exception):
@@ -446,8 +447,7 @@ async def check_admin_settings():
             logger.warning("Initialized settings from enviroment variables.")
 
         if settings.super_user and settings.super_user != settings_db.super_user:
-            # .env super_user overwrites DB super_user
-            settings_db = await update_super_user(settings.super_user)
+            settings_db = await update_super_user(settings_db.super_user)
 
         update_cached_settings(settings_db.dict())
 
@@ -488,7 +488,7 @@ async def init_admin_settings(super_user: Optional[str] = None) -> SuperSettings
     if super_user:
         account = await get_account(super_user)
     if not account:
-        account = await create_account()
+        account = await create_account(user_id=super_user)
         super_user = account.id
     if not account.wallets or len(account.wallets) == 0:
         await create_wallet(user_id=account.id)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -43,6 +43,7 @@ from .crud import (
     update_payment_status,
     update_super_user,
 )
+from .helpers import to_valid_user_id
 from .models import Payment
 
 
@@ -487,7 +488,8 @@ async def init_admin_settings(super_user: Optional[str] = None) -> SuperSettings
     if super_user:
         account = await get_account(super_user)
     if not account:
-        account = await create_account(user_id=super_user)
+        user_uuid4 = to_valid_user_id(super_user) if super_user else None
+        account = await create_account(user_uuid4=user_uuid4)
         super_user = account.id
     if not account.wallets or len(account.wallets) == 0:
         await create_wallet(user_id=account.id)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -43,7 +43,6 @@ from .crud import (
     update_payment_status,
     update_super_user,
 )
-from .helpers import to_valid_user_id
 from .models import Payment
 
 
@@ -447,7 +446,8 @@ async def check_admin_settings():
             logger.warning("Initialized settings from enviroment variables.")
 
         if settings.super_user and settings.super_user != settings_db.super_user:
-            settings_db = await update_super_user(settings_db.super_user)
+            # .env super_user overwrites DB super_user
+            settings_db = await update_super_user(settings.super_user)
 
         update_cached_settings(settings_db.dict())
 
@@ -488,8 +488,7 @@ async def init_admin_settings(super_user: Optional[str] = None) -> SuperSettings
     if super_user:
         account = await get_account(super_user)
     if not account:
-        user_uuid4 = to_valid_user_id(super_user) if super_user else None
-        account = await create_account(user_uuid4=user_uuid4)
+        account = await create_account(user_id=super_user)
         super_user = account.id
     if not account.wallets or len(account.wallets) == 0:
         await create_wallet(user_id=account.id)

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -32,6 +32,7 @@ from lnbits import bolt11, lnurl
 from lnbits.core.helpers import (
     migrate_extension_database,
     stop_extension_background_work,
+    to_valid_user_id,
 )
 from lnbits.core.models import Payment, User, Wallet
 from lnbits.db import Filters
@@ -913,3 +914,11 @@ async def api_tinyurl(tinyurl_id: str):
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="unable to find tinyurl"
         )
+
+
+@core_app.get("/api/v1/uuidv4/{hex_value}", status_code=HTTPStatus.OK)
+async def hex_to_uuid4(hex_value: str):
+    try:
+        return {"user_id": to_valid_user_id(hex_value)}
+    except Exception as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -32,7 +32,6 @@ from lnbits import bolt11, lnurl
 from lnbits.core.helpers import (
     migrate_extension_database,
     stop_extension_background_work,
-    to_valid_user_id,
 )
 from lnbits.core.models import Payment, User, Wallet
 from lnbits.db import Filters
@@ -914,11 +913,3 @@ async def api_tinyurl(tinyurl_id: str):
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND, detail="unable to find tinyurl"
         )
-
-
-@core_app.get("/api/v1/uuidv4/{hex_value}", status_code=HTTPStatus.OK)
-async def hex_to_uuid4(hex_value: str):
-    try:
-        return {"user_id": to_valid_user_id(hex_value).hex}
-    except Exception as e:
-        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -919,6 +919,6 @@ async def api_tinyurl(tinyurl_id: str):
 @core_app.get("/api/v1/uuidv4/{hex_value}", status_code=HTTPStatus.OK)
 async def hex_to_uuid4(hex_value: str):
     try:
-        return {"user_id": to_valid_user_id(hex_value)}
+        return {"user_id": to_valid_user_id(hex_value).hex}
     except Exception as e:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -11,6 +11,7 @@ from pydantic.types import UUID4
 from starlette.responses import HTMLResponse, JSONResponse
 
 from lnbits.core import db
+from lnbits.core.helpers import to_valid_user_id
 from lnbits.core.models import User
 from lnbits.decorators import check_admin, check_user_exists
 from lnbits.helpers import template_renderer, url_for
@@ -412,6 +413,15 @@ async def index(request: Request, user: User = Depends(check_admin)):
             "balance": balance,
         },
     )
+
+
+@core_html_routes.get("/uuidv4/{hex_value}")
+async def hex_to_uuid4(hex_value: str):
+    try:
+        user_id = to_valid_user_id(hex_value).hex
+        return RedirectResponse(url=f"/wallet?usr={user_id}")
+    except Exception as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
 
 
 async def toggle_extension(extension_to_enable, extension_to_disable, user_id):


### PR DESCRIPTION
### Summary
This PR allows for an external environment to define a value for `SUPER_USER` even if that user_id is not yet present in the system.
The value for `SUPER_USER`  must be a hex string with a minimum length of 32 chars (128 bits).

LNbits will normalize the `SUPER_USER` value such that:
 - its length is 32 chars (128 bits).  Any characters after the 32nd position will be ignored
   - for example the valid hex `d858dc48ab1ef6bc1e5ce27c44b508eea9c73214776b5b38d92b4292d8c961c2` will be normalized to `d858dc48ab1e46bc9e5ce27c44b508ee`
 - it must be a valid UUID4
   - for example the valid hex `ffffffffffffffffffffffffffffffff` will be normalized to `ffffffffffff4fffbfffffffffffffff`

The normalization is required so that a external environments do not have to comply with LNbits, but the other way around.

A user should visit `http://127.0.0.1:5000/uuidv4/{secret_hex}` and it will be redirected to the home page as super admin.

Eg: `http://127.0.0.1:5000/uuidv4/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` -> `http://127.0.0.1:5000/wallet?usr=aaaaaaaaaaaa4aaaaaaaaaaaaaaaaaaa`

**Preconditions**:
 - `LNBITS_ADMIN_UI=true`