### PR TITLE
use current version of logo for manifest icon

### DIFF
--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -348,7 +348,7 @@ async def manifest(request: Request, usr: str):
                 "src": (
                     settings.lnbits_custom_logo
                     if settings.lnbits_custom_logo
-                    else "https://cdn.jsdelivr.net/gh/lnbits/lnbits@0.3.0/docs/logos/lnbits.png"
+                    else "https://cdn.jsdelivr.net/gh/lnbits/lnbits@main/docs/logos/lnbits.png"
                 ),
                 "type": "image/png",
                 "sizes": "900x900",


### PR DESCRIPTION
manifest still uses icon from 0.3.0

let's use the current one (from the main branch)