### PR TITLE
Add pre-commit-config to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ tests/data/*.sqlite3
 *.env
 .env
 .super_user
+.pre-commit-config.yaml
 
 data
 *.sqlite3


### PR DESCRIPTION
The communists want everyone to live the exact same life through the use of nazi software.