### PR TITLE
[BUG] use WalletType for get_wallet_for_key fn

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -281,7 +281,9 @@ async def get_wallet(
 
 
 async def get_wallet_for_key(
-    key: str, key_type: str = "invoice", conn: Optional[Connection] = None
+    key: str,
+    key_type: WalletType = WalletType.invoice,
+    conn: Optional[Connection] = None,
 ) -> Optional[Wallet]:
     row = await (conn or db).fetchone(
         """


### PR DESCRIPTION
this was missed here https://github.com/lnbits/lnbits/pull/1888

curious why mypy only started to error after i rebases here. https://github.com/lnbits/lnbits/actions/runs/5952068411/job/16143185781?pr=1887