### PR TITLE
fix: Closed channels affecting the stats

### DIFF
--- a/lnbits/nodes/base.py
+++ b/lnbits/nodes/base.py
@@ -70,7 +70,7 @@ class ChannelStats(BaseModel):
 
         return cls(
             counts=counts,
-            avg_size=int(sum(active_channel_sizes) / len(channels)),
+            avg_size=int(sum(active_channel_sizes) / len(active_channel_sizes)),
             biggest_size=max(active_channel_sizes),
             smallest_size=min(active_channel_sizes),
             total_capacity=sum(active_channel_sizes),

--- a/lnbits/nodes/base.py
+++ b/lnbits/nodes/base.py
@@ -67,9 +67,9 @@ class ChannelStats(BaseModel):
             avg_size=int(
                 sum(channel.balance.total_msat for channel in channels) / len(channels)
             ),
-            biggest_size=max(channel.balance.total_msat for channel in channels),
-            smallest_size=min(channel.balance.total_msat for channel in channels),
-            total_capacity=sum(channel.balance.total_msat for channel in channels),
+            biggest_size=max(channel.balance.total_msat for channel in channels if channel.state == ChannelState.ACTIVE),
+            smallest_size=min(channel.balance.total_msat for channel in channels if channel.state == ChannelState.ACTIVE),
+            total_capacity=sum(channel.balance.total_msat for channel in channels if channel.state == ChannelState.ACTIVE),
         )
 
 

--- a/lnbits/nodes/base.py
+++ b/lnbits/nodes/base.py
@@ -67,9 +67,21 @@ class ChannelStats(BaseModel):
             avg_size=int(
                 sum(channel.balance.total_msat for channel in channels) / len(channels)
             ),
-            biggest_size=max(channel.balance.total_msat for channel in channels if channel.state == ChannelState.ACTIVE),
-            smallest_size=min(channel.balance.total_msat for channel in channels if channel.state == ChannelState.ACTIVE),
-            total_capacity=sum(channel.balance.total_msat for channel in channels if channel.state == ChannelState.ACTIVE),
+            biggest_size=max(
+                channel.balance.total_msat
+                for channel in channels
+                if channel.state == ChannelState.ACTIVE
+            ),
+            smallest_size=min(
+                channel.balance.total_msat
+                for channel in channels
+                if channel.state == ChannelState.ACTIVE
+            ),
+            total_capacity=sum(
+                channel.balance.total_msat
+                for channel in channels
+                if channel.state == ChannelState.ACTIVE
+            ),
         )
 
 

--- a/lnbits/nodes/base.py
+++ b/lnbits/nodes/base.py
@@ -62,26 +62,18 @@ class ChannelStats(BaseModel):
         for channel in channels:
             counts[channel.state] = counts.get(channel.state, 0) + 1
 
+        active_channel_sizes = [
+            channel.balance.total_msat
+            for channel in channels
+            if channel.state == ChannelState.ACTIVE
+        ]
+
         return cls(
             counts=counts,
-            avg_size=int(
-                sum(channel.balance.total_msat for channel in channels) / len(channels)
-            ),
-            biggest_size=max(
-                channel.balance.total_msat
-                for channel in channels
-                if channel.state == ChannelState.ACTIVE
-            ),
-            smallest_size=min(
-                channel.balance.total_msat
-                for channel in channels
-                if channel.state == ChannelState.ACTIVE
-            ),
-            total_capacity=sum(
-                channel.balance.total_msat
-                for channel in channels
-                if channel.state == ChannelState.ACTIVE
-            ),
+            avg_size=int(sum(active_channel_sizes) / len(channels)),
+            biggest_size=max(active_channel_sizes),
+            smallest_size=min(active_channel_sizes),
+            total_capacity=sum(active_channel_sizes),
         )
 
 


### PR DESCRIPTION
So I've updated to 0.11.0, rushed the new node stats and it just doesn't seem right to me. Closed channels are being included. Here I'm offering my humble hot fix. 

Maybe also inactive channels should be included in some/all of those stats? Let me know what you think. 