### PR TITLE
websocket internal payment notifications

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -44,7 +44,7 @@ from .crud import (
     update_super_user,
 )
 from .helpers import to_valid_user_id
-from .models import Payment
+from .models import Payment, Wallet
 
 
 class PaymentFailure(Exception):
@@ -429,6 +429,18 @@ def fee_reserve(amount_msat: int) -> int:
     reserve_min = settings.lnbits_reserve_fee_min
     reserve_percent = settings.lnbits_reserve_fee_percent
     return max(int(reserve_min), int(amount_msat * reserve_percent / 100.0))
+
+
+async def send_payment_notification(wallet: Wallet, payment: Payment):
+    await websocketUpdater(
+        wallet.id,
+        json.dumps(
+            {
+                "wallet_balance": wallet.balance,
+                "payment": payment.dict(),
+            }
+        ),
+    )
 
 
 async def update_wallet_balance(wallet_id: str, amount: int):

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -249,7 +249,9 @@ async def pay_invoice(
                     conn=conn,
                 )
                 wallet = await get_wallet(wallet_id, conn=conn)
-                updated = await get_wallet_payment(wallet_id, payment.checking_id, conn=conn)
+                updated = await get_wallet_payment(
+                    wallet_id, payment.checking_id, conn=conn
+                )
                 if wallet and updated:
                     await send_payment_notification(wallet, updated)
                 logger.debug(f"payment successful {payment.checking_id}")

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -172,7 +172,7 @@ async def pay_invoice(
 
             logger.debug(f"creating temporary internal payment with id {internal_id}")
             # create a new payment from this wallet
-            await create_payment(
+            new_payment = await create_payment(
                 checking_id=internal_id,
                 fee=0,
                 pending=False,
@@ -184,7 +184,7 @@ async def pay_invoice(
             # create a temporary payment here so we can check if
             # the balance is enough in the next step
             try:
-                await create_payment(
+                new_payment = await create_payment(
                     checking_id=temp_id,
                     fee=-fee_reserve_msat,
                     conn=conn,
@@ -215,6 +215,7 @@ async def pay_invoice(
             await update_payment_status(
                 checking_id=internal_checking_id, pending=False, conn=conn
             )
+        await send_payment_notification(wallet, new_payment)
 
         # notify receiver asynchronously
         from lnbits.tasks import internal_invoice_queue
@@ -248,16 +249,9 @@ async def pay_invoice(
                     conn=conn,
                 )
                 wallet = await get_wallet(wallet_id, conn=conn)
-                if wallet:
-                    await websocketUpdater(
-                        wallet_id,
-                        json.dumps(
-                            {
-                                "wallet_balance": wallet.balance or None,
-                                "payment": payment._asdict(),
-                            }
-                        ),
-                    )
+                updated = await get_wallet_payment(wallet_id, payment.checking_id, conn=conn)
+                if wallet and updated:
+                    await send_payment_notification(wallet, updated)
                 logger.debug(f"payment successful {payment.checking_id}")
         elif payment.checking_id is None and payment.ok is False:
             # payment failed

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -112,14 +112,28 @@ async def test_create_invoice_custom_expiry(client, inkey_headers_to):
 
 # check POST /api/v1/payments: make payment
 @pytest.mark.asyncio
-async def test_pay_invoice(client, invoice, adminkey_headers_from):
+async def test_pay_invoice(
+    client, from_wallet_ws, to_wallet_ws, invoice, adminkey_headers_from
+):
     data = {"out": True, "bolt11": invoice["payment_request"]}
     response = await client.post(
         "/api/v1/payments", json=data, headers=adminkey_headers_from
     )
     assert response.status_code < 300
-    assert len(response.json()["payment_hash"]) == 64
-    assert len(response.json()["checking_id"]) > 0
+    invoice = response.json()
+    assert len(invoice["payment_hash"]) == 64
+    assert len(invoice["checking_id"]) > 0
+
+    data = from_wallet_ws.receive_json()
+    assert "wallet_balance" in data
+    payment = Payment(**data["payment"])
+    assert payment.payment_hash == invoice["payment_hash"]
+
+    # websocket from to_wallet cant be tested before https://github.com/lnbits/lnbits/pull/1793
+    # data = to_wallet_ws.receive_json()
+    # assert "wallet_balance" in data
+    # payment = Payment(**data["payment"])
+    # assert payment.payment_hash == invoice["payment_hash"]
 
 
 # check GET /api/v1/payments/<hash>: payment status
@@ -329,7 +343,7 @@ async def get_node_balance_sats():
 @pytest.mark.asyncio
 @pytest.mark.skipif(is_fake, reason="this only works in regtest")
 async def test_pay_real_invoice(
-    client, real_invoice, adminkey_headers_from, inkey_headers_from
+    client, real_invoice, adminkey_headers_from, inkey_headers_from, from_wallet_ws
 ):
     prev_balance = await get_node_balance_sats()
     response = await client.post(
@@ -339,6 +353,11 @@ async def test_pay_real_invoice(
     invoice = response.json()
     assert len(invoice["payment_hash"]) == 64
     assert len(invoice["checking_id"]) > 0
+
+    data = from_wallet_ws.receive_json()
+    assert "wallet_balance" in data
+    payment = Payment(**data["payment"])
+    assert payment.payment_hash == invoice["payment_hash"]
 
     # check the payment status
     response = await api_payment(


### PR DESCRIPTION
fixes: https://github.com/lnbits/lnbits/issues/1820

I introduced a `send_payment_notification` service because this logic is now needed in three seperate places in order to avoid inconsistent messages. Now all messages inclue the whole payment information ( `payment.dict`) which could be considered a breaking change (outgoing had the structure of `PaymentResponse`.