### PR TITLE
Fix admin notifications

### DIFF
--- a/lnbits/core/templates/admin/_tab_funding.html
+++ b/lnbits/core/templates/admin/_tab_funding.html
@@ -47,7 +47,8 @@
               <p>Invoice Expiry</p>
               <q-input
                 filled
-                v-model="formData.lightning_invoice_expiry"
+                v-model.number="formData.lightning_invoice_expiry"
+                type="number"
                 label="Invoice expiry (seconds)"
                 mask="#######"
               >

--- a/lnbits/core/templates/admin/index.html
+++ b/lnbits/core/templates/admin/index.html
@@ -376,7 +376,7 @@
         ])
       }
     },
-    created: function () {
+    created() {
       this.getSettings()
       this.getAudit()
       this.balance = +'{{ balance|safe }}'
@@ -593,7 +593,7 @@
           .then(response => {
             this.isSuperUser = response.data.is_super_user || false
             this.settings = response.data
-            this.formData = _.clone(this.settings)
+            this.formData = {...this.settings}
             this.updateFundingData()
             this.getNotifications()
           })
@@ -624,7 +624,9 @@
             this.updateFundingData()
             this.$q.notify({
               type: 'positive',
-              message: 'Success! Settings changed!',
+              message: `Success! Settings changed! ${
+                this.needsRestart ? 'Restart required!' : ''
+              }`,
               icon: null
             })
           })


### PR DESCRIPTION
Fix the save badge (red dot) being always on. Made the invoice expiry input as number, as the settings, so that the settings and the formData are equal, and don't trigger the badge!

Make a deep copy (not sure it's necessary, but `_.clone()` makes a shallow copy, and it can be done with vanilla js *maybe we could discard underscore **one less lib dependency)

Add a restart note when/if the settings changed require a server restart!

Closes #1801 