### PR TITLE
fix "boolean" query for sqlite

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -336,7 +336,7 @@ async def get_latest_payments_by_extension(ext_name: str, ext_id: str, limit: in
     rows = await db.fetchall(
         f"""
         SELECT * FROM apipayments
-        WHERE pending = 'false'
+        WHERE pending = false
         AND extra LIKE ?
         AND extra LIKE ?
         ORDER BY time DESC LIMIT {limit}


### PR DESCRIPTION
`get_latest_payments_by_extension` isn't working on SQlite. The query `WHERE pending = 'false'` doesn't work for SQLIte, changed it to `0`!

Issue was that TPOS wouldn't get the latest payments to display!