### PR TITLE
Increase default invoice expiry to 1 hour

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,7 @@ LNBITS_BACKEND_WALLET_CLASS=VoidWallet
 # just so you can see the UI before dealing with this file.
 
 # Invoice expiry for LND, CLN, Eclair, LNbits funding sources
-LIGHTNING_INVOICE_EXPIRY=600
+LIGHTNING_INVOICE_EXPIRY=3600
 
 # Set one of these blocks depending on the wallet kind you chose above:
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -199,7 +199,7 @@ class BoltzExtensionSettings(LNbitsSettings):
 
 
 class LightningSettings(LNbitsSettings):
-    lightning_invoice_expiry: int = Field(default=600)
+    lightning_invoice_expiry: int = Field(default=3600)
 
 
 class FundingSourcesSettings(


### PR DESCRIPTION
default is 600 = 10 minutes, which is a pretty short amount of time, for example when using lnbits fundingsource inside lnbits itself it would fail if you do a submarine swap or anything involved with hold invoices

i think 3600 = 1 hour should not make a difference in performance and is a way more reasonable default expiry