### PR TITLE
feat: remove commit version

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -418,7 +418,6 @@ def log_server_info():
     logger.info(f"Site title: {settings.lnbits_site_title}")
     logger.info(f"Funding source: {settings.lnbits_backend_wallet_class}")
     logger.info(f"Data folder: {settings.lnbits_data_folder}")
-    logger.info(f"Git version: {settings.lnbits_commit}")
     logger.info(f"Database: {get_db_vendor_name()}")
     logger.info(f"Service fee: {settings.lnbits_service_fee}")
 

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -49,7 +49,6 @@ def template_renderer(additional_folders: Optional[List] = None) -> Jinja2Templa
     t.env.globals["SITE_TAGLINE"] = settings.lnbits_site_tagline
     t.env.globals["SITE_DESCRIPTION"] = settings.lnbits_site_description
     t.env.globals["LNBITS_THEME_OPTIONS"] = settings.lnbits_theme_options
-    t.env.globals["COMMIT_VERSION"] = settings.lnbits_commit
     t.env.globals["LNBITS_VERSION"] = settings.version
     t.env.globals["LNBITS_ADMIN_UI"] = settings.lnbits_admin_ui
     t.env.globals["LNBITS_NODE_UI"] = (

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -4,7 +4,6 @@ import importlib
 import importlib.metadata
 import inspect
 import json
-import subprocess
 from os import path
 from sqlite3 import Row
 from typing import Any, List, Optional
@@ -289,7 +288,6 @@ class EnvSettings(LNbitsSettings):
     lnbits_title: str = Field(default="LNbits API")
     lnbits_path: str = Field(default=".")
     lnbits_extensions_path: str = Field(default="lnbits")
-    lnbits_commit: str = Field(default="unknown")
     super_user: str = Field(default="")
     version: str = Field(default="0.0.0")
 
@@ -419,18 +417,6 @@ transient_variables = TransientSettings.readonly_fields()
 settings = Settings()
 
 settings.lnbits_path = str(path.dirname(path.realpath(__file__)))
-
-try:
-    settings.lnbits_commit = (
-        subprocess.check_output(
-            ["git", "-C", settings.lnbits_path, "rev-parse", "HEAD"],
-            stderr=subprocess.DEVNULL,
-        )
-        .strip()
-        .decode("ascii")
-    )
-except Exception:
-    settings.lnbits_commit = "docker"
 
 settings.version = importlib.metadata.version("lnbits")
 

--- a/lnbits/static/i18n/br.js
+++ b/lnbits/static/i18n/br.js
@@ -37,7 +37,6 @@ window.localisation.br = {
   toggle_darkmode: 'Alternar modo escuro',
   view_swagger_docs: 'Ver a documentação da API do LNbits Swagger',
   api_docs: 'Documentação da API',
-  commit_version: 'Versão de commit',
   lnbits_version: 'Versão do LNbits',
   runs_on: 'Executa em',
   credit_hint: 'Pressione Enter para creditar a conta',

--- a/lnbits/static/i18n/cn.js
+++ b/lnbits/static/i18n/cn.js
@@ -36,7 +36,6 @@ window.localisation.cn = {
   toggle_darkmode: '切换暗黑模式',
   view_swagger_docs: '查看 LNbits Swagger API 文档',
   api_docs: 'API文档',
-  commit_version: '提交版本',
   lnbits_version: 'LNbits版本',
   runs_on: '可运行在',
   credit_hint: '按 Enter 键充值账户',

--- a/lnbits/static/i18n/de.js
+++ b/lnbits/static/i18n/de.js
@@ -40,7 +40,6 @@ window.localisation.de = {
   toggle_darkmode: 'Auf Dark Mode umschalten',
   view_swagger_docs: 'LNbits Swagger API-Dokumente',
   api_docs: 'API docs',
-  commit_version: 'Commit Version',
   runs_on: 'Läuft auf',
   credit_hint: 'Klicke Enter, um das Konto zu belasten',
   credit_label: '%{denomination} zu belasten',

--- a/lnbits/static/i18n/en.js
+++ b/lnbits/static/i18n/en.js
@@ -58,7 +58,6 @@ window.localisation.en = {
   toggle_darkmode: 'Toggle Dark Mode',
   view_swagger_docs: 'View LNbits Swagger API docs',
   api_docs: 'Api docs',
-  commit_version: 'Commit version',
   lnbits_version: 'LNbits version',
   runs_on: 'Runs on',
   credit_hint: 'Press Enter to credit account',

--- a/lnbits/static/i18n/es.js
+++ b/lnbits/static/i18n/es.js
@@ -38,7 +38,6 @@ window.localisation.es = {
   toggle_darkmode: 'Cambiar modo oscuro',
   view_swagger_docs: 'Ver documentos de API de LNbits Swagger',
   api_docs: 'Documentos de API',
-  commit_version: 'Versión de compromiso',
   runs_on: 'Corre en',
   credit_hint: 'Presione Enter para cargar la cuenta',
   credit_label: 'Cargar %{denomination}',

--- a/lnbits/static/i18n/fr.js
+++ b/lnbits/static/i18n/fr.js
@@ -41,7 +41,6 @@ window.localisation.fr = {
   toggle_darkmode: 'Basculer le mode sombre',
   view_swagger_docs: "Voir les documents de l'API Swagger de LNbits",
   api_docs: "Documents de l'API",
-  commit_version: 'Version de commit',
   lnbits_version: 'Version de LNbits',
   runs_on: 'Fonctionne sur',
   credit_hint: 'Appuyez sur Entrée pour créditer le compte',

--- a/lnbits/static/i18n/it.js
+++ b/lnbits/static/i18n/it.js
@@ -38,7 +38,6 @@ window.localisation.it = {
   toggle_darkmode: 'Attiva la modalità notturna',
   view_swagger_docs: "Visualizza i documenti dell'API Swagger di LNbits",
   api_docs: 'Documenti API',
-  commit_version: 'Commit version',
   lnbits_version: 'Versione di LNbits',
   runs_on: 'Esegue su',
   credit_hint: 'Premere Invio per accreditare i fondi',

--- a/lnbits/static/i18n/jp.js
+++ b/lnbits/static/i18n/jp.js
@@ -36,7 +36,6 @@ window.localisation.jp = {
   toggle_dark_mode: 'ダークモードを切り替える',
   view_swagger_docs: 'Swaggerドキュメントを表示',
   api_docs: 'APIドキュメント',
-  commit_version: 'コミットバージョン',
   runs_on: 'で実行',
   credit_hint:
     'クレジットカードを使用して資金を追加するには、LNbitsを使用してください。',

--- a/lnbits/static/i18n/nl.js
+++ b/lnbits/static/i18n/nl.js
@@ -39,7 +39,6 @@ window.localisation.nl = {
   toggle_darkmode: 'Donkere modus aan/uit',
   view_swagger_docs: 'Bekijk LNbits Swagger API-documentatie',
   api_docs: 'API-documentatie',
-  commit_version: 'Commit-versie',
   lnbits_version: 'LNbits-versie',
   runs_on: 'Draait op',
   credit_hint: 'Druk op Enter om de rekening te crediteren',

--- a/lnbits/static/i18n/pi.js
+++ b/lnbits/static/i18n/pi.js
@@ -38,7 +38,6 @@ window.localisation.pi = {
   toggle_darkmode: 'Toggle Dark Mode, arr!',
   view_swagger_docs: 'View LNbits Swagger API docs and learn the secrets',
   api_docs: 'API docs for the scallywags',
-  commit_version: 'Commit version like a true pirate',
   lnbits_version: 'LNbits version, arr!',
   runs_on: 'Runs on, matey',
   credit_hint: 'Press Enter to credit account and make it richer',

--- a/lnbits/static/i18n/pl.js
+++ b/lnbits/static/i18n/pl.js
@@ -36,7 +36,6 @@ window.localisation.pl = {
   toggle_darkmode: 'Tryb nocny',
   view_swagger_docs: 'Dokumentacja Swagger API',
   api_docs: 'Dokumentacja API',
-  commit_version: 'Commit',
   lnbits_version: 'Wersja LNbits',
   runs_on: 'Działa na',
   credit_hint: 'Naciśnij Enter aby doładować konto',

--- a/lnbits/static/i18n/pt.js
+++ b/lnbits/static/i18n/pt.js
@@ -37,7 +37,6 @@ window.localisation.pt = {
   toggle_darkmode: 'Alternar modo escuro',
   view_swagger_docs: 'Ver a documentação da API do LNbits Swagger',
   api_docs: 'Documentação da API',
-  commit_version: 'Versão de commit',
   lnbits_version: 'Versão do LNbits',
   runs_on: 'Executa em',
   credit_hint: 'Pressione Enter para creditar a conta',

--- a/lnbits/static/i18n/we.js
+++ b/lnbits/static/i18n/we.js
@@ -37,7 +37,6 @@ window.localisation.we = {
   toggle_darkmode: 'Toglo Modd Tywyll',
   view_swagger_docs: 'Gweld dogfennau API LNbits Swagger',
   api_docs: 'Api docs',
-  commit_version: 'fersiwn ymrwymo',
   lnbits_version: 'Fersiwn LNbits',
   Runs_on: 'Yn rhedeg ymlaen',
   credit_hint: 'Pwyswch Enter i gyfrif credyd',

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -253,10 +253,6 @@
               >{% raw %}{{ $t('lnbits_version') }}{% endraw %}:
               {{LNBITS_VERSION}},
             </small>
-            <small
-              >{% raw %}{{ $t('commit_version') }}{% endraw %}:
-              {{COMMIT_VERSION}}</small
-            >
           </q-toolbar-title>
           <q-space></q-space>
           <q-btn


### PR DESCRIPTION
### Summary
- remove the `settings.lnbits_commit` property from logs and UI

Reason:
 - it makes it harder to have reproducible build
 - lnbits  now uses `dev` branch for unstable releases and `main` for stable, tagged releases. Therefore the commit version is redundant