### PR TITLE
do not show deleted wallets

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -62,7 +62,9 @@ async def get_account(
 
 
 async def get_user(
-    user_id: str, conn: Optional[Connection] = None, deleted: Optional[bool] = False
+    user_id: str,
+    conn: Optional[Connection] = None,
+    include_deleted_wallets: Optional[bool] = False,
 ) -> Optional[User]:
     user = await (conn or db).fetchone(
         "SELECT id, email FROM accounts WHERE id = ?", (user_id,)
@@ -72,7 +74,7 @@ async def get_user(
         clauses = ["user = ?"]
         values: List[Any] = [user_id]
 
-        if not deleted:
+        if not include_deleted_wallets:
             clauses.append("deleted = ?")
             values.append(False)
 

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -61,25 +61,35 @@ async def get_account(
     return User(**row) if row else None
 
 
-async def get_user(user_id: str, conn: Optional[Connection] = None) -> Optional[User]:
+async def get_user(
+    user_id: str, conn: Optional[Connection] = None, deleted: Optional[bool] = False
+) -> Optional[User]:
     user = await (conn or db).fetchone(
         "SELECT id, email FROM accounts WHERE id = ?", (user_id,)
     )
 
     if user:
+        clauses = ["user = ?"]
+        values: List[Any] = [user_id]
+
+        if not deleted:
+            clauses.append("deleted = ?")
+            values.append(False)
+
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
         extensions = await (conn or db).fetchall(
             """SELECT extension FROM extensions WHERE "user" = ? AND active""",
             (user_id,),
         )
         wallets = await (conn or db).fetchall(
-            """
+            f"""
             SELECT *, COALESCE((
                 SELECT balance FROM balances WHERE wallet = wallets.id
             ), 0) AS balance_msat
             FROM wallets
-            WHERE "user" = ?
+            {where}
             """,
-            (user_id,),
+            tuple(values),
         )
     else:
         return None

--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -29,7 +29,7 @@ class Wallet(BaseModel):
     inkey: str
     currency: Optional[str]
     balance_msat: int
-    deleted: bool
+    deleted: Optional[bool] = False
 
     @property
     def balance(self) -> int:

--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -29,7 +29,7 @@ class Wallet(BaseModel):
     inkey: str
     currency: Optional[str]
     balance_msat: int
-    deleted: Optional[bool] = False
+    deleted: bool
 
     @property
     def balance(self) -> int:


### PR DESCRIPTION
Adds the deleted flag to the CRUD for `get_user`, so it doesn't send deleted wallets to the UI.

Closes #1939