### PR TITLE
clnrest: revert unnecessary changes

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -11,7 +11,6 @@ from lnurl import decode as decode_lnurl
 from loguru import logger
 
 from lnbits import bolt11
-from lnbits.core.models import PaymentStatus
 from lnbits.db import Connection
 from lnbits.decorators import WalletTypeInfo, require_admin_key
 from lnbits.helpers import url_for
@@ -23,7 +22,7 @@ from lnbits.settings import (
     settings,
 )
 from lnbits.wallets import FAKE_WALLET, get_wallet_class, set_wallet_class
-from lnbits.wallets.base import PaymentResponse
+from lnbits.wallets.base import PaymentResponse, PaymentStatus
 
 from . import db
 from .crud import (

--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, Coroutine, NamedTuple, Optional
 
-from ..core.models import Payment, PaymentStatus
-
 
 class StatusResponse(NamedTuple):
     error_message: Optional[str]
@@ -23,6 +21,30 @@ class PaymentResponse(NamedTuple):
     fee_msat: Optional[int] = None
     preimage: Optional[str] = None
     error_message: Optional[str] = None
+
+
+class PaymentStatus(NamedTuple):
+    paid: Optional[bool] = None
+    fee_msat: Optional[int] = None
+    preimage: Optional[str] = None
+
+    @property
+    def pending(self) -> bool:
+        return self.paid is not True
+
+    @property
+    def failed(self) -> bool:
+        return self.paid is False
+
+    def __str__(self) -> str:
+        if self.paid is True:
+            return "settled"
+        elif self.paid is False:
+            return "failed"
+        elif self.paid is None:
+            return "still pending"
+        else:
+            return "unknown (should never happen)"
 
 
 class Wallet(ABC):
@@ -51,13 +73,13 @@ class Wallet(ABC):
 
     @abstractmethod
     def get_invoice_status(
-        self, payment: Payment
+        self, checking_id: str
     ) -> Coroutine[None, None, PaymentStatus]:
         pass
 
     @abstractmethod
     def get_payment_status(
-        self, payment: Payment
+        self, checking_id: str
     ) -> Coroutine[None, None, PaymentStatus]:
         pass
 

--- a/lnbits/wallets/cliche.py
+++ b/lnbits/wallets/cliche.py
@@ -8,8 +8,13 @@ from websocket import create_connection
 
 from lnbits.settings import settings
 
-from ..core.models import Payment, PaymentStatus
-from .base import InvoiceResponse, PaymentResponse, StatusResponse, Wallet
+from .base import (
+    InvoiceResponse,
+    PaymentResponse,
+    PaymentStatus,
+    StatusResponse,
+    Wallet,
+)
 
 
 class ClicheWallet(Wallet):
@@ -122,9 +127,9 @@ class ClicheWallet(Wallet):
             payment_ok, checking_id, fee_msat, preimage, error_message
         )
 
-    async def get_invoice_status(self, payment: Payment) -> PaymentStatus:
+    async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
         ws = create_connection(self.endpoint)
-        ws.send(f"check-payment --hash {payment.checking_id}")
+        ws.send(f"check-payment --hash {checking_id}")
         r = ws.recv()
         data = json.loads(r)
 
@@ -135,21 +140,21 @@ class ClicheWallet(Wallet):
         statuses = {"pending": None, "complete": True, "failed": False}
         return PaymentStatus(statuses[data["result"]["status"]])
 
-    async def get_payment_status(self, payment: Payment) -> PaymentStatus:
+    async def get_payment_status(self, checking_id: str) -> PaymentStatus:
         ws = create_connection(self.endpoint)
-        ws.send(f"check-payment --hash {payment.checking_id}")
+        ws.send(f"check-payment --hash {checking_id}")
         r = ws.recv()
         data = json.loads(r)
 
         if data.get("error") is not None and data["error"].get("message"):
             logger.error(data["error"]["message"])
             return PaymentStatus(None)
-        paymentResult = data["result"]
+        payment = data["result"]
         statuses = {"pending": None, "complete": True, "failed": False}
         return PaymentStatus(
-            statuses[paymentResult["status"]],
-            paymentResult.get("fee_msatoshi"),
-            paymentResult.get("preimage"),
+            statuses[payment["status"]],
+            payment.get("fee_msatoshi"),
+            payment.get("preimage"),
         )
 
     async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -11,8 +11,13 @@ from websockets.client import connect
 
 from lnbits.settings import settings
 
-from ..core.models import Payment, PaymentStatus
-from .base import InvoiceResponse, PaymentResponse, StatusResponse, Wallet
+from .base import (
+    InvoiceResponse,
+    PaymentResponse,
+    PaymentStatus,
+    StatusResponse,
+    Wallet,
+)
 
 
 class EclairError(Exception):
@@ -151,11 +156,11 @@ class EclairWallet(Wallet):
             statuses[data["status"]["type"]], checking_id, fee_msat, preimage, None
         )
 
-    async def get_invoice_status(self, payment: Payment) -> PaymentStatus:
+    async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
         try:
             r = await self.client.post(
                 "/getreceivedinfo",
-                data={"paymentHash": payment.checking_id},
+                data={"paymentHash": checking_id},
             )
 
             r.raise_for_status()
@@ -173,11 +178,11 @@ class EclairWallet(Wallet):
         except:
             return PaymentStatus(None)
 
-    async def get_payment_status(self, payment: Payment) -> PaymentStatus:
+    async def get_payment_status(self, checking_id: str) -> PaymentStatus:
         try:
             r = await self.client.post(
                 "/getsentinfo",
-                data={"paymentHash": payment.checking_id},
+                data={"paymentHash": checking_id},
                 timeout=40,
             )
 

--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -9,8 +9,13 @@ from loguru import logger
 from lnbits.settings import settings
 
 from ..bolt11 import Invoice, decode, encode
-from ..core.models import Payment, PaymentStatus
-from .base import InvoiceResponse, PaymentResponse, StatusResponse, Wallet
+from .base import (
+    InvoiceResponse,
+    PaymentResponse,
+    PaymentStatus,
+    StatusResponse,
+    Wallet,
+)
 
 
 class FakeWallet(Wallet):
@@ -83,10 +88,10 @@ class FakeWallet(Wallet):
                 ok=False, error_message="Only internal invoices can be used!"
             )
 
-    async def get_invoice_status(self, _: Payment) -> PaymentStatus:
+    async def get_invoice_status(self, _: str) -> PaymentStatus:
         return PaymentStatus(None)
 
-    async def get_payment_status(self, _: Payment) -> PaymentStatus:
+    async def get_payment_status(self, _: str) -> PaymentStatus:
         return PaymentStatus(None)
 
     async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -7,8 +7,13 @@ from loguru import logger
 
 from lnbits.settings import settings
 
-from ..core.models import Payment, PaymentStatus
-from .base import InvoiceResponse, PaymentResponse, StatusResponse, Wallet
+from .base import (
+    InvoiceResponse,
+    PaymentResponse,
+    PaymentStatus,
+    StatusResponse,
+    Wallet,
+)
 
 
 class LNbitsWallet(Wallet):
@@ -100,18 +105,14 @@ class LNbitsWallet(Wallet):
             checking_id = data["payment_hash"]
 
         # we do this to get the fee and preimage
-        payment: PaymentStatus = await self.get_payment_status(
-            Payment.dummy(
-                checking_id=data["payment_hash"],
-            )
-        )
+        payment: PaymentStatus = await self.get_payment_status(checking_id)
 
         return PaymentResponse(ok, checking_id, payment.fee_msat, payment.preimage)
 
-    async def get_invoice_status(self, payment: Payment) -> PaymentStatus:
+    async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
         try:
             r = await self.client.get(
-                url=f"/api/v1/payments/{payment.checking_id}",
+                url=f"/api/v1/payments/{checking_id}",
             )
             if r.is_error:
                 return PaymentStatus(None)
@@ -119,8 +120,8 @@ class LNbitsWallet(Wallet):
         except:
             return PaymentStatus(None)
 
-    async def get_payment_status(self, payment: Payment) -> PaymentStatus:
-        r = await self.client.get(url=f"/api/v1/payments/{payment.checking_id}")
+    async def get_payment_status(self, checking_id: str) -> PaymentStatus:
+        r = await self.client.get(url=f"/api/v1/payments/{checking_id}")
 
         if r.is_error:
             return PaymentStatus(False)

--- a/lnbits/wallets/lnpay.py
+++ b/lnbits/wallets/lnpay.py
@@ -10,8 +10,13 @@ from loguru import logger
 
 from lnbits.settings import settings
 
-from ..core.models import Payment, PaymentStatus
-from .base import InvoiceResponse, PaymentResponse, StatusResponse, Wallet
+from .base import (
+    InvoiceResponse,
+    PaymentResponse,
+    PaymentStatus,
+    StatusResponse,
+    Wallet,
+)
 
 
 class LNPayWallet(Wallet):
@@ -110,12 +115,12 @@ class LNPayWallet(Wallet):
         preimage = data["lnTx"]["payment_preimage"]
         return PaymentResponse(True, checking_id, fee_msat, preimage, None)
 
-    async def get_invoice_status(self, payment: Payment) -> PaymentStatus:
-        return await self.get_payment_status(payment)
+    async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
+        return await self.get_payment_status(checking_id)
 
-    async def get_payment_status(self, payment: Payment) -> PaymentStatus:
+    async def get_payment_status(self, checking_id: str) -> PaymentStatus:
         r = await self.client.get(
-            url=f"/lntx/{payment.checking_id}",
+            url=f"/lntx/{checking_id}",
         )
 
         if r.is_error:

--- a/lnbits/wallets/lntips.py
+++ b/lnbits/wallets/lntips.py
@@ -9,8 +9,13 @@ from loguru import logger
 
 from lnbits.settings import settings
 
-from ..core.models import Payment, PaymentStatus
-from .base import InvoiceResponse, PaymentResponse, StatusResponse, Wallet
+from .base import (
+    InvoiceResponse,
+    PaymentResponse,
+    PaymentStatus,
+    StatusResponse,
+    Wallet,
+)
 
 
 class LnTipsWallet(Wallet):
@@ -104,10 +109,10 @@ class LnTipsWallet(Wallet):
         preimage = data["preimage"]
         return PaymentResponse(True, checking_id, fee_msat, preimage, None)
 
-    async def get_invoice_status(self, payment: Payment) -> PaymentStatus:
+    async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
         try:
             r = await self.client.post(
-                f"/api/v1/invoicestatus/{payment.checking_id}",
+                f"/api/v1/invoicestatus/{checking_id}",
             )
 
             if r.is_error or len(r.text) == 0:
@@ -118,10 +123,10 @@ class LnTipsWallet(Wallet):
         except:
             return PaymentStatus(None)
 
-    async def get_payment_status(self, payment: Payment) -> PaymentStatus:
+    async def get_payment_status(self, checking_id: str) -> PaymentStatus:
         try:
             r = await self.client.post(
-                url=f"/api/v1/paymentstatus/{payment.checking_id}",
+                url=f"/api/v1/paymentstatus/{checking_id}",
             )
 
             if r.is_error:

--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -9,8 +9,14 @@ from loguru import logger
 
 from lnbits.settings import settings
 
-from ..core.models import Payment, PaymentStatus
-from .base import InvoiceResponse, PaymentResponse, StatusResponse, Unsupported, Wallet
+from .base import (
+    InvoiceResponse,
+    PaymentResponse,
+    PaymentStatus,
+    StatusResponse,
+    Unsupported,
+    Wallet,
+)
 
 
 class OpenNodeWallet(Wallet):
@@ -98,16 +104,16 @@ class OpenNodeWallet(Wallet):
 
         return PaymentResponse(True, checking_id, fee_msat, None, None)
 
-    async def get_invoice_status(self, payment: Payment) -> PaymentStatus:
-        r = await self.client.get(f"/v1/charge/{payment.checking_id}")
+    async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
+        r = await self.client.get(f"/v1/charge/{checking_id}")
         if r.is_error:
             return PaymentStatus(None)
         data = r.json()["data"]
         statuses = {"processing": None, "paid": True, "unpaid": None}
         return PaymentStatus(statuses[data.get("status")])
 
-    async def get_payment_status(self, payment: Payment) -> PaymentStatus:
-        r = await self.client.get(f"/v1/withdrawal/{payment.checking_id}")
+    async def get_payment_status(self, checking_id: str) -> PaymentStatus:
+        r = await self.client.get(f"/v1/withdrawal/{checking_id}")
 
         if r.is_error:
             return PaymentStatus(None)

--- a/lnbits/wallets/void.py
+++ b/lnbits/wallets/void.py
@@ -2,8 +2,13 @@ from typing import AsyncGenerator
 
 from loguru import logger
 
-from ..core.models import Payment, PaymentStatus
-from .base import InvoiceResponse, PaymentResponse, StatusResponse, Wallet
+from .base import (
+    InvoiceResponse,
+    PaymentResponse,
+    PaymentStatus,
+    StatusResponse,
+    Wallet,
+)
 
 
 class VoidWallet(Wallet):
@@ -26,10 +31,10 @@ class VoidWallet(Wallet):
             ok=False, error_message="VoidWallet cannot pay invoices."
         )
 
-    async def get_invoice_status(self, payment: Payment) -> PaymentStatus:
+    async def get_invoice_status(self, *_, **__) -> PaymentStatus:
         return PaymentStatus(None)
 
-    async def get_payment_status(self, payment: Payment) -> PaymentStatus:
+    async def get_payment_status(self, *_, **__) -> PaymentStatus:
         return PaymentStatus(None)
 
     async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:

--- a/tests/core/views/test_api.py
+++ b/tests/core/views/test_api.py
@@ -378,11 +378,7 @@ async def test_pay_real_invoice(
     payment_status = response.json()
     assert payment_status["paid"]
 
-    # create a dummy payment object of which we will
-    # only use checking_id in get_payment_status
-    status = await WALLET.get_payment_status(
-        Payment.dummy(checking_id=invoice["payment_hash"])
-    )
+    status = await WALLET.get_payment_status(invoice["payment_hash"])
     assert status.paid
 
     await asyncio.sleep(0.3)
@@ -462,11 +458,7 @@ async def test_pay_real_invoice_set_pending_and_check_state(
     assert response["paid"]
 
     # make sure that the backend also thinks it's paid
-    status = await WALLET.get_payment_status(
-        Payment.dummy(
-            checking_id=invoice["payment_hash"],
-        )
-    )
+    status = await WALLET.get_payment_status(invoice["payment_hash"])
     assert status.paid
 
     # get the outgoing payment from the db

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,8 +1,7 @@
 from mock import AsyncMock
 
 from lnbits import bolt11
-from lnbits.core.models import PaymentStatus
-from lnbits.wallets.base import PaymentResponse, StatusResponse
+from lnbits.wallets.base import PaymentResponse, PaymentStatus, StatusResponse
 from lnbits.wallets.fake import FakeWallet
 
 from .helpers import WALLET, get_random_string, is_fake


### PR DESCRIPTION
Changing up the entire wallet interface is not necessary. We can just get the `bolt11` via the database for now.