### PR TITLE
UI: hide paste payment request in unsupported environments

### DIFF
--- a/lnbits/core/static/js/wallet.js
+++ b/lnbits/core/static/js/wallet.js
@@ -137,6 +137,9 @@ new Vue({
           comment: ''
         },
         paymentChecker: null,
+        copy: {
+          show: false
+        },
         camera: {
           show: false,
           camera: 'auto'
@@ -302,6 +305,8 @@ new Vue({
       this.parse.invoice = null
       this.parse.lnurlpay = null
       this.parse.lnurlauth = null
+      this.parse.copy.show =
+        window.isSecureContext && navigator.clipboard?.readText !== undefined
       this.parse.data.request = ''
       this.parse.data.comment = ''
       this.parse.data.paymentChecker = null

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -726,6 +726,7 @@
                   name="content_paste"
                   color="grey"
                   class="q-mt-xs q-ml-sm q-mr-auto"
+                  v-if="parse.copy.show"
                   @click="pasteToTextArea"
                   ><q-tooltip
                     >{% raw %}{{$t('paste_from_clipboard')}}{% endraw


### PR DESCRIPTION
Followup to https://github.com/lnbits/lnbits/pull/1845

This PR hides the paste button in unsupported environments:

- the clipboard API only works in [secure context](https://stackoverflow.com/a/51823007)
- [Firefox supports the clipboard API only in extensions](https://support.mozilla.org/en-US/questions/1331833); `navigator.clipboard.readText` is undefined in Firefox