### PR TITLE
BUGFIX: Docker image wont build on debian12, use 11 instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-slim-bullseye
 
 RUN apt-get clean
 RUN apt-get update


### PR DESCRIPTION
- use debian 11 instead of 12
