### PR TITLE
FEAT: add installed extensions to log

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -180,6 +180,10 @@ async def check_installed_extensions(app: FastAPI):
                 f"Failed to re-install extension: {ext.id} ({ext.installed_version})"
             )
 
+    logger.info(f"Installed Extensions ({len(installed_extensions)}):")
+    for ext in installed_extensions:
+        logger.info(f"{ext.id} ({ext.installed_version})")
+
 
 async def build_all_installed_extensions_list() -> List[InstallableExtension]:
     """


### PR DESCRIPTION
for immediate vision of installed extensions. i tried it to have a onliner to save some space. but it was very hard to read if there are many extensions installed.
![screenshot-1691308749](https://github.com/lnbits/lnbits/assets/1743657/9758f6db-5e27-4d2f-b55c-21037f73b1ad)


for comparison:
![screenshot-1691308187](https://github.com/lnbits/lnbits/assets/1743657/4bdbe837-bad1-4023-b9cf-71cd09dc7518)
