### PR TITLE
remove db lock

### DIFF
--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -259,9 +259,7 @@ class Database(Compat):
                             f"CREATE SCHEMA IF NOT EXISTS {self.schema}"
                         )
                     elif self.type == SQLITE:
-                        await wconn.execute(
-                            f"ATTACH '{self.path}' AS {self.schema}"
-                        )
+                        await wconn.execute(f"ATTACH '{self.path}' AS {self.schema}")
 
                 yield wconn
 


### PR DESCRIPTION
When playing around with the legend server I noticed that api response times seem to spike up significantly at random times (ranging from 80ms all the way to 1s).

Doing a bit of investigation I suspected the cause being the `asyncio.Lock` which is put around the db. 
https://github.com/lnbits/lnbits/blob/e13426a56b579d228e83e59726f5ec8f75846ffe/lnbits/db.py#L254-L256

Take this for example:
https://github.com/lnbits/lnbits/blob/e13426a56b579d228e83e59726f5ec8f75846ffe/lnbits/core/views/api.py#L227-L244

During the entire duration of the `create_invoice` call no other request can be processed because the db is locked which can cause big latency spikes.

To confirm this I used postman to do a little load test on a local instance (added 300ms artificial delay in fake wallet to simulate a real one).
Creating and reading payments with just 2 users simultaneously caused payment creation calls to take up to 867 ms compared to ~380 ms when isolated.

The simple fix:
just get rid of it.

Response times are are now consistent, even with concurrent requests.

Postgres doesnt have any problems with concurrency at all - so no issue here.

Sqlite supports concurrent readers, altough no concurrent writers. But we don't need to take care of locking it. When sqlite3 cant lock the db for a write transaction it simply waits a bit (default 5 seconds) until it actually throws as an error. 
This condition should never occur unless hundreds of users try to create invoices at the same time - which will probably not happen, and if it would youd be using postgres anyways. 

I tested 20 simultaneous users on sqlite and no errors came up (latency now  starts to spike again - but that can be expected when served from a single python worker)
