### PR TITLE
[BUG] dont install default extensions for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ from tests.helpers import (
     get_real_invoice,
 )
 
+# dont install extensions for tests
+settings.lnbits_extensions_default_install = []
+
 
 @pytest_asyncio.fixture(scope="session")
 def event_loop():


### PR DESCRIPTION
this is important for local testing. else you will install those extensions if you have them inside env.