### PR TITLE
Refactor get walletclass

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -29,7 +29,8 @@ from lnbits.core.tasks import (  # register_watchdog,; unregister_watchdog,
     register_task_listeners,
     unregister_killswitch,
 )
-from lnbits.settings import get_wallet_class, set_wallet_class, settings
+from lnbits.settings import settings
+from lnbits.wallets import get_wallet_class, set_wallet_class
 
 from .commands import db_versions, load_disabled_extension_list, migrate_databases
 from .core import (
@@ -342,7 +343,6 @@ def register_shutdown(app: FastAPI):
 
 
 def initialize_server_logger():
-
     super_user_hash = sha256(settings.super_user.encode("utf-8")).hexdigest()
 
     serverlog_queue = asyncio.Queue()

--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -13,7 +13,8 @@ from pydantic import BaseModel
 
 from lnbits.db import Connection, FilterModel, FromRowModel
 from lnbits.helpers import url_for
-from lnbits.settings import get_wallet_class, settings
+from lnbits.settings import settings
+from lnbits.wallets import get_wallet_class
 from lnbits.wallets.base import PaymentStatus
 
 
@@ -37,7 +38,6 @@ class Wallet(BaseModel):
 
     @property
     def lnurlwithdraw_full(self) -> str:
-
         url = url_for("/withdraw", external=True, usr=self.user, wal=self.id)
         try:
             return lnurl_encode(url)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -15,15 +15,13 @@ from lnbits.db import Connection
 from lnbits.decorators import WalletTypeInfo, require_admin_key
 from lnbits.helpers import url_for
 from lnbits.settings import (
-    FAKE_WALLET,
     EditableSettings,
     SuperSettings,
-    get_wallet_class,
     readonly_variables,
     send_admin_user_to_saas,
-    set_wallet_class,
     settings,
 )
+from lnbits.wallets import FAKE_WALLET, get_wallet_class, set_wallet_class
 from lnbits.wallets.base import PaymentResponse, PaymentStatus
 
 from . import db
@@ -85,7 +83,7 @@ async def create_invoice(
         unhashed_description=unhashed_description,
         expiry=expiry or settings.lightning_invoice_expiry,
     )
-    if not ok:
+    if not ok or not payment_request or not checking_id:
         raise InvoiceFailure(error_message or "unexpected backend error.")
 
     invoice = bolt11.decode(payment_request)

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -15,7 +15,8 @@ from lnbits.core.helpers import to_valid_user_id
 from lnbits.core.models import User
 from lnbits.decorators import check_admin, check_user_exists
 from lnbits.helpers import template_renderer, url_for
-from lnbits.settings import get_wallet_class, settings
+from lnbits.settings import settings
+from lnbits.wallets import get_wallet_class
 
 from ...extension_manager import InstallableExtension, get_valid_extensions
 from ...utils.exchange_rates import currencies

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -341,19 +341,6 @@ def set_cli_settings(**kwargs):
         setattr(settings, key, value)
 
 
-# set wallet class after settings are loaded
-def set_wallet_class(class_name: Optional[str] = None):
-    backend_wallet_class = class_name or settings.lnbits_backend_wallet_class
-    wallet_class = getattr(wallets_module, backend_wallet_class)
-    global WALLET
-    WALLET = wallet_class()
-
-
-def get_wallet_class():
-    # wallet_class = getattr(wallets_module, settings.lnbits_backend_wallet_class)
-    return WALLET
-
-
 def send_admin_user_to_saas():
     if settings.lnbits_saas_callback:
         with httpx.Client() as client:
@@ -399,8 +386,11 @@ except:
 
 settings.version = importlib.metadata.version("lnbits")
 
-wallets_module = importlib.import_module("lnbits.wallets")
-FAKE_WALLET = getattr(wallets_module, "FakeWallet")()
 
-# initialize as fake wallet
-WALLET = FAKE_WALLET
+def get_wallet_class():
+    """
+    Backwards compatibility
+    """
+    from lnbits.wallets import get_wallet_class
+
+    return get_wallet_class()

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -15,7 +15,7 @@ from lnbits.core.crud import (
     get_standalone_payment,
 )
 from lnbits.core.services import redeem_lnurl_withdraw
-from lnbits.settings import get_wallet_class
+from lnbits.wallets import get_wallet_class
 
 from .core import db
 

--- a/lnbits/wallets/__init__.py
+++ b/lnbits/wallets/__init__.py
@@ -34,7 +34,7 @@ def get_wallet_class() -> Wallet:
 
 
 wallets_module = importlib.import_module("lnbits.wallets")
-FAKE_WALLET = FakeWallet()
+FAKE_WALLET: Wallet = FakeWallet()
 
 # initialize as fake wallet
 WALLET: Wallet = FAKE_WALLET

--- a/lnbits/wallets/__init__.py
+++ b/lnbits/wallets/__init__.py
@@ -1,4 +1,12 @@
+from __future__ import annotations
+
 # flake8: noqa: F401
+import importlib
+from typing import Optional
+
+from lnbits.settings import settings
+from lnbits.wallets.base import Wallet
+
 from .cliche import ClicheWallet
 from .cln import CoreLightningWallet
 from .cln import CoreLightningWallet as CLightningWallet
@@ -12,3 +20,21 @@ from .lntips import LnTipsWallet
 from .opennode import OpenNodeWallet
 from .spark import SparkWallet
 from .void import VoidWallet
+
+
+def set_wallet_class(class_name: Optional[str] = None):
+    backend_wallet_class = class_name or settings.lnbits_backend_wallet_class
+    wallet_class = getattr(wallets_module, backend_wallet_class)
+    global WALLET
+    WALLET = wallet_class()
+
+
+def get_wallet_class() -> Wallet:
+    return WALLET
+
+
+wallets_module = importlib.import_module("lnbits.wallets")
+FAKE_WALLET = FakeWallet()
+
+# initialize as fake wallet
+WALLET: Wallet = FAKE_WALLET

--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -61,6 +61,7 @@ class Wallet(ABC):
         amount: int,
         memo: Optional[str] = None,
         description_hash: Optional[bytes] = None,
+        **kwargs,
     ) -> Coroutine[None, None, InvoiceResponse]:
         pass
 

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -9,7 +9,7 @@ from lnbits.core.models import Payment
 from lnbits.core.views.admin_api import api_auditor
 from lnbits.core.views.api import api_payment
 from lnbits.db import DB_TYPE, SQLITE
-from lnbits.settings import get_wallet_class
+from lnbits.wallets import get_wallet_class
 from tests.conftest import CreateInvoiceData, api_payments_create_invoice
 
 from ...helpers import get_random_invoice_data, is_fake, pay_real_invoice

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ import string
 from subprocess import PIPE, Popen, run
 
 from lnbits.core.crud import create_payment
-from lnbits.settings import get_wallet_class, set_wallet_class
+from lnbits.wallets import get_wallet_class, set_wallet_class
 
 
 async def credit_wallet(wallet_id: str, amount: int):


### PR DESCRIPTION
These are some changes from https://github.com/lnbits/lnbits/pull/1702 which probably deserve its own pr.

I moved the `get_wallet_class` and `set_wallet_class` functions into the wallets module for two reasons:
- probably fits better logically
- fixed some issue with circular imports in https://github.com/lnbits/lnbits/pull/1702

I left a `get_wallet_class` wrapper for now in settings because lndhub and bleskomat reliy on it being there, maybe update that in the future.
https://github.com/search?q=org%3Alnbits%20NOT%20repo%3Alnbits%2Flnbits%20NOT%20repo%3Alnbits%2Flnbits-legend-1%20get_wallet_class&type=code

`set_wallet_class` isnt used in any vetted extension:
https://github.com/search?q=org%3Alnbits+NOT+repo%3Alnbits%2Flnbits+NOT+repo%3Alnbits%2Flnbits-legend-1+set_wallet_class&type=code

I also added a type hint which caused some type errors to show up around its usage (some inconsistent function signatures and small errors)