### PR TITLE
refactor exchange rates

### DIFF
--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -249,7 +249,10 @@ async def btc_price(currency: str) -> float:
                 data = r.json()
                 return float(provider.getter(data, replacements))
         except Exception as e:
-            logger.warning(f"Failed to fetch Bitcoin price for {currency} from {provider.name}: {e}")
+            logger.warning(
+                f"Failed to fetch Bitcoin price "
+                f"for {currency} from {provider.name}: {e}"
+            )
             raise
 
     results = await asyncio.gather(

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -183,6 +183,19 @@ class Provider(NamedTuple):
 
 
 exchange_rate_providers = {
+    # https://binance-docs.github.io/apidocs/spot/en/#symbol-price-ticker
+    "binance": Provider(
+        "Binance",
+        "binance.com",
+        "https://api.binance.com/api/v3/ticker/price?symbol={FROM}{TO}",
+        lambda data, replacements: data["price"],
+    ),
+    "exir": Provider(
+        "Exir",
+        "exir.io",
+        "https://api.exir.io/v1/ticker?symbol={from}-{to}",
+        lambda data, replacements: data["last"],
+    ),
     "bitfinex": Provider(
         "Bitfinex",
         "bitfinex.com",
@@ -217,6 +230,9 @@ exchange_rate_providers = {
 
 
 async def btc_price(currency: str) -> float:
+    if currency == "USD":
+        currency = "USDT"
+
     replacements = {
         "FROM": "BTC",
         "from": "btc",

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -248,8 +248,8 @@ async def btc_price(currency: str) -> float:
                 r.raise_for_status()
                 data = r.json()
                 return float(provider.getter(data, replacements))
-        except Exception:
-            logger.warning(f"Failed to fetch Bitcoin price from {provider.name}.")
+        except Exception as e:
+            logger.warning(f"Failed to fetch Bitcoin price for {currency} from {provider.name}: {e}")
             raise
 
     results = await asyncio.gather(

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -190,6 +190,12 @@ exchange_rate_providers = {
         "https://api.binance.com/api/v3/ticker/price?symbol={FROM}{TO}",
         lambda data, replacements: data["price"],
     ),
+    "blockchain": Provider(
+        "Blockchain",
+        "blockchain.com",
+        "https://blockchain.info/tobtc?currency={TO}&value=1",
+        lambda data, replacements: 1 / data,
+    ),
     "exir": Provider(
         "Exir",
         "exir.io",
@@ -230,9 +236,6 @@ exchange_rate_providers = {
 
 
 async def btc_price(currency: str) -> float:
-    if currency == "USD":
-        currency = "USDT"
-
     replacements = {
         "FROM": "BTC",
         "from": "btc",

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -1,8 +1,10 @@
 import asyncio
-from typing import Callable, List, NamedTuple
+from typing import Callable, NamedTuple
 
 import httpx
 from loguru import logger
+
+from lnbits.cache import cache
 
 currencies = {
     "AED": "United Arab Emirates Dirham",
@@ -181,12 +183,6 @@ class Provider(NamedTuple):
 
 
 exchange_rate_providers = {
-    "exir": Provider(
-        "Exir",
-        "exir.io",
-        "https://api.exir.io/v1/ticker?symbol={from}-{to}",
-        lambda data, replacements: data["last"],
-    ),
     "bitfinex": Provider(
         "Bitfinex",
         "bitfinex.com",
@@ -227,28 +223,6 @@ async def btc_price(currency: str) -> float:
         "TO": currency.upper(),
         "to": currency.lower(),
     }
-    rates: List[float] = []
-    tasks: List[asyncio.Task] = []
-
-    send_channel: asyncio.Queue = asyncio.Queue()
-
-    async def controller():
-        failures = 0
-        while True:
-            rate = await send_channel.get()
-            if rate:
-                rates.append(rate)
-            else:
-                failures += 1
-
-            if len(rates) >= 2 or len(rates) == 1 and failures >= 2:
-                for t in tasks:
-                    t.cancel()
-                break
-            if failures == len(exchange_rate_providers):
-                for t in tasks:
-                    t.cancel()
-                break
 
     async def fetch_price(provider: Provider):
         url = provider.api_url.format(**replacements)
@@ -257,40 +231,30 @@ async def btc_price(currency: str) -> float:
                 r = await client.get(url, timeout=0.5)
                 r.raise_for_status()
                 data = r.json()
-                rate = float(provider.getter(data, replacements))
-                await send_channel.put(rate)
-        except (
-            # CoinMate returns HTTPStatus 200 but no data when a pair is not found
-            TypeError,
-            # Kraken's response dictionary doesn't include keys we look up for
-            KeyError,
-            httpx.ConnectTimeout,
-            httpx.ConnectError,
-            httpx.ReadTimeout,
-            # Some providers throw a 404 when a currency pair is not found
-            httpx.HTTPStatusError,
-        ):
-            await send_channel.put(None)
+                return float(provider.getter(data, replacements))
+        except Exception:
+            logger.warning(f"Failed to fetch Bitcoin price from {provider.name}.")
+            raise
 
-    asyncio.create_task(controller())
-    for _, provider in exchange_rate_providers.items():
-        tasks.append(asyncio.create_task(fetch_price(provider)))
-
-    try:
-        await asyncio.gather(*tasks)
-    except asyncio.CancelledError:
-        pass
+    results = await asyncio.gather(
+        *[fetch_price(provider) for provider in exchange_rate_providers.values()],
+        return_exceptions=True,
+    )
+    rates = [r for r in results if not isinstance(r, Exception)]
 
     if not rates:
         return 9999999999
     elif len(rates) == 1:
         logger.warning("Could only fetch one Bitcoin price.")
 
-    return sum([rate for rate in rates]) / len(rates)
+    return sum(rates) / len(rates)
 
 
 async def get_fiat_rate_satoshis(currency: str) -> float:
-    return float(100_000_000 / (await btc_price(currency)))
+    price = await cache.save_result(
+        lambda: btc_price(currency), f"btc-price-{currency}"
+    )
+    return float(100_000_000 / price)
 
 
 async def fiat_amount_as_satoshis(amount: float, currency: str) -> int:

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -84,6 +84,19 @@ async def test_create_invoice(client, inkey_headers_to):
     return invoice
 
 
+@pytest.mark.asyncio
+async def test_create_invoice_fiat_amount(client, inkey_headers_to):
+    data = await get_random_invoice_data()
+    data["unit"] = "EUR"
+    response = await client.post(
+        "/api/v1/payments", json=data, headers=inkey_headers_to
+    )
+    assert response.status_code == 201
+    invoice = response.json()
+    decode = bolt11.decode(invoice["payment_request"])
+    assert decode.amount_msat != data["amount"] * 1000
+
+
 # check POST /api/v1/payments: invoice creation for internal payments only
 @pytest.mark.asyncio
 async def test_create_internal_invoice(client, inkey_headers_to):


### PR DESCRIPTION
simplifies the code and adds caching.
the the `return_exceptions` on  the `gather` is key as it tells gather not to return if one of the tasks fail but instead wait for all to complete.

Exir was removed as a provider because it doesnt work (maybe binance alternative?)