### PR TITLE
[REFACTOR] core/__init__ to not have circular import issues

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -33,14 +33,11 @@ from lnbits.utils.cache import cache
 from lnbits.wallets import get_wallet_class, set_wallet_class
 
 from .commands import db_versions, load_disabled_extension_list, migrate_databases
-from .core import (
-    add_installed_extension,
-    core_app,
-    core_app_extra,
-    update_installed_extension_state,
-)
+from .core import init_core_routers
+from .core.db import core_app_extra
 from .core.services import check_admin_settings, check_webpush_settings
-from .core.views.generic import core_html_routes
+from .core.views.api import add_installed_extension
+from .core.views.generic import update_installed_extension_state
 from .extension_manager import Extension, InstallableExtension, get_valid_extensions
 from .helpers import template_renderer
 from .middleware import (
@@ -257,8 +254,7 @@ async def restore_installed_extension(app: FastAPI, ext: InstallableExtension):
 
 def register_routes(app: FastAPI) -> None:
     """Register FastAPI routes / LNbits extensions."""
-    app.include_router(core_app)
-    app.include_router(core_html_routes)
+    init_core_routers(app)
 
     for ext in get_valid_extensions():
         try:

--- a/lnbits/core/__init__.py
+++ b/lnbits/core/__init__.py
@@ -1,15 +1,20 @@
-from fastapi.routing import APIRouter
+from fastapi import APIRouter
 
-from lnbits.core.models import CoreAppExtra
-from lnbits.db import Database
+from .db import core_app_extra, db
+from .views.admin_api import admin_router
+from .views.api import api_router
 
-db = Database("database")
+# this compat is needed for usermanager extension
+from .views.generic import generic_router, update_user_extension
+from .views.public_api import public_router
 
-core_app: APIRouter = APIRouter(tags=["Core"])
+# backwards compatibility for extensions
+core_app = APIRouter(tags=["Core"])
 
-core_app_extra: CoreAppExtra = CoreAppExtra()
 
-from .views.admin_api import *
-from .views.api import *
-from .views.generic import *
-from .views.public_api import *
+def init_core_routers(app):
+    app.include_router(core_app)
+    app.include_router(generic_router)
+    app.include_router(public_router)
+    app.include_router(api_router)
+    app.include_router(admin_router)

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 import shortuuid
 
 from lnbits import bolt11
+from lnbits.core.db import db
 from lnbits.core.models import WalletType
 from lnbits.db import Connection, Database, Filters, Page
 from lnbits.extension_manager import InstallableExtension
@@ -17,7 +18,6 @@ from lnbits.settings import (
     settings,
 )
 
-from . import db
 from .models import (
     BalanceCheck,
     Payment,

--- a/lnbits/core/db.py
+++ b/lnbits/core/db.py
@@ -1,0 +1,5 @@
+from lnbits.core.models import CoreAppExtra
+from lnbits.db import Database
+
+db = Database("database")
+core_app_extra: CoreAppExtra = CoreAppExtra()

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -6,11 +6,11 @@ from uuid import UUID
 import httpx
 from loguru import logger
 
+from lnbits.core.db import db as core_db
 from lnbits.db import Connection
 from lnbits.extension_manager import Extension
 from lnbits.settings import settings
 
-from . import db as core_db
 from .crud import update_migration_version
 
 

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -15,6 +15,7 @@ from py_vapid import Vapid
 from py_vapid.utils import b64urlencode
 
 from lnbits import bolt11
+from lnbits.core.db import db
 from lnbits.db import Connection
 from lnbits.decorators import WalletTypeInfo, require_admin_key
 from lnbits.helpers import url_for
@@ -29,7 +30,6 @@ from lnbits.utils.exchange_rates import fiat_amount_as_satoshis, satoshis_amount
 from lnbits.wallets import FAKE_WALLET, get_wallet_class, set_wallet_class
 from lnbits.wallets.base import PaymentResponse, PaymentStatus
 
-from . import db
 from .crud import (
     check_internal,
     check_internal_pending,

--- a/lnbits/core/tasks.py
+++ b/lnbits/core/tasks.py
@@ -4,6 +4,18 @@ from typing import Dict
 import httpx
 from loguru import logger
 
+from lnbits.core.crud import (
+    get_balance_notify,
+    get_wallet,
+    get_webpush_subscriptions_for_user,
+)
+from lnbits.core.db import db
+from lnbits.core.models import Payment
+from lnbits.core.services import (
+    get_balance_delta,
+    send_payment_notification,
+    switch_to_voidwallet,
+)
 from lnbits.settings import get_wallet_class, settings
 from lnbits.tasks import (
     SseListenersDict,
@@ -12,15 +24,6 @@ from lnbits.tasks import (
     register_invoice_listener,
     send_push_notification,
 )
-
-from . import db
-from .crud import (
-    get_balance_notify,
-    get_wallet,
-    get_webpush_subscriptions_for_user,
-)
-from .models import Payment
-from .services import get_balance_delta, send_payment_notification, switch_to_voidwallet
 
 api_invoice_listeners: Dict[str, asyncio.Queue] = SseListenersDict(
     "api_invoice_listeners"

--- a/lnbits/core/views/admin_api.py
+++ b/lnbits/core/views/admin_api.py
@@ -6,7 +6,7 @@ from subprocess import Popen
 from typing import Optional
 from urllib.parse import urlparse
 
-from fastapi import Depends
+from fastapi import APIRouter, Depends
 from fastapi.responses import FileResponse
 from starlette.exceptions import HTTPException
 
@@ -21,11 +21,13 @@ from lnbits.decorators import check_admin, check_super_user
 from lnbits.server import server_restart
 from lnbits.settings import AdminSettings, settings
 
-from .. import core_app, core_app_extra
+from .. import core_app_extra
 from ..crud import delete_admin_settings, get_admin_settings, update_admin_settings
 
+admin_router = APIRouter()
 
-@core_app.get(
+
+@admin_router.get(
     "/admin/api/v1/audit",
     name="Audit",
     description="show the current balance of the node and the LNbits database",
@@ -46,7 +48,7 @@ async def api_auditor():
         )
 
 
-@core_app.get("/admin/api/v1/settings/")
+@admin_router.get("/admin/api/v1/settings/")
 async def api_get_settings(
     user: User = Depends(check_admin),
 ) -> Optional[AdminSettings]:
@@ -54,7 +56,7 @@ async def api_get_settings(
     return admin_settings
 
 
-@core_app.put(
+@admin_router.put(
     "/admin/api/v1/settings/",
     status_code=HTTPStatus.OK,
 )
@@ -67,7 +69,7 @@ async def api_update_settings(data: dict, user: User = Depends(check_admin)):
     return {"status": "Success"}
 
 
-@core_app.delete(
+@admin_router.delete(
     "/admin/api/v1/settings/",
     status_code=HTTPStatus.OK,
     dependencies=[Depends(check_super_user)],
@@ -77,7 +79,7 @@ async def api_delete_settings() -> None:
     server_restart.set()
 
 
-@core_app.get(
+@admin_router.get(
     "/admin/api/v1/restart/",
     status_code=HTTPStatus.OK,
     dependencies=[Depends(check_super_user)],
@@ -87,7 +89,7 @@ async def api_restart_server() -> dict[str, str]:
     return {"status": "Success"}
 
 
-@core_app.put(
+@admin_router.put(
     "/admin/api/v1/topup/",
     name="Topup",
     status_code=HTTPStatus.OK,
@@ -111,7 +113,7 @@ async def api_topup_balance(data: CreateTopup) -> dict[str, str]:
     return {"status": "Success"}
 
 
-@core_app.get(
+@admin_router.get(
     "/admin/api/v1/backup/",
     status_code=HTTPStatus.OK,
     dependencies=[Depends(check_super_user)],

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -994,10 +994,7 @@ async def api_tinyurl(tinyurl_id: str):
         )
 
 
-############################WEBPUSH##################################
-
-
-@core_app.post("/api/v1/webpush", status_code=HTTPStatus.CREATED)
+@api_router.post("/api/v1/webpush", status_code=HTTPStatus.CREATED)
 async def api_create_webpush_subscription(
     request: Request,
     data: CreateWebPushSubscription,
@@ -1019,7 +1016,7 @@ async def api_create_webpush_subscription(
         )
 
 
-@core_app.delete("/api/v1/webpush", status_code=HTTPStatus.OK)
+@api_router.delete("/api/v1/webpush", status_code=HTTPStatus.OK)
 async def api_delete_webpush_subscription(
     request: Request,
     wallet: WalletTypeInfo = Depends(require_admin_key),

--- a/lnbits/core/views/public_api.py
+++ b/lnbits/core/views/public_api.py
@@ -2,17 +2,18 @@ import asyncio
 import datetime
 from http import HTTPStatus
 
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 from loguru import logger
 
 from lnbits import bolt11
 
-from .. import core_app
 from ..crud import get_standalone_payment
 from ..tasks import api_invoice_listeners
 
+public_router = APIRouter()
 
-@core_app.get("/public/v1/payment/{payment_hash}")
+
+@public_router.get("/public/v1/payment/{payment_hash}")
 async def api_public_payment_longpolling(payment_hash):
     payment = await get_standalone_payment(payment_hash)
 

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -10,7 +10,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from lnbits.core import core_app_extra
+from lnbits.core.db import core_app_extra
 from lnbits.helpers import template_renderer
 from lnbits.settings import settings
 

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -18,11 +18,10 @@ from lnbits.core.crud import (
     get_payments,
     get_standalone_payment,
 )
+from lnbits.core.db import db
 from lnbits.core.services import redeem_lnurl_withdraw
 from lnbits.settings import settings
 from lnbits.wallets import get_wallet_class
-
-from .core import db
 
 tasks: List[asyncio.Task] = []
 

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -184,7 +184,7 @@ class CoreLightningRestWallet(Wallet):
             return PaymentStatus(None)
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
-        from lnbits.core import get_standalone_payment
+        from lnbits.core.services import get_standalone_payment
 
         payment = await get_standalone_payment(checking_id)
         if not payment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,9 +122,7 @@ line-length = 88
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 # (`I`) is for `isort`.
 select = ["E", "F", "I"]
-ignore = [
-    "E402", # Module level import not at top of file
-]
+ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
+# ruff: noqa: E402
 import asyncio
 
 import uvloop
 
-uvloop.install()  # noqa
+uvloop.install()
 
 import pytest
 import pytest_asyncio


### PR DESCRIPTION
This fixes `E402: module level import not at top of file` and required a bit of a refactor for core imports.

now every core.view creates its own `APIRouter` which is imported into `core/__init__.py` where its initialised inside app via `init_core_routers(app)`

tested backwards compatibility for extensions and they at least not crash with import errors.