### PR TITLE
[TEST] proper credit_wallet function from services for test helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,15 +8,11 @@ from httpx import AsyncClient
 from lnbits.app import create_app
 from lnbits.commands import migrate_databases
 from lnbits.core.crud import create_account, create_wallet
+from lnbits.core.services import update_wallet_balance
 from lnbits.core.views.api import CreateInvoiceData, api_payments_create_invoice
 from lnbits.db import Database
 from lnbits.settings import settings
-from tests.helpers import (
-    credit_wallet,
-    get_hold_invoice,
-    get_random_invoice_data,
-    get_real_invoice,
-)
+from tests.helpers import get_hold_invoice, get_random_invoice_data, get_real_invoice
 
 
 @pytest_asyncio.fixture(scope="session")
@@ -68,7 +64,7 @@ async def from_user():
 async def from_wallet(from_user):
     user = from_user
     wallet = await create_wallet(user_id=user.id, wallet_name="test_wallet_from")
-    await credit_wallet(
+    await update_wallet_balance(
         wallet_id=wallet.id,
         amount=999999999,
     )
@@ -91,7 +87,7 @@ async def to_user():
 async def to_wallet(to_user):
     user = to_user
     wallet = await create_wallet(user_id=user.id, wallet_name="test_wallet_to")
-    await credit_wallet(
+    await update_wallet_balance(
         wallet_id=wallet.id,
         amount=999999999,
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,30 +2,11 @@ import hashlib
 import json
 import os
 import random
-import secrets
 import string
 from subprocess import PIPE, Popen, run
 from typing import Tuple
 
-from lnbits.core.crud import create_payment
 from lnbits.wallets import get_wallet_class, set_wallet_class
-
-
-async def credit_wallet(wallet_id: str, amount: int):
-    preimage = secrets.token_hex(32)
-    m = hashlib.sha256()
-    m.update(f"{preimage}".encode())
-    payment_hash = m.hexdigest()
-    await create_payment(
-        wallet_id=wallet_id,
-        payment_request="",
-        payment_hash=payment_hash,
-        checking_id=payment_hash,
-        preimage=preimage,
-        memo=f"funding_test_{get_random_string(5)}",
-        amount=amount,  # msat
-        pending=False,  # not pending, so it will increase the wallet's balance
-    )
 
 
 def get_random_string(N: int = 10):


### PR DESCRIPTION
this is required for bolt11 library merge PR https://github.com/lnbits/lnbits/pull/1817

the issue was, creditwallet used an empty ```payment_hash```