### PR TITLE
nix: fix nixosModule and build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,41 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688870561,
+        "narHash": "sha256-4UYkifnPEw1nAzqqPOTL2MvWtm3sNGw1UTYTalkTcGY=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "165b1650b753316aa7f1787f3005a8d2da0f5301",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
         "type": "github"
       }
     },
@@ -34,16 +58,17 @@
     "poetry2nix": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1678513806,
-        "narHash": "sha256-bEto1lp9bIQ+DlJsXQyRxN5l6B/oy3Skb7DueYRJJBo=",
+        "lastModified": 1695386222,
+        "narHash": "sha256-5lgnhCCGW0NH5+m5iTED8u6NSSM/dbH9LBPvX0x0XXg=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "bf239d53fafb53cf439a72b3a50e86dd6a3984a5",
+        "rev": "093383b3d7fdd36846a7d84e128ca11865800538",
         "type": "github"
       },
       "original": {
@@ -56,6 +81,21 @@
       "inputs": {
         "nixpkgs": "nixpkgs",
         "poetry2nix": "poetry2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.metadata
 import inspect
 import json
+import os
 import subprocess
 from os import path
 from sqlite3 import Row
@@ -430,7 +431,11 @@ try:
         .decode("ascii")
     )
 except Exception:
-    settings.lnbits_commit = "docker"
+    # Check if the LNBITS_COMMIT environment variable is set
+    if "LNBITS_COMMIT" in os.environ:
+        settings.lnbits_commit = os.environ["LNBITS_COMMIT"]
+    else:
+        settings.lnbits_commit = "docker"
 
 settings.version = importlib.metadata.version("lnbits")
 

--- a/nix/modules/lnbits-service.nix
+++ b/nix/modules/lnbits-service.nix
@@ -90,7 +90,6 @@ in
         LNBITS_DATA_FOLDER = "${cfg.stateDir}";
         LNBITS_EXTENSIONS_PATH = "${cfg.stateDir}/extensions";
         LNBITS_PATH = "${cfg.package.src}";
-        LNBITS_COMMIT = "${cfg.package.meta.rev}";
       };
       serviceConfig = {
         User = cfg.user;

--- a/nix/modules/lnbits-service.nix
+++ b/nix/modules/lnbits-service.nix
@@ -88,6 +88,9 @@ in
       after = [ "network-online.target" ];
       environment = {
         LNBITS_DATA_FOLDER = "${cfg.stateDir}";
+        LNBITS_EXTENSIONS_PATH = "${cfg.stateDir}/extensions";
+        LNBITS_PATH = "${cfg.package.src}";
+        LNBITS_COMMIT = "${cfg.package.meta.rev}";
       };
       serviceConfig = {
         User = cfg.user;

--- a/nix/tests/nixos-module/default.nix
+++ b/nix/tests/nixos-module/default.nix
@@ -1,5 +1,6 @@
 { pkgs, makeTest, inputs }:
 makeTest {
+  name = "lnbits-nixos-module";
   nodes = {
     client = { config, pkgs, ... }: {
       environment.systemPackages = [ pkgs.curl ];


### PR DESCRIPTION
There wasn't too much bitrot over time, this is a minimal PR to update potree2nix, get lnbits building again and passing the existing vmTest which is buildable via `nix build .#checks.x86_64-linux.vmTest -L` or `nix flake check` for example.

I've tested this as working on x86_64-linux and aarch64-linux.

It would be really nice if we could explain how to use the nixosModule in the Documentation rather than telling people to just `nix build` and run the program. The correct way to use the Nix work is via `services.lnbits.enable = true`, but this can be done in a later PR, and I'll endeavor to write that document.