### PR TITLE
fix: catch sse exceptions

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -478,8 +478,10 @@ async def subscribe_wallet_invoices(request: Request, wallet: Wallet):
                 yield dict(data=payment.json(), event="payment-received")
     except asyncio.CancelledError:
         logger.debug(f"removing listener for wallet {uid}")
+    except Exception as exc:
+        logger.error(f"Error in sse: {exc}")
+    finally:
         api_invoice_listeners.pop(uid)
-        return
 
 
 @api_router.get("/api/v1/payments/sse")


### PR DESCRIPTION
catches
```
2023-09-26T17:35:19-06:00  Task exception was never retrieved
2023-09-26T17:35:19-06:00  future: <Task finished name='Task-5361' coro=<EventSourceResponse._ping() done, defined at /root/.cache/pypoetry/virtualenvs/lnbits-9TtSrW0h-py3.10/lib/python3.10/site-packages/sse_starlette/sse.py:249> exception=ClosedResourceError()>
2023-09-26T17:35:19-06:00  Traceback (most recent call last):
2023-09-26T17:35:19-06:00    File "/root/.cache/pypoetry/virtualenvs/lnbits-9TtSrW0h-py3.10/lib/python3.10/site-packages/sse_starlette/sse.py", line 259, in _ping
2023-09-26T17:35:19-06:00      await send({"type": "http.response.body", "body": ping, "more_body": True})
2023-09-26T17:35:19-06:00    File "/root/.cache/pypoetry/virtualenvs/lnbits-9TtSrW0h-py3.10/lib/python3.10/site-packages/starlette/exceptions.py", line 79, in sender
2023-09-26T17:35:19-06:00      await send(message)
2023-09-26T17:35:19-06:00    File "/root/.cache/pypoetry/virtualenvs/lnbits-9TtSrW0h-py3.10/lib/python3.10/site-packages/anyio/streams/memory.py", line 209, in send
2023-09-26T17:35:19-06:00      self.send_nowait(item)
2023-09-26T17:35:19-06:00    File "/root/.cache/pypoetry/virtualenvs/lnbits-9TtSrW0h-py3.10/lib/python3.10/site-packages/anyio/streams/memory.py", line 191, in send_nowait
2023-09-26T17:35:19-06:00      raise ClosedResourceError
2023-09-26T17:35:19-06:00  anyio.ClosedResourceError
```