### PR TITLE
remove mypy from precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,11 +32,3 @@ repos:
     hooks:
       - id: flake8
         entry: poetry run flake8
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
-    hooks:
-      - id: mypy
-        name: mypy
-        entry: poetry run mypy
-        args: [--ignore-missing-imports]
-        additional_dependencies: [types-mock, types-protobuf]


### PR DESCRIPTION
mypy in pre-commit is flakey and does not and will never support configs from pyproject.yaml.
also its pretty slow so i think its best to remove it from pre-commit
