### PR TITLE
Ability to limit available fiat currencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ LNBITS_RESERVE_FEE_MIN=2000
 # value in percent
 LNBITS_RESERVE_FEE_PERCENT=1.0
 
+# Limit fiat currencies allowed to see in UI
+# LNBITS_ALLOWED_CURRENCIES="EUR, USD"
+
 # Change theme
 LNBITS_SITE_TITLE="LNbits"
 LNBITS_SITE_TAGLINE="free and open-source lightning wallet"

--- a/lnbits/core/templates/admin/_tab_server.html
+++ b/lnbits/core/templates/admin/_tab_server.html
@@ -56,6 +56,20 @@
       </div>
       <div class="row q-col-gutter-md">
         <div class="col-12 col-md-6">
+          <p>Allowed currencies</p>
+          <q-select
+            filled
+            v-model="formData.lnbits_allowed_currencies"
+            multiple
+            hint="Limit the number of available fiat currencies"
+            label="Allowed currencies"
+            :options="{{ currencies | safe }}"
+          ></q-select>
+          <br />
+        </div>
+      </div>
+      <div class="row q-col-gutter-md">
+        <div class="col-12 col-md-6">
           <p>Admin Extensions</p>
           <q-select
             filled

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -670,11 +670,12 @@ async def api_perform_lnurlauth(
 
 @core_app.get("/api/v1/currencies")
 async def api_list_currencies_available():
-    allow_list = {currency.upper() for currency in settings.lnbits_allowed_currencies}
-
-    if allow_list:
-        return [item for item in currencies.keys() if item.upper() in allow_list]
-
+    if len(settings.lnbits_allowed_currencies) > 0:
+        return [
+            item
+            for item in currencies.keys()
+            if item.upper() in settings.lnbits_allowed_currencies
+        ]
     return list(currencies.keys())
 
 

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -670,6 +670,11 @@ async def api_perform_lnurlauth(
 
 @core_app.get("/api/v1/currencies")
 async def api_list_currencies_available():
+    allow_list = {currency.upper() for currency in settings.lnbits_allowed_currencies}
+
+    if allow_list:
+        return [item for item in currencies.keys() if item.upper() in allow_list]
+
     return list(currencies.keys())
 
 

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -18,6 +18,7 @@ from lnbits.helpers import template_renderer, url_for
 from lnbits.settings import get_wallet_class, settings
 
 from ...extension_manager import InstallableExtension, get_valid_extensions
+from ...utils.exchange_rates import currencies
 from ..crud import (
     create_account,
     create_wallet,
@@ -396,6 +397,7 @@ async def index(request: Request, user: User = Depends(check_admin)):
             "user": user.dict(),
             "settings": settings.dict(),
             "balance": balance,
+            "currencies": list(currencies.keys()),
         },
     )
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -43,6 +43,10 @@ class UsersSettings(LNbitsSettings):
     lnbits_allowed_users: List[str] = Field(default=[])
 
 
+class AllowedCurrencies(LNbitsSettings):
+    lnbits_allowed_currencies: List[str] = Field(default=[])
+
+
 class ExtensionsSettings(LNbitsSettings):
     lnbits_admin_extensions: List[str] = Field(default=[])
     lnbits_extensions_manifests: List[str] = Field(
@@ -203,6 +207,7 @@ class FundingSourcesSettings(
 
 class EditableSettings(
     UsersSettings,
+    AllowedCurrencies,
     ExtensionsSettings,
     ThemesSettings,
     OpsSettings,

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -43,10 +43,6 @@ class UsersSettings(LNbitsSettings):
     lnbits_allowed_users: List[str] = Field(default=[])
 
 
-class AllowedCurrencies(LNbitsSettings):
-    lnbits_allowed_currencies: List[str] = Field(default=[])
-
-
 class ExtensionsSettings(LNbitsSettings):
     lnbits_admin_extensions: List[str] = Field(default=[])
     lnbits_extensions_manifests: List[str] = Field(
@@ -93,6 +89,7 @@ class ThemesSettings(LNbitsSettings):
         default="https://shop.lnbits.com/;/static/images/lnbits-shop-light.png;/static/images/lnbits-shop-dark.png"
     )  # sneaky sneaky
     lnbits_ad_space_enabled: bool = Field(default=False)
+    lnbits_allowed_currencies: List[str] = Field(default=[])
 
 
 class OpsSettings(LNbitsSettings):
@@ -207,7 +204,6 @@ class FundingSourcesSettings(
 
 class EditableSettings(
     UsersSettings,
-    AllowedCurrencies,
     ExtensionsSettings,
     ThemesSettings,
     OpsSettings,


### PR DESCRIPTION
Allow server admin to limit the number of available fiat currencies

![allowed_currencies_demo](https://github.com/lnbits/lnbits/assets/120722620/a458e1ab-b33e-4c47-bc11-92dbcb7721f4)
