### PR TITLE
Add deleted flag wallet

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -253,11 +253,8 @@ async def delete_wallet(
 ) -> None:
     await (conn or db).execute(
         """
-        UPDATE wallets AS w
-        SET
-            "user" = 'del:' || w."user",
-            adminkey = 'del:' || w.adminkey,
-            inkey = 'del:' || w.inkey
+        UPDATE wallets
+        SET deleted = true
         WHERE id = ? AND "user" = ?
         """,
         (wallet_id, user_id),

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -290,7 +290,10 @@ async def get_wallet_for_key(
 
     if not row:
         return None
-
+    
+    if row["deleted"]:
+        return None
+    
     if key_type == "admin" and row["adminkey"] != key:
         return None
 

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -301,3 +301,53 @@ async def m010_create_installed_extensions_table(db):
         );
     """
     )
+
+async def m011_add_deleted_to_wallets(db):
+    """
+    Adds deleted column to wallets.
+    """
+    try:
+        await db.execute("ALTER TABLE wallets ADD COLUMN deleted BOOLEAN")
+    except OperationalError:
+        pass
+
+async def m012_set_deleted_wallets(db):
+    """
+    Sets deleted column to wallets.
+    """
+    try:
+        rows = await (
+            await db.execute(
+                f"""
+                SELECT *
+                FROM wallets
+                WHERE user LIKE 'del:%'
+                AND adminkey LIKE 'del:%'
+                AND inkey LIKE 'del:%'
+                """
+            
+            )
+        ).fetchall()
+        
+        for row in rows:
+            try:
+                user = row[2].split(":")[1]
+                adminkey = row[3].split(":")[1]
+                inkey = row[4].split(":")[1]
+                await db.execute(
+                    """
+                    UPDATE wallets SET user = ?, adminkey = ?, inkey = ?, deleted = true
+                    WHERE id = ?
+                    """,
+                    (
+                        user, adminkey, inkey, row[0]
+                    ),
+                )
+            except:
+                continue
+    except OperationalError:
+        # this is necessary now because it may be the case that this migration will
+        # run twice in some environments.
+        # catching errors like this won't be necessary in anymore now that we
+        # keep track of db versions so no migration ever runs twice.
+        pass


### PR DESCRIPTION
Adds a `deleted` column to wallets DB.

On `deleteWallet`, set flag to `true` don't prefix keys with `del:`

Invalidate wallet on KeyChecker if wallet is deleted, makes all request dependent on wallet key `Depends(...)` fail if wallet is deleted!

Closes #1706 