### PR TITLE
optimize balances view

### DIFF
--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -302,3 +302,19 @@ async def m010_create_installed_extensions_table(db):
         );
     """
     )
+
+
+async def m011_optimize_balances_view(db):
+    """
+    Make the calculation of the balance a single aggregation over the payments table instead of 2.
+    """
+    await db.execute("DROP VIEW balances")
+    await db.execute(
+        """
+        CREATE VIEW balances AS
+        SELECT wallet, SUM(amount - abs(fee)) AS balance
+        FROM apipayments
+        WHERE (pending = false AND amount > 0) OR amount < 0
+        GROUP BY wallet
+    """
+    )

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -306,7 +306,8 @@ async def m010_create_installed_extensions_table(db):
 
 async def m011_optimize_balances_view(db):
     """
-    Make the calculation of the balance a single aggregation over the payments table instead of 2.
+    Make the calculation of the balance a single aggregation
+    over the payments table instead of 2.
     """
     await db.execute("DROP VIEW balances")
     await db.execute(


### PR DESCRIPTION
I recently noticed that the `balances` view is a bit more complicated that it has to be. Instead of doing two full row scans over the payments table (once for incoming, once for outgoing) it can be reduced to just one, making it faster and easier to understand.


`EXPLAIN ANALYZE` for old view
```
Finalize GroupAggregate  (cost=6828.51..6876.21 rows=200 width=63) (actual time=61.485..63.383 rows=526 loops=1)
  Group Key: apipayments.wallet
  ->  Gather Merge  (cost=6828.51..6871.16 rows=340 width=63) (actual time=61.460..62.855 rows=749 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        ->  Partial GroupAggregate  (cost=5828.49..5831.89 rows=170 width=63) (actual time=25.640..25.836 rows=250 loops=3)
              Group Key: apipayments.wallet
              ->  Sort  (cost=5828.49..5828.91 rows=170 width=63) (actual time=25.636..25.654 rows=250 loops=3)
                    Sort Key: apipayments.wallet
                    Sort Method: quicksort  Memory: 42kB
                    Worker 0:  Sort Method: quicksort  Memory: 70kB
                    Worker 1:  Sort Method: quicksort  Memory: 25kB
                    ->  Parallel Append  (cost=4990.27..5822.19 rows=170 width=63) (actual time=25.355..25.435 rows=250 loops=3)
                          ->  HashAggregate  (cost=5816.77..5819.31 rows=203 width=63) (actual time=57.160..57.298 rows=526 loops=1)
                                Group Key: apipayments.wallet
                                Worker 0:  Batches: 1  Memory Usage: 185kB
                                ->  Seq Scan on apipayments  (cost=0.00..4971.99 rows=168957 width=39) (actual time=0.013..24.136 rows=170497 loops=1)
                                      Filter: ((NOT pending) AND (amount > 0))
                                      Rows Removed by Filter: 462
                          ->  HashAggregate  (cost=4990.27..4992.80 rows=203 width=63) (actual time=18.902..18.950 rows=223 loops=1)
                                Group Key: apipayments_1.wallet
                                Batches: 1  Memory Usage: 96kB
                                ->  Seq Scan on apipayments apipayments_1  (cost=0.00..4971.99 rows=1828 width=43) (actual time=0.009..18.787 rows=293 loops=1)
                                      Filter: (amount < 0)
                                      Rows Removed by Filter: 170666
Planning Time: 0.159 ms
Execution Time: 63.457 ms
```


`EXPLAIN ANALYZE` for new view
```
Finalize GroupAggregate  (cost=6347.78..6375.18 rows=203 width=63) (actual time=32.934..34.028 rows=526 loops=1)
  Group Key: wallet
  ->  Gather Merge  (cost=6347.78..6371.12 rows=203 width=63) (actual time=32.928..33.681 rows=586 loops=1)
        Workers Planned: 1
        Workers Launched: 1
        ->  Sort  (cost=5347.77..5348.28 rows=203 width=63) (actual time=31.321..31.336 rows=293 loops=2)
              Sort Key: wallet
              Sort Method: quicksort  Memory: 68kB
              Worker 0:  Sort Method: quicksort  Memory: 41kB
              ->  Partial HashAggregate  (cost=5337.45..5339.99 rows=203 width=63) (actual time=31.038..31.108 rows=293 loops=2)
                    Group Key: wallet
                    Batches: 1  Memory Usage: 173kB
                    Worker 0:  Batches: 1  Memory Usage: 64kB
                    ->  Parallel Seq Scan on apipayments  (cost=0.00..4343.46 rows=99399 width=43) (actual time=0.006..12.465 rows=85395 loops=2)
                          Filter: (((NOT pending) AND (amount > 0)) OR (amount < 0))
                          Rows Removed by Filter: 84
Planning Time: 0.101 ms
Execution Time: 34.081 ms
```

Altough neglible for small wallets, adds meaningful time to bigger ones
