### PR TITLE
fix: ext short description for pre-installed extensions

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -154,7 +154,7 @@ async def check_installed_extensions(app: FastAPI):
 
     for ext in installed_extensions:
         try:
-            installed = check_installed_extension(ext)
+            installed = check_installed_extension_files(ext)
             if not installed:
                 await restore_installed_extension(app, ext)
                 logger.info(
@@ -187,13 +187,11 @@ async def build_all_installed_extensions_list() -> List[InstallableExtension]:
                 id=ext_id, name=ext_id, installed_release=release, icon=release.icon
             )
             installed_extensions.append(ext_info)
-            await add_installed_extension(ext_info)
-            await update_installed_extension_state(ext_id=ext_id, active=True)
 
     return installed_extensions
 
 
-def check_installed_extension(ext: InstallableExtension) -> bool:
+def check_installed_extension_files(ext: InstallableExtension) -> bool:
     if ext.has_installed_version:
         return True
 
@@ -209,6 +207,9 @@ def check_installed_extension(ext: InstallableExtension) -> bool:
 
 
 async def restore_installed_extension(app: FastAPI, ext: InstallableExtension):
+    await add_installed_extension(ext)
+    await update_installed_extension_state(ext_id=ext.id, active=True)
+
     extension = Extension.from_installable_ext(ext)
     register_ext_routes(app, extension)
 

--- a/lnbits/core/templates/core/extensions.html
+++ b/lnbits/core/templates/core/extensions.html
@@ -108,7 +108,8 @@
               class="text-subtitle2 gt-sm"
               style="font-size: 11px; height: 34px"
             >
-              {{ extension.shortDescription }}
+              {{ extension.shortDescription ||
+              extension.installedRelease?.description }}
             </div>
             <div class="text-subtitle1 lt-md q-mt-sm q-mb-xs">
               {{ extension.name }}


### PR DESCRIPTION
### Summary
 - when an extension is installed via `LNBITS_EXTENSIONS_DEFAULT_INSTALL` the `shortDescription` value is not shown
 - see `gerty`, `juckebox` or `events` in the screenshot below:
![telegram-cloud-photo-size-4-6015088650393598874-y](https://github.com/lnbits/lnbits/assets/2951406/6abbec07-8c51-46b2-8ced-8837d872fd72)

 - the fix will now show the `shortDescription` no matter how the extension was installed
 - re-install of extension not required
