### PR TITLE
[FIX] fakewallet: set tag of description_hash invoice correctly

### DIFF
--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -61,7 +61,7 @@ class FakeWallet(Wallet):
             data["tags_set"] = ["h"]
             data["description_hash"] = description_hash
         elif unhashed_description:
-            data["tags_set"] = ["d"]
+            data["tags_set"] = ["h"]
             data["description_hash"] = hashlib.sha256(unhashed_description).digest()
         else:
             data["tags_set"] = ["d"]


### PR DESCRIPTION
When using `description_hash` the tag `h` needs to be set. 