### PR TITLE
TEST: fix tests for real wallets

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -38,8 +38,8 @@ jobs:
           LNBITS_DATA_FOLDER: ./data
           LNBITS_BACKEND_WALLET_CLASS: LndRestWallet
           LND_REST_ENDPOINT: https://localhost:8081/
-          LND_REST_CERT: ./docker/data/lnd-1/tls.cert
-          LND_REST_MACAROON: ./docker/data/lnd-1/data/chain/bitcoin/regtest/admin.macaroon
+          LND_REST_CERT: ./docker/data/lnd-3/tls.cert
+          LND_REST_MACAROON: ./docker/data/lnd-3/data/chain/bitcoin/regtest/admin.macaroon
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet
@@ -83,8 +83,8 @@ jobs:
           LNBITS_BACKEND_WALLET_CLASS: LndWallet
           LND_GRPC_ENDPOINT: localhost
           LND_GRPC_PORT: 10009
-          LND_GRPC_CERT: docker/data/lnd-1/tls.cert
-          LND_GRPC_MACAROON: docker/data/lnd-1/data/chain/bitcoin/regtest/admin.macaroon
+          LND_GRPC_CERT: docker/data/lnd-3/tls.cert
+          LND_GRPC_MACAROON: docker/data/lnd-3/data/chain/bitcoin/regtest/admin.macaroon
         run: |
           sudo chmod -R a+rwx . && rm -rf ./data && mkdir -p ./data
           make test-real-wallet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 RUN apt-get clean
 RUN apt-get update

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -3,7 +3,7 @@ import base64
 import hashlib
 import json
 import urllib.parse
-from typing import AsyncGenerator, Dict, Optional
+from typing import Any, AsyncGenerator, Dict, Optional
 
 import httpx
 from loguru import logger
@@ -70,7 +70,7 @@ class EclairWallet(Wallet):
         **kwargs,
     ) -> InvoiceResponse:
 
-        data: Dict = {
+        data: Dict[str, Any] = {
             "amountMsat": amount * 1000,
         }
         if kwargs.get("expiry"):

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -72,8 +72,6 @@ class EclairWallet(Wallet):
 
         data: Dict = {
             "amountMsat": amount * 1000,
-            "description_hash": b"",
-            "description": memo,
         }
         if kwargs.get("expiry"):
             data["expireIn"] = kwargs["expiry"]
@@ -82,6 +80,8 @@ class EclairWallet(Wallet):
             data["descriptionHash"] = description_hash.hex()
         elif unhashed_description:
             data["descriptionHash"] = hashlib.sha256(unhashed_description).hexdigest()
+        else:
+            data["description"] = memo
 
         async with httpx.AsyncClient() as client:
             r = await client.post(

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -76,6 +76,7 @@ class EclairWallet(Wallet):
         if kwargs.get("expiry"):
             data["expireIn"] = kwargs["expiry"]
 
+        # Either 'description' (string) or 'descriptionHash' must be supplied
         if description_hash:
             data["descriptionHash"] = description_hash.hex()
         elif unhashed_description:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,6 @@ async def invoice(to_wallet):
 
 @pytest_asyncio.fixture(scope="session")
 async def real_invoice():
-    invoice = get_real_invoice(100_000, "test-fixture")
-    yield invoice
+    invoice = get_real_invoice(100, "test-fixture")
+    yield {"bolt11": invoice["payment_request"]}
     del invoice

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,6 @@ async def invoice(to_wallet):
 
 @pytest_asyncio.fixture(scope="session")
 async def real_invoice():
-    invoice = get_real_invoice(100, "test-fixture")
+    invoice = get_real_invoice(100)
     yield {"bolt11": invoice["payment_request"]}
     del invoice

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,7 +3,6 @@ import json
 import random
 import secrets
 import string
-import time
 from subprocess import PIPE, Popen, run
 
 from lnbits.core.crud import create_payment
@@ -48,8 +47,8 @@ docker_bitcoin_rpc = "lnbits"
 docker_prefix = "lnbits-legend"
 docker_cmd = "docker exec"
 
-docker_lightning = f"{docker_cmd} {docker_prefix}-clightning-2-1"
-docker_lightning_cli = f"{docker_lightning} lightning-cli --network regtest"
+docker_lightning = f"{docker_cmd} {docker_prefix}-lnd-1-1"
+docker_lightning_cli = f"{docker_lightning} lncli --network regtest --rpcserver=lnd-1"
 
 docker_bitcoin = f"{docker_cmd} {docker_prefix}-bitcoind-1-1"
 docker_bitcoin_cli = f"{docker_bitcoin} bitcoin-cli -rpcuser={docker_bitcoin_rpc} -rpcpassword={docker_bitcoin_rpc} -regtest"
@@ -65,14 +64,15 @@ def run_cmd_json(cmd: str) -> dict:
 
 def get_real_invoice(sats: int, prefix: str, description: str = "test") -> dict:
     msats = sats * 1000
-    return run_cmd_json(
-        f"{docker_lightning_cli} invoice {msats} {prefix}-{time.time()} {description}"
-    )
+    return run_cmd_json(f"{docker_lightning_cli} addinvoice {msats}")
 
 
 def pay_real_invoice(invoice: str) -> Popen:
     return Popen(
-        f"{docker_lightning_cli} pay {invoice}", shell=True, stdin=PIPE, stdout=PIPE
+        f"{docker_lightning_cli} payinvoice {invoice}",
+        shell=True,
+        stdin=PIPE,
+        stdout=PIPE,
     )
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,7 +7,7 @@ import time
 from subprocess import PIPE, Popen, run
 
 from lnbits.core.crud import create_payment
-from lnbits.settings import get_wallet_class
+from lnbits.settings import get_wallet_class, set_wallet_class
 
 
 async def credit_wallet(wallet_id: str, amount: int):
@@ -38,6 +38,7 @@ async def get_random_invoice_data():
     return {"out": False, "amount": 10, "memo": f"test_memo_{get_random_string(10)}"}
 
 
+set_wallet_class()
 WALLET = get_wallet_class()
 is_fake: bool = WALLET.__class__.__name__ == "FakeWallet"
 is_regtest: bool = not is_fake

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -62,7 +62,7 @@ def run_cmd_json(cmd: str) -> dict:
     return json.loads(run_cmd(cmd))
 
 
-def get_real_invoice(sats: int, prefix: str, description: str = "test") -> dict:
+def get_real_invoice(sats: int) -> dict:
     msats = sats * 1000
     return run_cmd_json(f"{docker_lightning_cli} addinvoice {msats}")
 


### PR DESCRIPTION
as @jackstar12 discover the regtest were not using the actual fundingsources.

- switched invoice create to lnd-1 node because it is connected the best inside regtest
- make invoice amount smaller
- switch LndWallet, LndRestWallet to use lnd-3 (selfpayments)

had to change the docker regtest setup aswell, because eclair was actually not working. using a wrong zmq endpoint

also @jackstar12 fixed eclair backend, it was also not beeing able to pay a real invoice.