### PR TITLE
refactor: split admin_api and superuser_api

### DIFF
--- a/lnbits/core/__init__.py
+++ b/lnbits/core/__init__.py
@@ -8,6 +8,7 @@ from .views.api import api_router
 from .views.generic import generic_router, update_user_extension
 from .views.node_api import node_router, public_node_router, super_node_router
 from .views.public_api import public_router
+from .views.superuser_api import superuser_router
 
 # backwards compatibility for extensions
 core_app = APIRouter(tags=["Core"])
@@ -22,3 +23,4 @@ def init_core_routers(app):
     app.include_router(super_node_router)
     app.include_router(public_node_router)
     app.include_router(admin_router)
+    app.include_router(superuser_router)

--- a/lnbits/core/templates/admin/index.html
+++ b/lnbits/core/templates/admin/index.html
@@ -537,7 +537,7 @@
       },
       restartServer() {
         LNbits.api
-          .request('GET', '/admin/api/v1/restart/?usr=' + this.g.user.id)
+          .request('GET', '/superuser/api/v1/restart/?usr=' + this.g.user.id)
           .then(response => {
             this.$q.notify({
               type: 'positive',
@@ -554,7 +554,7 @@
         LNbits.api
           .request(
             'PUT',
-            '/admin/api/v1/topup/?usr=' + this.g.user.id,
+            '/superuser/api/v1/topup/?usr=' + this.g.user.id,
             this.g.user.wallets[0].adminkey,
             this.wallet
           )
@@ -675,7 +675,7 @@
             LNbits.api
               .request(
                 'DELETE',
-                '/admin/api/v1/settings/?usr=' + this.g.user.id
+                '/superuser/api/v1/settings/?usr=' + this.g.user.id
               )
               .then(response => {
                 this.$q.notify({
@@ -692,7 +692,7 @@
           })
       },
       downloadBackup() {
-        window.open('/admin/api/v1/backup/?usr=' + this.g.user.id, '_blank')
+        window.open('/superuser/api/v1/backup/?usr=' + this.g.user.id, '_blank')
       }
     }
   })

--- a/lnbits/core/views/admin_api.py
+++ b/lnbits/core/views/admin_api.py
@@ -1,37 +1,30 @@
-import os
-import time
 from http import HTTPStatus
-from shutil import make_archive
-from subprocess import Popen
 from typing import Optional
-from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends
-from fastapi.responses import FileResponse
 from starlette.exceptions import HTTPException
 
-from lnbits.core.crud import get_wallet
-from lnbits.core.models import CreateTopup, User
+from lnbits.core.models import User
 from lnbits.core.services import (
     get_balance_delta,
     update_cached_settings,
-    update_wallet_balance,
 )
-from lnbits.decorators import check_admin, check_super_user
-from lnbits.server import server_restart
-from lnbits.settings import AdminSettings, UpdateSettings, settings
+from lnbits.decorators import check_admin
+from lnbits.settings import AdminSettings, UpdateSettings
 
 from .. import core_app_extra
-from ..crud import delete_admin_settings, get_admin_settings, update_admin_settings
+from ..crud import get_admin_settings, update_admin_settings
 
-admin_router = APIRouter()
+admin_router = APIRouter(
+    prefix="/admin/api/v1",
+    dependencies=[Depends(check_admin)],
+)
 
 
 @admin_router.get(
-    "/admin/api/v1/audit",
+    "/audit",
     name="Audit",
     description="show the current balance of the node and the LNbits database",
-    dependencies=[Depends(check_admin)],
 )
 async def api_auditor():
     try:
@@ -48,7 +41,10 @@ async def api_auditor():
         )
 
 
-@admin_router.get("/admin/api/v1/settings/", response_model=Optional[AdminSettings])
+@admin_router.get(
+    "/settings",
+    response_model=Optional[AdminSettings],
+)
 async def api_get_settings(
     user: User = Depends(check_admin),
 ) -> Optional[AdminSettings]:
@@ -57,7 +53,7 @@ async def api_get_settings(
 
 
 @admin_router.put(
-    "/admin/api/v1/settings/",
+    "/settings",
     status_code=HTTPStatus.OK,
 )
 async def api_update_settings(data: UpdateSettings, user: User = Depends(check_admin)):
@@ -67,87 +63,3 @@ async def api_update_settings(data: UpdateSettings, user: User = Depends(check_a
     update_cached_settings(admin_settings.dict())
     core_app_extra.register_new_ratelimiter()
     return {"status": "Success"}
-
-
-@admin_router.delete(
-    "/admin/api/v1/settings/",
-    status_code=HTTPStatus.OK,
-    dependencies=[Depends(check_super_user)],
-)
-async def api_delete_settings() -> None:
-    await delete_admin_settings()
-    server_restart.set()
-
-
-@admin_router.get(
-    "/admin/api/v1/restart/",
-    status_code=HTTPStatus.OK,
-    dependencies=[Depends(check_super_user)],
-)
-async def api_restart_server() -> dict[str, str]:
-    server_restart.set()
-    return {"status": "Success"}
-
-
-@admin_router.put(
-    "/admin/api/v1/topup/",
-    name="Topup",
-    status_code=HTTPStatus.OK,
-    dependencies=[Depends(check_super_user)],
-)
-async def api_topup_balance(data: CreateTopup) -> dict[str, str]:
-    try:
-        await get_wallet(data.id)
-    except Exception:
-        raise HTTPException(
-            status_code=HTTPStatus.FORBIDDEN, detail="wallet does not exist."
-        )
-
-    if settings.lnbits_backend_wallet_class == "VoidWallet":
-        raise HTTPException(
-            status_code=HTTPStatus.FORBIDDEN, detail="VoidWallet active"
-        )
-
-    await update_wallet_balance(wallet_id=data.id, amount=int(data.amount))
-
-    return {"status": "Success"}
-
-
-@admin_router.get(
-    "/admin/api/v1/backup/",
-    status_code=HTTPStatus.OK,
-    dependencies=[Depends(check_super_user)],
-    response_class=FileResponse,
-)
-async def api_download_backup() -> FileResponse:
-    last_filename = "lnbits-backup"
-    filename = f"lnbits-backup-{int(time.time())}.zip"
-    db_url = settings.lnbits_database_url
-    pg_backup_filename = f"{settings.lnbits_data_folder}/lnbits-database.dmp"
-    is_pg = db_url and db_url.startswith("postgres://")
-
-    if is_pg:
-        p = urlparse(db_url)
-        command = (
-            f"pg_dump --host={p.hostname} "
-            f"--dbname={p.path.replace('/', '')} "
-            f"--username={p.username} "
-            "--no-password "
-            "--format=c "
-            f"--file={pg_backup_filename}"
-        )
-        proc = Popen(
-            command, shell=True, env={**os.environ, "PGPASSWORD": p.password or ""}
-        )
-        proc.wait()
-
-    make_archive(last_filename, "zip", settings.lnbits_data_folder)
-
-    # cleanup pg_dump file
-    if is_pg:
-        proc = Popen(f"rm {pg_backup_filename}", shell=True)
-        proc.wait()
-
-    return FileResponse(
-        path=f"{last_filename}.zip", filename=filename, media_type="application/zip"
-    )

--- a/lnbits/core/views/admin_api.py
+++ b/lnbits/core/views/admin_api.py
@@ -22,7 +22,7 @@ admin_router = APIRouter(
 
 
 @admin_router.get(
-    "/audit",
+    "/audit/",
     name="Audit",
     description="show the current balance of the node and the LNbits database",
 )
@@ -42,7 +42,7 @@ async def api_auditor():
 
 
 @admin_router.get(
-    "/settings",
+    "/settings/",
     response_model=Optional[AdminSettings],
 )
 async def api_get_settings(
@@ -53,7 +53,7 @@ async def api_get_settings(
 
 
 @admin_router.put(
-    "/settings",
+    "/settings/",
     status_code=HTTPStatus.OK,
 )
 async def api_update_settings(data: UpdateSettings, user: User = Depends(check_admin)):

--- a/lnbits/core/views/superuser_api.py
+++ b/lnbits/core/views/superuser_api.py
@@ -27,7 +27,7 @@ superuser_router = APIRouter(
 
 
 @superuser_router.delete(
-    "/settings",
+    "/settings/",
     status_code=HTTPStatus.OK,
 )
 async def api_delete_settings() -> None:
@@ -36,7 +36,7 @@ async def api_delete_settings() -> None:
 
 
 @superuser_router.get(
-    "/restart",
+    "/restart/",
     status_code=HTTPStatus.OK,
 )
 async def api_restart_server() -> dict[str, str]:
@@ -45,7 +45,7 @@ async def api_restart_server() -> dict[str, str]:
 
 
 @superuser_router.put(
-    "/topup",
+    "/topup/",
     name="Topup",
     status_code=HTTPStatus.OK,
 )
@@ -68,7 +68,7 @@ async def api_topup_balance(data: CreateTopup) -> dict[str, str]:
 
 
 @superuser_router.get(
-    "/backup",
+    "/backup/",
     status_code=HTTPStatus.OK,
     response_class=FileResponse,
 )

--- a/lnbits/core/views/superuser_api.py
+++ b/lnbits/core/views/superuser_api.py
@@ -1,0 +1,106 @@
+import os
+import time
+from http import HTTPStatus
+from shutil import make_archive
+from subprocess import Popen
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import FileResponse
+from starlette.exceptions import HTTPException
+
+from lnbits.core.crud import get_wallet
+from lnbits.core.models import CreateTopup
+from lnbits.core.services import (
+    update_wallet_balance,
+)
+from lnbits.decorators import check_super_user
+from lnbits.server import server_restart
+from lnbits.settings import settings
+
+from ..crud import delete_admin_settings
+
+superuser_router = APIRouter(
+    prefix="/superuser/api/v1",
+    dependencies=[Depends(check_super_user)],
+)
+
+
+@superuser_router.delete(
+    "/settings",
+    status_code=HTTPStatus.OK,
+)
+async def api_delete_settings() -> None:
+    await delete_admin_settings()
+    server_restart.set()
+
+
+@superuser_router.get(
+    "/restart",
+    status_code=HTTPStatus.OK,
+)
+async def api_restart_server() -> dict[str, str]:
+    server_restart.set()
+    return {"status": "Success"}
+
+
+@superuser_router.put(
+    "/topup",
+    name="Topup",
+    status_code=HTTPStatus.OK,
+)
+async def api_topup_balance(data: CreateTopup) -> dict[str, str]:
+    try:
+        await get_wallet(data.id)
+    except Exception:
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN, detail="wallet does not exist."
+        )
+
+    if settings.lnbits_backend_wallet_class == "VoidWallet":
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN, detail="VoidWallet active"
+        )
+
+    await update_wallet_balance(wallet_id=data.id, amount=int(data.amount))
+
+    return {"status": "Success"}
+
+
+@superuser_router.get(
+    "/backup",
+    status_code=HTTPStatus.OK,
+    response_class=FileResponse,
+)
+async def api_download_backup() -> FileResponse:
+    last_filename = "lnbits-backup"
+    filename = f"lnbits-backup-{int(time.time())}.zip"
+    db_url = settings.lnbits_database_url
+    pg_backup_filename = f"{settings.lnbits_data_folder}/lnbits-database.dmp"
+    is_pg = db_url and db_url.startswith("postgres://")
+
+    if is_pg:
+        p = urlparse(db_url)
+        command = (
+            f"pg_dump --host={p.hostname} "
+            f"--dbname={p.path.replace('/', '')} "
+            f"--username={p.username} "
+            "--no-password "
+            "--format=c "
+            f"--file={pg_backup_filename}"
+        )
+        proc = Popen(
+            command, shell=True, env={**os.environ, "PGPASSWORD": p.password or ""}
+        )
+        proc.wait()
+
+    make_archive(last_filename, "zip", settings.lnbits_data_folder)
+
+    # cleanup pg_dump file
+    if is_pg:
+        proc = Popen(f"rm {pg_backup_filename}", shell=True)
+        proc.wait()
+
+    return FileResponse(
+        path=f"{last_filename}.zip", filename=filename, media_type="application/zip"
+    )


### PR DESCRIPTION
adds dependencies `check_admin` and `check_super_user` to APIRouter. 
goal of this pr is to make it clearer which api endpoint has which permissions.