### PR TITLE
feat: show extension repo as tooltip for each repo

### DIFF
--- a/lnbits/core/templates/core/extensions.html
+++ b/lnbits/core/templates/core/extensions.html
@@ -300,6 +300,11 @@
                     {%raw%}{{ $t('repository') }}{%endraw%}
                     <br />
                     <small v-text="repoName"></small>
+                    <q-tooltip
+                      ><span
+                        v-text="selectedExtensionRepos[repoName].repo"
+                      ></span
+                    ></q-tooltip>
                   </div>
                   <div class="col-2"></div>
                 </div>
@@ -541,7 +546,8 @@
           this.selectedExtensionRepos = data.reduce((repos, release) => {
             repos[release.source_repo] = repos[release.source_repo] || {
               releases: [],
-              isInstalled: false
+              isInstalled: false,
+              repo: release.repo
             }
             release.inProgress = false
             release.error = null

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -25,6 +25,7 @@ class ExplicitRelease(BaseModel):
     archive: str
     hash: str
     dependencies: List[str] = []
+    repo: Optional[str]
     icon: Optional[str]
     short_description: Optional[str]
     min_lnbits_version: Optional[str]
@@ -254,6 +255,7 @@ class ExtensionRelease(BaseModel):
     html_url: Optional[str] = None
     description: Optional[str] = None
     warning: Optional[str] = None
+    repo: Optional[str] = None
     icon: Optional[str] = None
 
     @classmethod
@@ -267,7 +269,7 @@ class ExtensionRelease(BaseModel):
             archive=r.zipball_url,
             source_repo=source_repo,
             is_github_release=True,
-            # description=r.body, # bad for JSON
+            repo=f"https://github.com/{source_repo}",
             html_url=r.html_url,
         )
 
@@ -286,6 +288,7 @@ class ExtensionRelease(BaseModel):
             is_version_compatible=e.is_version_compatible(),
             warning=e.warning,
             html_url=e.html_url,
+            repo=e.repo,
             icon=e.icon,
         )
 


### PR DESCRIPTION
### Summary
Extension repository is required in order to show more info about the extension to the user.
This PR only shows the repo url as a tooltip.

### Test
Add more manifests to the `Extension Sources` list:
 - https://raw.githubusercontent.com/lnbits/lnbits-extensions/main/extensions.json
 - https://raw.githubusercontent.com/motorina0/lnbits-extensions/main/extensions.json
 - https://raw.githubusercontent.com/lnbits/nostrclient/main/manifest.json

Each source should show the correct repo as tooltip:
![image](https://github.com/lnbits/lnbits/assets/2951406/54befa34-e989-407e-9106-87d21f2e09d5)
