### PR TITLE
[FEAT] make db lock optional

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -24,6 +24,7 @@ from lnbits.core.crud import get_installed_extensions
 from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.services import websocketUpdater
 from lnbits.core.tasks import (  # register_watchdog,; unregister_watchdog,
+    payment_processor,
     register_killswitch,
     register_task_listeners,
 )
@@ -427,6 +428,7 @@ def register_async_tasks(app):
         create_permanent_task(invoice_listener)
         create_permanent_task(internal_invoice_listener)
         create_permanent_task(cache.invalidate_forever)
+        create_permanent_task(payment_processor)
         register_task_listeners()
         register_killswitch()
         # await run_deferred_async() # calle: doesn't do anyting?

--- a/lnbits/core/db.py
+++ b/lnbits/core/db.py
@@ -1,5 +1,5 @@
 from lnbits.core.models import CoreAppExtra
 from lnbits.db import Database
 
-db = Database("database")
+db = Database("database", use_lock=False)
 core_app_extra: CoreAppExtra = CoreAppExtra()

--- a/lnbits/core/tasks.py
+++ b/lnbits/core/tasks.py
@@ -143,6 +143,185 @@ async def dispatch_api_invoice_listeners(payment: Payment):
             api_invoice_listeners.pop(chan_name)
 
 
+async def pay_invoice(
+    *,
+    wallet_id: str,
+    payment_request: str,
+    max_sat: Optional[int] = None,
+    extra: Optional[Dict] = None,
+    description: str = "",
+    conn: Optional[Connection] = None,
+) -> str:
+    """
+    Pay a Lightning invoice.
+    First, we create a temporary payment in the database with fees set to the reserve
+    fee. We then check whether the balance of the payer would go negative.
+    We then attempt to pay the invoice through the backend. If the payment is
+    successful, we update the payment in the database with the payment details.
+    If the payment is unsuccessful, we delete the temporary payment.
+    If the payment is still in flight, we hope that some other process
+    will regularly check for the payment.
+    """
+    invoice = bolt11.decode(payment_request)
+    fee_reserve_msat = fee_reserve(invoice.amount_msat)
+    async with db.reuse_conn(conn) if conn else db.connect() as conn:
+        temp_id = invoice.payment_hash
+        internal_id = f"internal_{invoice.payment_hash}"
+
+        if invoice.amount_msat == 0:
+            raise ValueError("Amountless invoices not supported.")
+        if max_sat and invoice.amount_msat > max_sat * 1000:
+            raise ValueError("Amount in invoice is too high.")
+
+        _, extra = await calculate_fiat_amounts(
+            invoice.amount_msat / 1000, wallet_id, extra=extra, conn=conn
+        )
+
+        # put all parameters that don't change here
+        class PaymentKwargs(TypedDict):
+            wallet_id: str
+            payment_request: str
+            payment_hash: str
+            amount: int
+            memo: str
+            extra: Optional[Dict]
+
+        payment_kwargs: PaymentKwargs = PaymentKwargs(
+            wallet_id=wallet_id,
+            payment_request=payment_request,
+            payment_hash=invoice.payment_hash,
+            amount=-invoice.amount_msat,
+            memo=description or invoice.description or "",
+            extra=extra,
+        )
+
+        # we check if an internal invoice exists that has already been paid
+        # (not pending anymore)
+        if not await check_internal_pending(invoice.payment_hash, conn=conn):
+            raise PaymentFailure("Internal invoice already paid.")
+
+        # check_internal() returns the checking_id of the invoice we're waiting for
+        # (pending only)
+        internal_checking_id = await check_internal(invoice.payment_hash, conn=conn)
+        if internal_checking_id:
+            # perform additional checks on the internal payment
+            # the payment hash is not enough to make sure that this is the same invoice
+            internal_invoice = await get_standalone_payment(
+                internal_checking_id, incoming=True, conn=conn
+            )
+            assert internal_invoice is not None
+            if (
+                internal_invoice.amount != invoice.amount_msat
+                or internal_invoice.bolt11 != payment_request.lower()
+            ):
+                raise PaymentFailure("Invalid invoice.")
+
+            logger.debug(f"creating temporary internal payment with id {internal_id}")
+            # create a new payment from this wallet
+            new_payment = await create_payment(
+                checking_id=internal_id,
+                fee=0,
+                pending=False,
+                conn=conn,
+                **payment_kwargs,
+            )
+        else:
+            logger.debug(f"creating temporary payment with id {temp_id}")
+            # create a temporary payment here so we can check if
+            # the balance is enough in the next step
+            try:
+                new_payment = await create_payment(
+                    checking_id=temp_id,
+                    fee=-fee_reserve_msat,
+                    conn=conn,
+                    **payment_kwargs,
+                )
+            except Exception as e:
+                logger.error(f"could not create temporary payment: {e}")
+                # happens if the same wallet tries to pay an invoice twice
+                raise PaymentFailure("Could not make payment.")
+
+        # do the balance check
+        wallet = await get_wallet(wallet_id, conn=conn)
+        assert wallet, "Wallet for balancecheck could not be fetched"
+        if wallet.balance_msat < 0:
+            logger.debug("balance is too low, deleting temporary payment")
+            if not internal_checking_id and wallet.balance_msat > -fee_reserve_msat:
+                raise PaymentFailure(
+                    f"You must reserve at least ({round(fee_reserve_msat/1000)} sat) to"
+                    " cover potential routing fees."
+                )
+            raise PermissionError("Insufficient balance.")
+
+    if internal_checking_id:
+        logger.debug(f"marking temporary payment as not pending {internal_checking_id}")
+        # mark the invoice from the other side as not pending anymore
+        # so the other side only has access to his new money when we are sure
+        # the payer has enough to deduct from
+        async with db.connect() as conn:
+            await update_payment_status(
+                checking_id=internal_checking_id, pending=False, conn=conn
+            )
+        await send_payment_notification(wallet, new_payment)
+
+        # notify receiver asynchronously
+        from lnbits.tasks import internal_invoice_queue
+
+        logger.debug(f"enqueuing internal invoice {internal_checking_id}")
+        await internal_invoice_queue.put(internal_checking_id)
+    else:
+        logger.debug(f"backend: sending payment {temp_id}")
+        # actually pay the external invoice
+        WALLET = get_wallet_class()
+        payment: PaymentResponse = await WALLET.pay_invoice(
+            payment_request, fee_reserve_msat
+        )
+
+        if payment.checking_id and payment.checking_id != temp_id:
+            logger.warning(
+                f"backend sent unexpected checking_id (expected: {temp_id} got:"
+                f" {payment.checking_id})"
+            )
+
+        logger.debug(f"backend: pay_invoice finished {temp_id}")
+        if payment.checking_id and payment.ok is not False:
+            # payment.ok can be True (paid) or None (pending)!
+            logger.debug(f"updating payment {temp_id}")
+            async with db.connect() as conn:
+                await update_payment_details(
+                    checking_id=temp_id,
+                    pending=payment.ok is not True,
+                    fee=payment.fee_msat,
+                    preimage=payment.preimage,
+                    new_checking_id=payment.checking_id,
+                    conn=conn,
+                )
+                wallet = await get_wallet(wallet_id, conn=conn)
+                updated = await get_wallet_payment(
+                    wallet_id, payment.checking_id, conn=conn
+                )
+                if wallet and updated:
+                    await send_payment_notification(wallet, updated)
+                logger.debug(f"payment successful {payment.checking_id}")
+        elif payment.checking_id is None and payment.ok is False:
+            # payment failed
+            logger.warning("backend sent payment failure")
+            async with db.connect() as conn:
+                logger.debug(f"deleting temporary payment {temp_id}")
+                await delete_wallet_payment(temp_id, wallet_id, conn=conn)
+            raise PaymentFailure(
+                f"Payment failed: {payment.error_message}"
+                or "Payment failed, but backend didn't give us an error message."
+            )
+        else:
+            logger.warning(
+                "didn't receive checking_id from backend, payment may be stuck in"
+                f" database: {temp_id}"
+            )
+
+    return invoice.payment_hash
+
+
 async def dispatch_webhook(payment: Payment):
     """
     Dispatches the webhook to the webhook url.

--- a/lnbits/core/tasks.py
+++ b/lnbits/core/tasks.py
@@ -332,6 +332,7 @@ async def _process_payment(job: PaymentJob) -> str:
 async def payment_processor():
     while True:
         job = await payment_queue.get()
+        logger.debug(f"processing payment {job=}")
         try:
             payment = await _process_payment(job)
             job.fut.set_result(payment)

--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -237,7 +237,7 @@ class Database(Compat):
             self.schema = None
 
         self.engine = create_engine(database_uri, strategy=ASYNCIO_STRATEGY)
-        self.use_lock = use_lock
+        self.use_lock = use_lock or self.type == SQLITE
         self.lock = asyncio.Lock()
 
         logger.trace(f"database {self.type} added for {self.name}")

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -184,7 +184,7 @@ class CoreLightningRestWallet(Wallet):
             return PaymentStatus(None)
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
-        from lnbits.core.services import get_standalone_payment
+        from lnbits.core.crud import get_standalone_payment
 
         payment = await get_standalone_payment(checking_id)
         if not payment:


### PR DESCRIPTION
another approach to https://github.com/lnbits/lnbits/pull/1802

This allows turning off the lock on a per-database level. This allows us to remove it from the core database, making sure no problems arise while extensions remain unaffected.

Removing the lock would make the payments api vulnerable due to race conditions. This can be avoided by sequential processing in a seperate task.