### PR TITLE
[TEST] use clean db in postgres tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import asyncio
 
 import uvloop
 
-uvloop.install()  # noqa
+uvloop.install()
 
 import pytest
 import pytest_asyncio
@@ -16,7 +16,12 @@ from lnbits.core.services import update_wallet_balance
 from lnbits.core.views.api import api_payments_create_invoice
 from lnbits.db import Database
 from lnbits.settings import settings
-from tests.helpers import get_hold_invoice, get_random_invoice_data, get_real_invoice
+from tests.helpers import (
+    clean_database,
+    get_hold_invoice,
+    get_random_invoice_data,
+    get_real_invoice,
+)
 
 # dont install extensions for tests
 settings.lnbits_extensions_default_install = []
@@ -32,6 +37,7 @@ def event_loop():
 # use session scope to run once before and once after all tests
 @pytest_asyncio.fixture(scope="session")
 async def app():
+    clean_database(settings)
     app = create_app()
     await app.router.startup()
     yield app

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,8 +7,12 @@ import time
 from subprocess import PIPE, Popen, TimeoutExpired
 from typing import Tuple
 
+import psycopg2
 from loguru import logger
+from sqlalchemy.engine.url import make_url
 
+from lnbits import core
+from lnbits.db import DB_TYPE, POSTGRES
 from lnbits.wallets import get_wallet_class, set_wallet_class
 
 
@@ -131,3 +135,28 @@ def pay_onchain(address: str, sats: int) -> str:
     cmd = docker_bitcoin_cli.copy()
     cmd.extend(["sendtoaddress", address, str(btc)])
     return run_cmd(cmd)
+
+
+def clean_database(settings):
+    if DB_TYPE == POSTGRES:
+        db_url = make_url(settings.lnbits_database_url)
+
+        conn = psycopg2.connect(settings.lnbits_database_url)
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            try:
+                cur.execute("DROP DATABASE lnbits_test")
+            except psycopg2.errors.InvalidCatalogName:
+                pass
+            cur.execute("CREATE DATABASE lnbits_test")
+
+        db_url.database = "lnbits_test"
+        settings.lnbits_database_url = str(db_url)
+
+        core.db.__init__("database")
+
+        conn.close()
+    else:
+        # FIXME: do this once mock data is removed from test data folder
+        # os.remove(settings.lnbits_data_folder + "/database.sqlite3")
+        pass


### PR DESCRIPTION
Using the admin ui in tests has the side effect of loading settings from the database, which might contain some settings from manual testing.

To mitigates this, we can create a fresh postgres database for testing. This has also has the advantage that migrations run everytime and no leftovers are produced.