### PR TITLE
[FEAT] improve update_admin_settings

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -797,11 +797,11 @@ async def get_admin_settings(is_super_user: bool = False) -> Optional[AdminSetti
     return admin_settings
 
 
-async def delete_admin_settings():
+async def delete_admin_settings() -> None:
     await db.execute("DELETE FROM settings")
 
 
-async def update_admin_settings(data: dict):
+async def update_admin_settings(data: dict) -> None:
     row = await db.fetchone("SELECT editable_settings FROM settings")
     if not row:
         return None

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -12,6 +12,7 @@ from lnbits.db import Connection, Database, Filters, Page
 from lnbits.extension_manager import InstallableExtension
 from lnbits.settings import (
     AdminSettings,
+    EditableSettings,
     SuperSettings,
     WebPushSettings,
     settings,
@@ -801,13 +802,10 @@ async def delete_admin_settings() -> None:
     await db.execute("DELETE FROM settings")
 
 
-async def update_admin_settings(data: dict) -> None:
+async def update_admin_settings(data: EditableSettings) -> None:
     row = await db.fetchone("SELECT editable_settings FROM settings")
-    if not row:
-        return None
-    editable_settings = json.loads(row["editable_settings"])
-    for key, value in data.items():
-        editable_settings[key] = value
+    editable_settings = json.loads(row["editable_settings"]) if row else {}
+    editable_settings.update(data.dict(exclude_unset=True))
     await db.execute(
         "UPDATE settings SET editable_settings = ?", (json.dumps(editable_settings),)
     )

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -571,7 +571,7 @@ async def check_webpush_settings():
             "lnbits_webpush_pubkey": pubkey,
         }
         update_cached_settings(push_settings)
-        await update_admin_settings(push_settings)
+        await update_admin_settings(EditableSettings(**push_settings))
 
     logger.info("Initialized webpush settings with generated VAPID key pair.")
     logger.info(f"Pubkey: {settings.lnbits_webpush_pubkey}")

--- a/lnbits/core/views/admin_api.py
+++ b/lnbits/core/views/admin_api.py
@@ -8,7 +8,6 @@ from urllib.parse import urlparse
 
 from fastapi import Depends
 from fastapi.responses import FileResponse
-from pydantic import Extra
 from starlette.exceptions import HTTPException
 
 from lnbits.core.crud import get_wallet
@@ -20,7 +19,7 @@ from lnbits.core.services import (
 )
 from lnbits.decorators import check_admin, check_super_user
 from lnbits.server import server_restart
-from lnbits.settings import AdminSettings, EditableSettings, settings
+from lnbits.settings import AdminSettings, UpdateSettings, settings
 
 from .. import core_app, core_app_extra
 from ..crud import delete_admin_settings, get_admin_settings, update_admin_settings
@@ -53,11 +52,6 @@ async def api_get_settings(
 ) -> Optional[AdminSettings]:
     admin_settings = await get_admin_settings(user.super_user)
     return admin_settings
-
-
-class UpdateSettings(EditableSettings):
-    class Config:
-        extra = Extra.forbid
 
 
 @core_app.put(

--- a/lnbits/core/views/admin_api.py
+++ b/lnbits/core/views/admin_api.py
@@ -61,7 +61,7 @@ async def api_get_settings(
 async def api_update_settings(
     data: EditableSettings, user: User = Depends(check_admin)
 ):
-    await update_admin_settings(EditableSettings(**data))  # type: ignore
+    await update_admin_settings(data)
     admin_settings = await get_admin_settings(user.super_user)
     assert admin_settings, "Updated admin settings not found."
     update_cached_settings(admin_settings.dict())

--- a/lnbits/core/views/admin_api.py
+++ b/lnbits/core/views/admin_api.py
@@ -19,7 +19,7 @@ from lnbits.core.services import (
 )
 from lnbits.decorators import check_admin, check_super_user
 from lnbits.server import server_restart
-from lnbits.settings import AdminSettings, settings
+from lnbits.settings import AdminSettings, EditableSettings, settings
 
 from .. import core_app, core_app_extra
 from ..crud import delete_admin_settings, get_admin_settings, update_admin_settings
@@ -58,8 +58,10 @@ async def api_get_settings(
     "/admin/api/v1/settings/",
     status_code=HTTPStatus.OK,
 )
-async def api_update_settings(data: dict, user: User = Depends(check_admin)):
-    await update_admin_settings(data)
+async def api_update_settings(
+    data: EditableSettings, user: User = Depends(check_admin)
+):
+    await update_admin_settings(EditableSettings(**data))  # type: ignore
     admin_settings = await get_admin_settings(user.super_user)
     assert admin_settings, "Updated admin settings not found."
     update_cached_settings(admin_settings.dict())

--- a/lnbits/core/views/admin_api.py
+++ b/lnbits/core/views/admin_api.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 from fastapi import Depends
 from fastapi.responses import FileResponse
+from pydantic import Extra
 from starlette.exceptions import HTTPException
 
 from lnbits.core.crud import get_wallet
@@ -54,13 +55,16 @@ async def api_get_settings(
     return admin_settings
 
 
+class UpdateSettings(EditableSettings):
+    class Config:
+        extra = Extra.forbid
+
+
 @core_app.put(
     "/admin/api/v1/settings/",
     status_code=HTTPStatus.OK,
 )
-async def api_update_settings(
-    data: EditableSettings, user: User = Depends(check_admin)
-):
+async def api_update_settings(data: UpdateSettings, user: User = Depends(check_admin)):
     await update_admin_settings(data)
     admin_settings = await get_admin_settings(user.super_user)
     assert admin_settings, "Updated admin settings not found."

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional
 
 import httpx
 from loguru import logger
-from pydantic import BaseModel, BaseSettings, Field, validator
+from pydantic import BaseModel, BaseSettings, Extra, Field, validator
 
 
 def list_parse_fallback(v: str):
@@ -260,6 +260,11 @@ class EditableSettings(
         def schema_extra(schema: dict[str, Any]) -> None:
             for prop in schema.get("properties", {}).values():
                 prop.pop("env_names", None)
+
+
+class UpdateSettings(EditableSettings):
+    class Config:
+        extra = Extra.forbid
 
 
 class EnvSettings(LNbitsSettings):

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -25,7 +25,7 @@ def list_parse_fallback(v: str):
 
 class LNbitsSettings(BaseSettings):
     @classmethod
-    def validate(cls, val):
+    def validate_list(cls, val):
         if isinstance(val, str):
             val = val.split(",") if val else []
         return val
@@ -35,7 +35,6 @@ class LNbitsSettings(BaseSettings):
         env_file_encoding = "utf-8"
         case_sensitive = False
         json_loads = list_parse_fallback
-        extra = Extra.ignore
 
 
 class UsersSettings(LNbitsSettings):
@@ -253,7 +252,7 @@ class EditableSettings(
     )
     @classmethod
     def validate_editable_settings(cls, val):
-        return super().validate(val)
+        return super().validate_list(val)
 
     @classmethod
     def from_dict(cls, d: dict):
@@ -338,7 +337,7 @@ class ReadOnlySettings(
     )
     @classmethod
     def validate_readonly_settings(cls, val):
-        return super().validate(val)
+        return super().validate_list(val)
 
     @classmethod
     def readonly_fields(cls):

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional
 
 import httpx
 from loguru import logger
-from pydantic import BaseSettings, Extra, Field, validator
+from pydantic import BaseModel, BaseSettings, Field, validator
 
 
 def list_parse_fallback(v: str):
@@ -23,18 +23,12 @@ def list_parse_fallback(v: str):
         return []
 
 
-class LNbitsSettings(BaseSettings):
+class LNbitsSettings(BaseModel):
     @classmethod
     def validate_list(cls, val):
         if isinstance(val, str):
             val = val.split(",") if val else []
         return val
-
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        case_sensitive = False
-        json_loads = list_parse_fallback
 
 
 class UsersSettings(LNbitsSettings):
@@ -344,11 +338,17 @@ class ReadOnlySettings(
         return [f for f in inspect.signature(cls).parameters if not f.startswith("_")]
 
 
-class Settings(EditableSettings, ReadOnlySettings, TransientSettings):
+class Settings(EditableSettings, ReadOnlySettings, TransientSettings, BaseSettings):
     @classmethod
     def from_row(cls, row: Row) -> "Settings":
         data = dict(row)
         return cls(**data)
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+        json_loads = list_parse_fallback
 
 
 class SuperSettings(EditableSettings):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,8 @@ from lnbits.db import Database
 from lnbits.settings import settings
 from tests.helpers import get_hold_invoice, get_random_invoice_data, get_real_invoice
 
-# dont install extensions for tests
+# override settings for tests
+settings.lnbits_admin_ui = True
 settings.lnbits_extensions_default_install = []
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from lnbits.settings import settings
 from tests.helpers import get_hold_invoice, get_random_invoice_data, get_real_invoice
 
 # override settings for tests
+settings.lnbits_data_folder = "./tests/data"
 settings.lnbits_admin_ui = True
 settings.lnbits_extensions_default_install = []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from lnbits.settings import settings
 from tests.helpers import get_hold_invoice, get_random_invoice_data, get_real_invoice
 
 # override settings for tests
+settings.lnbits_admin_extensions = []
 settings.lnbits_data_folder = "./tests/data"
 settings.lnbits_admin_ui = True
 settings.lnbits_extensions_default_install = []
@@ -89,7 +90,7 @@ async def to_user():
 
 
 @pytest_asyncio.fixture(scope="session")
-async def to_superuser():
+async def superuser():
     user = await get_user(settings.super_user)
     yield user
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
 from lnbits.app import create_app
-from lnbits.core.crud import create_account, create_wallet
+from lnbits.core.crud import create_account, create_wallet, get_user
 from lnbits.core.models import CreateInvoice
 from lnbits.core.services import update_wallet_balance
 from lnbits.core.views.api import api_payments_create_invoice
@@ -84,6 +84,12 @@ async def from_wallet_ws(from_wallet, test_client):
 @pytest_asyncio.fixture(scope="session")
 async def to_user():
     user = await create_account()
+    yield user
+
+
+@pytest_asyncio.fixture(scope="session")
+async def to_superuser():
+    user = await get_user(settings.super_user)
     yield user
 
 

--- a/tests/core/views/test_admin_api.py
+++ b/tests/core/views/test_admin_api.py
@@ -2,7 +2,35 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_admin_index(client, adminkey_headers_to):
-    response = await client.get("/admin/api/v1/", headers=adminkey_headers_to)
+async def test_admin_get_settings_permission_denied(client, to_user):
+    response = await client.get(f"/admin/api/v1/settings/?usr={to_user.id}")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_get_settings(client, to_superuser):
+    response = await client.get(f"/admin/api/v1/settings/?usr={to_superuser.id}")
     assert response.status_code == 200
-    # result = response.json()
+    result = response.json()
+    assert "super_user" not in result
+
+
+@pytest.mark.asyncio
+async def test_admin_update_settings(client, to_superuser):
+    response = await client.put(
+        f"/admin/api/v1/settings/?usr={to_superuser.id}",
+        json={"lnbits_site_title": "UPDATED SITETITLE"},
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert "status" in result
+    assert result.get("status") == "Success"
+
+
+@pytest.mark.asyncio
+async def test_admin_update_noneditable_settings(client, to_superuser):
+    response = await client.put(
+        f"/admin/api/v1/settings/?usr={to_superuser.id}",
+        json={"super_user": "UPDATED"},
+    )
+    assert response.status_code == 422

--- a/tests/core/views/test_admin_api.py
+++ b/tests/core/views/test_admin_api.py
@@ -4,24 +4,24 @@ from lnbits.settings import settings
 
 
 @pytest.mark.asyncio
-async def test_admin_get_settings_permission_denied(client, to_user):
-    response = await client.get(f"/admin/api/v1/settings/?usr={to_user.id}")
-    assert response.status_code == 403
+async def test_admin_get_settings_permission_denied(client, from_user):
+    response = await client.get(f"/admin/api/v1/settings/?usr={from_user.id}")
+    assert response.status_code == 401
 
 
 @pytest.mark.asyncio
-async def test_admin_get_settings(client, to_superuser):
-    response = await client.get(f"/admin/api/v1/settings/?usr={to_superuser.id}")
+async def test_admin_get_settings(client, superuser):
+    response = await client.get(f"/admin/api/v1/settings/?usr={superuser.id}")
     assert response.status_code == 200
     result = response.json()
     assert "super_user" not in result
 
 
 @pytest.mark.asyncio
-async def test_admin_update_settings(client, to_superuser):
+async def test_admin_update_settings(client, superuser):
     new_site_title = "UPDATED SITETITLE"
     response = await client.put(
-        f"/admin/api/v1/settings/?usr={to_superuser.id}",
+        f"/admin/api/v1/settings/?usr={superuser.id}",
         json={"lnbits_site_title": new_site_title},
     )
     assert response.status_code == 200
@@ -32,9 +32,9 @@ async def test_admin_update_settings(client, to_superuser):
 
 
 @pytest.mark.asyncio
-async def test_admin_update_noneditable_settings(client, to_superuser):
+async def test_admin_update_noneditable_settings(client, superuser):
     response = await client.put(
-        f"/admin/api/v1/settings/?usr={to_superuser.id}",
+        f"/admin/api/v1/settings/?usr={superuser.id}",
         json={"super_user": "UPDATED"},
     )
     assert response.status_code == 400

--- a/tests/core/views/test_admin_api.py
+++ b/tests/core/views/test_admin_api.py
@@ -1,5 +1,7 @@
 import pytest
 
+from lnbits.settings import settings
+
 
 @pytest.mark.asyncio
 async def test_admin_get_settings_permission_denied(client, to_user):
@@ -17,14 +19,16 @@ async def test_admin_get_settings(client, to_superuser):
 
 @pytest.mark.asyncio
 async def test_admin_update_settings(client, to_superuser):
+    new_site_title = "UPDATED SITETITLE"
     response = await client.put(
         f"/admin/api/v1/settings/?usr={to_superuser.id}",
-        json={"lnbits_site_title": "UPDATED SITETITLE"},
+        json={"lnbits_site_title": new_site_title},
     )
     assert response.status_code == 200
     result = response.json()
     assert "status" in result
     assert result.get("status") == "Success"
+    assert settings.lnbits_site_title == new_site_title
 
 
 @pytest.mark.asyncio
@@ -33,4 +37,4 @@ async def test_admin_update_noneditable_settings(client, to_superuser):
         f"/admin/api/v1/settings/?usr={to_superuser.id}",
         json={"super_user": "UPDATED"},
     )
-    assert response.status_code == 422
+    assert response.status_code == 400

--- a/tests/core/views/test_admin_api.py
+++ b/tests/core/views/test_admin_api.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_admin_index(client, adminkey_headers_to):
+    response = await client.get("/admin/api/v1/", headers=adminkey_headers_to)
+    assert response.status_code == 200
+    # result = response.json()


### PR DESCRIPTION
while working on the push notification pr i found it very hard just to update 2 settings inside the db, so i improved upon update_admin_settings. now you just need to provide a dict with key/values you want to update inside db.

also debugging the endpoints for update_settings i found despite the type of `EditableSettings` fastapi did in fact pass a dict.

import