### PR TITLE
Bug: invalid type converter

### DIFF
--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -47,15 +47,6 @@ if settings.lnbits_database_url:
             lambda value, curs: float(value) if value is not None else None,
         )
     )
-    register_type(
-        new_type(
-            (1082, 1083, 1266),
-            "DATE2INT",
-            lambda value, curs: time.mktime(value.timetuple())
-            if value is not None
-            else None,
-        )
-    )
 
     register_type(new_type((1184, 1114), "TIMESTAMP2INT", _parse_timestamp))
 else:

--- a/tests/core/test_db.py
+++ b/tests/core/test_db.py
@@ -1,0 +1,13 @@
+from datetime import date
+
+import pytest
+
+from lnbits.db import POSTGRES
+
+
+@pytest.mark.asyncio
+async def test_date_conversion(db):
+    if db.type == POSTGRES:
+        row = await db.fetchone("SELECT now()::date")
+        assert row and type(row[0]) == date
+

--- a/tests/core/test_db.py
+++ b/tests/core/test_db.py
@@ -10,4 +10,3 @@ async def test_date_conversion(db):
     if db.type == POSTGRES:
         row = await db.fetchone("SELECT now()::date")
         assert row and type(row[0]) == date
-


### PR DESCRIPTION
This small pr demonstrates the faulty `register_type` call I mentioned in some other prs with a small test case.

This bug is specific to postgres because the faulty converter only applied there. The functions around times / dates are pretty inconsistent across dbs so when someone wants to use them they need to be aware of such differences.

Here you can see it failing:
https://github.com/lnbits/lnbits/actions/runs/5696767068/job/15442435962?pr=1842