### PR TITLE
Tests: hold invoice tests pending during payment

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -318,9 +318,12 @@ async def api_payments_create(
                 status_code=HTTPStatus.BAD_REQUEST,
                 detail="BOLT11 string is invalid or not given",
             )
-        return await api_payments_pay_invoice(
-            invoiceData.bolt11, wallet.wallet
-        )  # admin key
+        try:
+            return await api_payments_pay_invoice(
+                invoiceData.bolt11, wallet.wallet
+            )  # admin key
+        except Exception as exc:
+            raise HTTPException(status_code=520, detail=str(exc))
     elif not invoiceData.out:
         # invoice key
         return await api_payments_create_invoice(invoiceData, wallet.wallet)

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -318,12 +318,9 @@ async def api_payments_create(
                 status_code=HTTPStatus.BAD_REQUEST,
                 detail="BOLT11 string is invalid or not given",
             )
-        try:
-            return await api_payments_pay_invoice(
-                invoiceData.bolt11, wallet.wallet
-            )  # admin key
-        except Exception as exc:
-            raise HTTPException(status_code=520, detail=str(exc))
+        return await api_payments_pay_invoice(
+            invoiceData.bolt11, wallet.wallet
+        )  # admin key
     elif not invoiceData.out:
         # invoice key
         return await api_payments_create_invoice(invoiceData, wallet.wallet)

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -99,7 +99,7 @@ class LNbitsWallet(Wallet):
 
         if r.is_error:
             error_message = r.json()["detail"]
-            return PaymentResponse(None, None, None, None, error_message)
+            return PaymentResponse(False, None, None, None, error_message)
         else:
             data = r.json()
             checking_id = data["payment_hash"]

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -123,8 +123,8 @@ class LNbitsWallet(Wallet):
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
         r = await self.client.get(url=f"/api/v1/payments/{checking_id}")
 
-        if r.is_error:
-            return PaymentStatus(None)
+        # if r.is_error:
+        #     return PaymentStatus(None)
         data = r.json()
         if "paid" not in data and "details" not in data:
             return PaymentStatus(None)

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -123,8 +123,8 @@ class LNbitsWallet(Wallet):
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
         r = await self.client.get(url=f"/api/v1/payments/{checking_id}")
 
-        # if r.is_error:
-        #     return PaymentStatus(None)
+        if r.is_error:
+            return PaymentStatus(False)
         data = r.json()
         if "paid" not in data and "details" not in data:
             return PaymentStatus(None)

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -578,7 +578,7 @@ async def test_pay_hold_invoice_check_pending_and_fail_cancel_payment_task_in_me
 
     # status should still be available
     status = await payment_db.check_status()
-    assert status.paid is False
+    assert status.paid in [False or None]
 
     payment_db_after_settlement = await get_standalone_payment(invoice_obj.payment_hash)
     assert payment_db_after_settlement is None

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -578,7 +578,8 @@ async def test_pay_hold_invoice_check_pending_and_fail_cancel_payment_task_in_me
 
     # status should still be available
     status = await payment_db.check_status()
-    assert status.paid in [False or None]
+    # TODO: LNbitsWallet returns None but all other backends return False here. Why?
+    assert status.paid in [False, None]
 
     payment_db_after_settlement = await get_standalone_payment(invoice_obj.payment_hash)
     assert payment_db_after_settlement is None

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -544,6 +544,48 @@ async def test_pay_hold_invoice_check_pending_and_fail(
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(is_fake, reason="this only works in regtest")
+async def test_pay_hold_invoice_check_pending_and_fail_cancel_payment_task_in_meantime(
+    client, hold_invoice, adminkey_headers_from
+):
+    preimage, invoice = hold_invoice
+    task = asyncio.create_task(
+        client.post(
+            "/api/v1/payments",
+            json={"bolt11": invoice["payment_request"]},
+            headers=adminkey_headers_from,
+        )
+    )
+    await asyncio.sleep(1)
+
+    # get payment hash from the invoice
+    invoice_obj = bolt11.decode(invoice["payment_request"])
+
+    payment_db = await get_standalone_payment(invoice_obj.payment_hash)
+
+    assert payment_db
+    assert payment_db.pending is True
+
+    # cancel payment task
+    task.cancel()
+
+    preimage_hash = hashlib.sha256(bytes.fromhex(preimage)).hexdigest()
+
+    assert preimage_hash == invoice_obj.payment_hash
+    cancel_invoice(preimage_hash)
+
+    # check if paid
+    await asyncio.sleep(1)
+
+    # status should still be available
+    status = await payment_db.check_status()
+    assert status.paid is False
+
+    payment_db_after_settlement = await get_standalone_payment(invoice_obj.payment_hash)
+    assert payment_db_after_settlement is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(is_fake, reason="this only works in regtest")
 async def test_receive_real_invoice_set_pending_and_check_state(
     client, adminkey_headers_from, inkey_headers_from
 ):

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -576,12 +576,18 @@ async def test_pay_hold_invoice_check_pending_and_fail_cancel_payment_task_in_me
     # check if paid
     await asyncio.sleep(1)
 
+    payment_db_after_settlement = await get_standalone_payment(invoice_obj.payment_hash)
+    assert payment_db_after_settlement is not None
+
     # status should still be available
     status = await payment_db.check_status()
     assert status.paid is False
 
-    payment_db_after_settlement = await get_standalone_payment(invoice_obj.payment_hash)
-    assert payment_db_after_settlement is None
+    # now the payment should be gone after the status check
+    payment_db_after_status_check = await get_standalone_payment(
+        invoice_obj.payment_hash
+    )
+    assert payment_db_after_status_check is None
 
 
 @pytest.mark.asyncio

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -527,6 +527,8 @@ async def test_pay_hold_invoice_check_pending_and_fail(
     assert payment_db.pending is True
 
     preimage_hash = hashlib.sha256(bytes.fromhex(preimage)).hexdigest()
+
+    assert preimage_hash == invoice_obj.payment_hash
     cancel_invoice(preimage_hash)
 
     response = await task

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -532,7 +532,7 @@ async def test_pay_hold_invoice_check_pending_and_fail(
     cancel_invoice(preimage_hash)
 
     response = await task
-    assert response.status_code < 300
+    assert response.status_code > 200
 
     # check if paid
 

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -578,8 +578,7 @@ async def test_pay_hold_invoice_check_pending_and_fail_cancel_payment_task_in_me
 
     # status should still be available
     status = await payment_db.check_status()
-    # TODO: LNbitsWallet returns None but all other backends return False here. Why?
-    assert status.paid in [False, None]
+    assert status.paid is False
 
     payment_db_after_settlement = await get_standalone_payment(invoice_obj.payment_hash)
     assert payment_db_after_settlement is None

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -532,14 +532,11 @@ async def test_pay_hold_invoice_check_pending_and_fail(
     cancel_invoice(preimage_hash)
 
     response = await task
-    assert response.status_code > 200
+    assert response.status_code > 300  # should error
 
     # check if paid
 
     await asyncio.sleep(1)
-
-    status = await payment_db.check_status()
-    assert status.paid is False
 
     payment_db_after_settlement = await get_standalone_payment(invoice_obj.payment_hash)
     assert payment_db_after_settlement is None

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -526,7 +526,7 @@ async def test_pay_hold_invoice_check_pending_and_fail(
     assert payment_db
     assert payment_db.pending is True
 
-    preimage_hash = hashlib.sha256(preimage).hexdigest()
+    preimage_hash = hashlib.sha256(bytes.fromhex(preimage)).hexdigest()
     cancel_invoice(preimage_hash)
 
     response = await task

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -480,7 +480,7 @@ async def test_pay_hold_invoice_check_pending(
     await asyncio.sleep(1)
 
     # get payment hash from the invoice
-    invoice_obj = bolt11.decode(invoice)
+    invoice_obj = bolt11.decode(invoice["payment_request"])
 
     payment_db = await get_standalone_payment(invoice_obj.payment_hash)
 


### PR DESCRIPTION
Testing handling of pending payments by using hodl invoices generated in the regtest CI (by LND).

Fixes 2 bugs
- api_payents_create responds with error if payment fails
- bug in the LNbits backend that did not respond correctly for pending outgoing payments.