### PR TITLE
Ads layout fix

### DIFF
--- a/lnbits/core/templates/core/index.html
+++ b/lnbits/core/templates/core/index.html
@@ -159,10 +159,7 @@
               ></q-img>
             </a>
           </div>
-          <div class="col q-pl-md"></div>
-        </div>
-        <div class="row">
-          <div class="col">
+          <div class="col q-pl-md">
             <a href="https://voltage.cloud">
               <q-img
                 contain
@@ -170,7 +167,6 @@
               ></q-img>
             </a>
           </div>
-          <div class="col q-pl-md"></div>
         </div>
       </div>
 


### PR DESCRIPTION
Layout fix for #1834:
<div style="display:flex;">
  <br><img src="https://github.com/lnbits/lnbits/assets/3606313/ab6a603f-9e6b-41c9-8f8a-088e66195431" width="45%" />
  ➡️<img src="https://github.com/lnbits/lnbits/assets/3606313/8ca87695-1930-4d09-819f-dea3624234cb" width="45%" />
</div>
