### PR TITLE
cancel all long-running tasks

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -357,7 +357,7 @@ def initialize_server_logger():
             msg = await serverlog_queue.get()
             await websocketUpdater(super_user_hash, msg)
 
-    asyncio.create_task(update_websocket_serverlog())
+    create_permanent_task(update_websocket_serverlog)
 
     logger.add(
         lambda msg: serverlog_queue.put_nowait(msg),

--- a/lnbits/core/tasks.py
+++ b/lnbits/core/tasks.py
@@ -5,7 +5,12 @@ import httpx
 from loguru import logger
 
 from lnbits.settings import get_wallet_class, settings
-from lnbits.tasks import SseListenersDict, register_invoice_listener
+from lnbits.tasks import (
+    SseListenersDict,
+    create_permanent_task,
+    create_task,
+    register_invoice_listener,
+)
 
 from . import db
 from .crud import get_balance_notify, get_wallet
@@ -20,24 +25,13 @@ killswitch: Optional[asyncio.Task] = None
 watchdog: Optional[asyncio.Task] = None
 
 
-async def register_killswitch():
+def register_killswitch():
     """
     Registers a killswitch which will check lnbits-status repository
     for a signal from LNbits and will switch to VoidWallet if the killswitch is triggered.
     """
     logger.debug("Starting killswitch task")
-    global killswitch
-    killswitch = asyncio.create_task(killswitch_task())
-
-
-async def unregister_killswitch():
-    """
-    Unregisters a killswitch taskl
-    """
-    global killswitch
-    if killswitch:
-        logger.debug("Stopping killswitch task")
-        killswitch.cancel()
+    create_permanent_task(killswitch_task)
 
 
 async def killswitch_task():
@@ -73,16 +67,6 @@ async def register_watchdog():
     # watchdog = asyncio.create_task(watchdog_task())
 
 
-async def unregister_watchdog():
-    """
-    Unregisters a watchdog task
-    """
-    global watchdog
-    if watchdog:
-        logger.debug("Stopping watchdog task")
-        watchdog.cancel()
-
-
 async def watchdog_task():
     while True:
         WALLET = get_wallet_class()
@@ -98,7 +82,7 @@ async def watchdog_task():
         await asyncio.sleep(settings.lnbits_watchdog_interval * 60)
 
 
-async def register_task_listeners():
+def register_task_listeners():
     """
     Registers an invoice listener queue for the core tasks.
     Incoming payaments in this queue will eventually trigger the signals sent to all other extensions
@@ -108,7 +92,7 @@ async def register_task_listeners():
     # we register invoice_paid_queue to receive all incoming invoices
     register_invoice_listener(invoice_paid_queue, "core/tasks.py")
     # register a worker that will react to invoices
-    asyncio.create_task(wait_for_paid_invoices(invoice_paid_queue))
+    create_task(wait_for_paid_invoices(invoice_paid_queue))
 
 
 async def wait_for_paid_invoices(invoice_paid_queue: asyncio.Queue):

--- a/lnbits/core/tasks.py
+++ b/lnbits/core/tasks.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, Optional
+from typing import Dict
 
 import httpx
 from loguru import logger
@@ -21,14 +21,11 @@ api_invoice_listeners: Dict[str, asyncio.Queue] = SseListenersDict(
     "api_invoice_listeners"
 )
 
-killswitch: Optional[asyncio.Task] = None
-watchdog: Optional[asyncio.Task] = None
-
 
 def register_killswitch():
     """
-    Registers a killswitch which will check lnbits-status repository
-    for a signal from LNbits and will switch to VoidWallet if the killswitch is triggered.
+    Registers a killswitch which will check lnbits-status repository for a signal from
+    LNbits and will switch to VoidWallet if the killswitch is triggered.
     """
     logger.debug("Starting killswitch task")
     create_permanent_task(killswitch_task)
@@ -61,10 +58,9 @@ async def register_watchdog():
     Registers a watchdog which will check lnbits balance and nodebalance
     and will switch to VoidWallet if the watchdog delta is reached.
     """
-    # TODO: implement watchdog porperly
+    # TODO: implement watchdog properly
     # logger.debug("Starting watchdog task")
-    # global watchdog
-    # watchdog = asyncio.create_task(watchdog_task())
+    # create_permanent_task(watchdog_task)
 
 
 async def watchdog_task():

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -22,8 +22,8 @@ from .core import db
 tasks: List[asyncio.Task] = []
 
 
-def create_task(coro_or_fut):
-    task = asyncio.create_task(coro_or_fut)
+def create_task(func):
+    task = asyncio.create_task(func)
     tasks.append(task)
     return task
 
@@ -34,7 +34,10 @@ def create_permanent_task(func):
 
 def cancel_all_tasks():
     for task in tasks:
-        task.cancel()
+        try:
+            task.cancel()
+        except Exception as exc:
+            logger.warning(f"error while cancelling task: {str(exc)}")
 
 
 async def catch_everything_and_restart(func):

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -22,8 +22,8 @@ from .core import db
 tasks: List[asyncio.Task] = []
 
 
-def create_task(func):
-    task = asyncio.create_task(func)
+def create_task(coro):
+    task = asyncio.create_task(coro)
     tasks.append(task)
     return task
 

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -3,7 +3,7 @@ import time
 import traceback
 import uuid
 from http import HTTPStatus
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from fastapi.exceptions import HTTPException
 from loguru import logger
@@ -18,6 +18,23 @@ from lnbits.core.services import redeem_lnurl_withdraw
 from lnbits.wallets import get_wallet_class
 
 from .core import db
+
+tasks: List[asyncio.Task] = []
+
+
+def create_task(coro_or_fut):
+    task = asyncio.create_task(coro_or_fut)
+    tasks.append(task)
+    return task
+
+
+def create_permanent_task(func):
+    return create_task(catch_everything_and_restart(func))
+
+
+def cancel_all_tasks():
+    for task in tasks:
+        task.cancel()
 
 
 async def catch_everything_and_restart(func):


### PR DESCRIPTION
Not all long-running tasks are cancelled upon shutdown, which caused some issues with `WALLET.cleanup`.

I introduced a few new functions:

- `create_task` basically a wrapper around the asyncio equivalent, adds the task to a list
- `cancel_all_tasks` cancels all tasks previously created with `create_task` (if any are already stopped, `cancel` will do nothing)
- `create_permanent_task` wrapper around `create_task` with `catch_everything_and_restart`

Now all tasks are cancelled on shutdown and `WALLET.cleanup` goes without errors.
