### PR TITLE
add cache utility

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -21,6 +21,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from starlette.responses import JSONResponse
 
+from lnbits.cache import cache
 from lnbits.core.crud import get_installed_extensions
 from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.services import websocketUpdater
@@ -329,6 +330,8 @@ def register_startup(app: FastAPI):
 
             if settings.lnbits_admin_ui:
                 initialize_server_logger()
+
+            asyncio.create_task(cache.invalidate_forever())
 
         except Exception as e:
             logger.error(str(e))

--- a/lnbits/cache.py
+++ b/lnbits/cache.py
@@ -26,7 +26,7 @@ class Cache:
             if cached.expiry > time():
                 return cached.value
             else:
-                self.pop(key)
+                self._values.pop(key)
         return default
 
     def set(self, key: str, value: Any, expiry: float = 10):
@@ -34,7 +34,7 @@ class Cache:
 
     def pop(self, key: str, default=None) -> Optional[Any]:
         cached = self._values.pop(key, None)
-        if cached:
+        if cached and cached.expiry > time():
             return cached.value
         return default
 

--- a/lnbits/cache.py
+++ b/lnbits/cache.py
@@ -50,12 +50,14 @@ class Cache:
             self.set(key, value, expiry=expiry)
             return value
 
-    async def invalidate_forever(self, interval: float = 1):
+    async def invalidate_forever(self, interval: float = 10):
         while True:
             try:
                 await asyncio.sleep(interval)
                 ts = time()
-                self._values = {k: v for k, v in self._values.items() if v.expiry > ts}
+                expired = [k for k, v in self._values.items() if v.expiry < ts]
+                for k in expired:
+                    self._values.pop(k)
             except Exception:
                 logger.error("Error invalidating cache")
 

--- a/lnbits/cache.py
+++ b/lnbits/cache.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import asyncio
+from time import time
+from typing import Any, NamedTuple, Optional
+
+from loguru import logger
+
+
+class Cached(NamedTuple):
+    value: Any
+    expiry: float
+
+
+def _add_prefix(key: str, prefix: str):
+    return prefix + ":" + key if prefix else key
+
+
+class Cache:
+    """
+    Small caching utility providing simple get/set interface (very much like redis)
+    """
+
+    def __init__(self):
+        self._values: dict[Any, Cached] = {}
+
+    def get(self, key: str, prefix: str = "") -> Optional[Any]:
+        cached = self._values.get(_add_prefix(key, prefix))
+        if cached is not None:
+            if cached.expiry > time():
+                return cached.value
+            else:
+                self.pop(key, prefix)
+        return None
+
+    def set(self, key: str, value: Any, expiry: float = 10, prefix: str = ""):
+        self._values[_add_prefix(key, prefix)] = Cached(value, time() + expiry)
+
+    def pop(self, key: str, prefix: str = "", default=None) -> Optional[Any]:
+        cached = self._values.pop(_add_prefix(key, prefix), None)
+        if cached:
+            return cached.value
+        return default
+
+    async def save_result(self, coro, key: str, expiry: float = 10, prefix: str = ""):
+        """
+        Call the coroutine and cache its result
+        """
+        cached = self.get(key, prefix)
+        if cached:
+            return cached
+        else:
+            value = await coro()
+            self.set(key, value, expiry=expiry, prefix=prefix)
+            return value
+
+    async def invalidate_forever(self, interval: float = 1):
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                ts = time()
+                self._values = {k: v for k, v in self._values.items() if v.expiry > ts}
+            except Exception:
+                logger.error("Error invalidating cache")
+
+
+cache = Cache()

--- a/lnbits/cache.py
+++ b/lnbits/cache.py
@@ -20,7 +20,7 @@ class Cache:
     def __init__(self):
         self._values: dict[Any, Cached] = {}
 
-    def get(self, key: str, default: Any = None) -> Optional[Any]:
+    def get(self, key: str, default=None) -> Optional[Any]:
         cached = self._values.get(key)
         if cached is not None:
             if cached.expiry > time():

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -1,0 +1,61 @@
+import asyncio
+
+import pytest
+
+from lnbits.cache import Cache
+from tests.conftest import pytest_asyncio
+
+
+@pytest_asyncio.fixture(scope="session")
+async def cache():
+    cache = Cache()
+
+    task = asyncio.create_task(cache.invalidate_forever(interval=0.1))
+    yield cache
+    task.cancel()
+
+
+key = "foo"
+value = "bar"
+
+
+@pytest.mark.asyncio
+async def test_cache_get_set(cache):
+    cache.set(key, value)
+    assert cache.get(key) == value
+
+
+@pytest.mark.asyncio
+async def test_cache_expiry(cache):
+    cache.set(key, value, expiry=0.1)
+    await asyncio.sleep(0.2)
+    assert not cache.get(key)
+
+
+@pytest.mark.asyncio
+async def test_cache_pop(cache):
+    cache.set(key, value)
+    assert cache.pop(key) == value
+    assert not cache.get(key)
+    assert cache.pop(key, default="a") == "a"
+
+
+@pytest.mark.asyncio
+async def test_cache_prefix(cache):
+    cache.set(key, value, prefix="a")
+    assert cache.get(key, prefix="a") == value
+    assert not cache.get(key)
+
+
+@pytest.mark.asyncio
+async def test_cache_coro(cache):
+    called = 0
+
+    async def test():
+        nonlocal called
+        called += 1
+        return called
+
+    await cache.save_result(test, key="test")
+    result = await cache.save_result(test, key="test")
+    assert result == called == 1

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -23,6 +23,8 @@ value = "bar"
 async def test_cache_get_set(cache):
     cache.set(key, value)
     assert cache.get(key) == value
+    assert cache.get(key, default="default") == value
+    assert cache.get("i-dont-exist", default="default") == "default"
 
 
 @pytest.mark.asyncio
@@ -38,13 +40,6 @@ async def test_cache_pop(cache):
     assert cache.pop(key) == value
     assert not cache.get(key)
     assert cache.pop(key, default="a") == "a"
-
-
-@pytest.mark.asyncio
-async def test_cache_prefix(cache):
-    cache.set(key, value, prefix="a")
-    assert cache.get(key, prefix="a") == value
-    assert not cache.get(key)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pr introduces a simple redis-like cache utility.

### Possible use cases:

- temporary caching of exchange rates, especially usefull with something like https://github.com/lnbits/lnbits/pull/1789
- caching node peer information or payment history in cln at https://github.com/lnbits/lnbits/pull/1702
- improving api key validation which currently queries the entire wallet, including balance, see: https://github.com/lnbits/lnbits/blob/bc55d52ea25475a524059fccbc5a35039f8be533/lnbits/decorators.py#L52-L55
