### PR TITLE
remove extensions dir completly, create it on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,5 @@ fly.toml
 lnbits-backup.zip
 
 # Ignore extensions (post installable extension PR)
-extensions/
+extensions
 upgrades/

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -41,6 +41,9 @@ def main(
     # create data dir if it does not exist
     Path(settings.lnbits_data_folder).mkdir(parents=True, exist_ok=True)
 
+    # create extension dir if it does not exist
+    Path(settings.lnbits_path, "extensions").mkdir(parents=True, exist_ok=True)
+
     set_cli_settings(host=host, port=port, forwarded_allow_ips=forwarded_allow_ips)
 
     # this beautiful beast parses all command line arguments and passes them to the uvicorn server


### PR DESCRIPTION
like we did for the data dir. 
tested works great. 
so no more unstaged git files when you are symlinking into your own extensions dir.