### PR TITLE
Fix csv export

### DIFF
--- a/lnbits/core/static/js/wallet.js
+++ b/lnbits/core/static/js/wallet.js
@@ -787,14 +787,10 @@ new Vue({
       // status is important for export but it is not in paymentsTable
       // because it is manually added with payment detail link and icons
       // and would cause duplication in the list
-      let columns = structuredClone(this.paymentsCSV.columns)
-      columns.unshift({
-        name: 'pending',
-        align: 'left',
-        label: 'Pending',
-        field: 'pending'
+      LNbits.api.getPayments(this.g.wallet, {}).then(response => {
+        const payments = response.data.data.map(LNbits.map.payment)
+        LNbits.utils.exportCSV(this.paymentsCSV.columns, payments)
       })
-      LNbits.utils.exportCSV(columns, this.payments)
     },
     pasteToTextArea: function () {
       navigator.clipboard.readText().then(text => {

--- a/lnbits/core/static/js/wallet.js
+++ b/lnbits/core/static/js/wallet.js
@@ -173,6 +173,12 @@ new Vue({
       paymentsCSV: {
         columns: [
           {
+            name: 'pending',
+            align: 'left',
+            label: 'Pending',
+            field: 'pending'
+          },
+          {
             name: 'memo',
             align: 'left',
             label: this.$t('memo'),
@@ -221,6 +227,18 @@ new Vue({
             align: 'right',
             label: this.$t('webhook'),
             field: 'webhook'
+          },
+          {
+            name: 'fiat_currency',
+            align: 'right',
+            label: 'Fiat Currency',
+            field: row => row.extra.wallet_fiat_currency
+          },
+          {
+            name: 'fiat_amount',
+            align: 'right',
+            label: 'Fiat Amount',
+            field: row => row.extra.wallet_fiat_amount
           }
         ],
         filter: null,


### PR DESCRIPTION
Continuation of https://github.com/lnbits/lnbits/pull/1756

Instead of creating a new endpoint for csv just fetch all payments and create the csv in the browser.
It also exports the fiat value and currency from https://github.com/lnbits/lnbits/pull/1789