### PR TITLE
[REFACTOR] `.super_user` move it into data dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ tests/data/*.sqlite3
 *.pyc
 *.env
 .env
-.super_user
 .pre-commit-config.yaml
 
 data

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 
 import click
 from loguru import logger
@@ -20,11 +21,22 @@ def command_group():
     """
 
 
+def get_super_user() -> str:
+    """Get the superuser"""
+    with open(Path(settings.lnbits_data_folder) / ".super_user", "r") as file:
+        return file.readline()
+
+
 @click.command("superuser")
 def superuser():
     """Prints the superuser"""
-    with open(".super_user", "r") as file:
-        print(f"http://{settings.host}:{settings.port}/wallet?usr={file.readline()}")
+    click.echo(get_super_user())
+
+
+@click.command("superuser-url")
+def superuser_url():
+    """Prints the superuser"""
+    click.echo(f"http://{settings.host}:{settings.port}/wallet?usr={get_super_user()}")
 
 
 @click.command("delete-settings")
@@ -101,6 +113,7 @@ async def load_disabled_extension_list() -> None:
 def main():
     """main function"""
     command_group.add_command(superuser)
+    command_group.add_command(superuser_url)
     command_group.add_command(delete_settings)
     command_group.add_command(database_migrate)
     command_group.add_command(database_versions)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from io import BytesIO
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple, TypedDict
 from urllib.parse import parse_qs, urlparse
 
@@ -482,11 +483,8 @@ async def check_admin_settings():
 
         update_cached_settings(settings_db.dict())
 
-        admin_url = f'{settings.lnbits_baseurl}wallet?usr=<ID from ".super_user" file>'
-        logger.success(f"✔️ Access super user account at: {admin_url}")
-
-        # saving it to .super_user file
-        with open(".super_user", "w") as file:
+        # saving superuser to {data_dir}/.super_user file
+        with open(Path(settings.lnbits_data_folder) / ".super_user", "w") as file:
             file.write(settings.super_user)
 
         # callback for saas
@@ -496,6 +494,11 @@ async def check_admin_settings():
             and settings.lnbits_saas_instance_id
         ):
             send_admin_user_to_saas()
+
+        logger.success(
+            "✔️ Admin UI is enabled. run `poetry run lnbits-cli superuser` "
+            "to get the superuser."
+        )
 
 
 def update_cached_settings(sets_dict: dict):


### PR DESCRIPTION
related to https://github.com/lnbits/lnbits/pull/1855 put the `.super_user` into our data_dir to not pollute our root dir removed the weird mention to the url in the logs and mention the `lnbits-cli superuser` instead

this is a breaking change for the bundlers, `cat .super_user` is not good anymore. fix would be `cat data/.super_user` but for future compatibility i recommend using `poetry run lnbits-cli superuser`