### PR TITLE
[FEAT] save fiat amount in api_create_invoice

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -186,6 +186,7 @@ async def api_payments_paginated(
 
 
 async def api_payments_create_invoice(data: CreateInvoice, wallet: Wallet):
+    extra = data.extra or {}
     if data.description_hash or data.unhashed_description:
         try:
             description_hash = (
@@ -216,6 +217,7 @@ async def api_payments_create_invoice(data: CreateInvoice, wallet: Wallet):
         assert data.unit is not None, "unit not set"
         price_in_sats = await fiat_amount_as_satoshis(data.amount, data.unit)
         amount = price_in_sats
+        extra.update({"fiat_amount": data.amount, "fiat_currency": data.unit})
 
     async with db.connect() as conn:
         try:


### PR DESCRIPTION

![screenshot-1691492223](https://github.com/lnbits/lnbits/assets/1743657/90f104a2-7f64-4900-b2bc-de132d80e722)
save user input into extra when he chooses a currency for api_create invoice