### PR TITLE
quickfix spacing und mobile footer

### DIFF
--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -239,7 +239,7 @@
         class="bg-transparent q-px-lg q-py-md"
         :class="{'text-dark': !$q.dark.isActive}"
       >
-        <q-space class="q-py-lg lt-sm"></q-space>
+        <q-space class="q-py-lg lt-md"></q-space>
         <q-toolbar class="gt-sm">
           <q-toolbar-title class="text-caption">
             {{ SITE_TITLE }}, {{SITE_TAGLINE}}


### PR DESCRIPTION
![screenshot-1686817719](https://github.com/lnbits/lnbits/assets/1743657/ccae74bc-0581-4e74-bef8-266fea6a3a78)
![screenshot-1686817738](https://github.com/lnbits/lnbits/assets/1743657/8ca926a5-4ef1-424a-befb-9dbbcec0da15)

the footer nav is show until md, but the space only for mobile, should be on both.