### PR TITLE
Wallets: Catch errors during cleanup

### DIFF
--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -46,7 +46,7 @@ class EclairWallet(Wallet):
     async def cleanup(self):
         try:
             await self.client.aclose()
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -44,7 +44,10 @@ class EclairWallet(Wallet):
         self.client = httpx.AsyncClient(base_url=self.url, headers=self.auth)
 
     async def cleanup(self):
-        await self.client.aclose()
+        try:
+            await self.client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:
         r = await self.client.post("/globalbalance", timeout=5)

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -32,7 +32,10 @@ class LNbitsWallet(Wallet):
         self.client = httpx.AsyncClient(base_url=self.endpoint, headers=self.key)
 
     async def cleanup(self):
-        await self.client.aclose()
+        try:
+            await self.client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:
         try:

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -34,7 +34,7 @@ class LNbitsWallet(Wallet):
     async def cleanup(self):
         try:
             await self.client.aclose()
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -71,7 +71,7 @@ class LndRestWallet(Wallet):
     async def cleanup(self):
         try:
             await self.client.aclose()
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -69,7 +69,10 @@ class LndRestWallet(Wallet):
         )
 
     async def cleanup(self):
-        await self.client.aclose()
+        try:
+            await self.client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:
         try:

--- a/lnbits/wallets/lnpay.py
+++ b/lnbits/wallets/lnpay.py
@@ -35,7 +35,10 @@ class LNPayWallet(Wallet):
         self.client = httpx.AsyncClient(base_url=self.endpoint, headers=self.auth)
 
     async def cleanup(self):
-        await self.client.aclose()
+        try:
+            await self.client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:
         url = f"/wallet/{self.wallet_key}"

--- a/lnbits/wallets/lnpay.py
+++ b/lnbits/wallets/lnpay.py
@@ -37,7 +37,7 @@ class LNPayWallet(Wallet):
     async def cleanup(self):
         try:
             await self.client.aclose()
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:

--- a/lnbits/wallets/lntips.py
+++ b/lnbits/wallets/lntips.py
@@ -33,7 +33,10 @@ class LnTipsWallet(Wallet):
         self.client = httpx.AsyncClient(base_url=self.endpoint, headers=self.auth)
 
     async def cleanup(self):
-        await self.client.aclose()
+        try:
+            await self.client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:
         r = await self.client.get("/api/v1/balance", timeout=40)

--- a/lnbits/wallets/lntips.py
+++ b/lnbits/wallets/lntips.py
@@ -35,7 +35,7 @@ class LnTipsWallet(Wallet):
     async def cleanup(self):
         try:
             await self.client.aclose()
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:

--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -37,7 +37,10 @@ class OpenNodeWallet(Wallet):
         self.client = httpx.AsyncClient(base_url=self.endpoint, headers=self.auth)
 
     async def cleanup(self):
-        await self.client.aclose()
+        try:
+            await self.client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:
         try:

--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -39,7 +39,7 @@ class OpenNodeWallet(Wallet):
     async def cleanup(self):
         try:
             await self.client.aclose()
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(f"Error closing wallet connection: {e}")
 
     async def status(self) -> StatusResponse:

--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -39,7 +39,7 @@ class SparkWallet(Wallet):
     async def cleanup(self):
         try:
             await self.client.aclose()
-        except Exception as e:
+        except RuntimeError as e:
             logger.warning(f"Error closing wallet connection: {e}")
 
     def __getattr__(self, key):

--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -37,7 +37,10 @@ class SparkWallet(Wallet):
         )
 
     async def cleanup(self):
-        await self.client.aclose()
+        try:
+            await self.client.aclose()
+        except Exception as e:
+            logger.warning(f"Error closing wallet connection: {e}")
 
     def __getattr__(self, key):
         async def call(*args, **kwargs):


### PR DESCRIPTION
Leads to ugly stack traces when the cleanup routine is called while `paid_invoice_stream` is still streaming.

Example:
<img width="1283" alt="image" src="https://github.com/lnbits/lnbits/assets/93376500/5416e4ba-f02d-41dd-9807-5ba96e4b2188">
