### PR TITLE
feat: add useful query helpers for insert and update

### DIFF
--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Type
 
 import jinja2
 import shortuuid
+from pydantic import BaseModel
 from pydantic.schema import field_schema
 
 from lnbits.jinja2_templating import Jinja2Templates
@@ -135,3 +136,25 @@ def generate_filter_params_openapi(model: Type[FilterModel], keep_optional=False
     return {
         "parameters": params,
     }
+
+
+def insert_query(table_name: str, model: BaseModel) -> str:
+    """
+    Generate an insert query with placeholders for a given table and model
+    :param table_name: Name of the table
+    :param model: Pydantic model
+    """
+    placeholders = ", ".join(["?"] * len(model.dict().keys()))
+    fields = ", ".join(model.dict().keys())
+    return f"INSERT INTO {table_name} ({fields}) VALUES ({placeholders})"
+
+
+def update_query(table_name: str, model: BaseModel, where: str = "WHERE id = ?") -> str:
+    """
+    Generate an update query with placeholders for a given table and model
+    :param table_name: Name of the table
+    :param model: Pydantic model
+    :param where: Where string, default to `WHERE id = ?`
+    """
+    query = ", ".join([f"{field} = ?" for field in model.dict().keys()])
+    return f"UPDATE {table_name} SET ({query}) {where}"

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -157,4 +157,4 @@ def update_query(table_name: str, model: BaseModel, where: str = "WHERE id = ?")
     :param where: Where string, default to `WHERE id = ?`
     """
     query = ", ".join([f"{field} = ?" for field in model.dict().keys()])
-    return f"UPDATE {table_name} SET ({query}) {where}"
+    return f"UPDATE {table_name} SET {query} {where}"

--- a/tests/core/test_helpers_query.py
+++ b/tests/core/test_helpers_query.py
@@ -24,4 +24,4 @@ async def test_helpers_insert_query():
 @pytest.mark.asyncio
 async def test_helpers_update_query():
     q = update_query("test_helpers_query", test)
-    assert q == "UPDATE test_helpers_query SET (id = ?, name = ?) WHERE id = ?"
+    assert q == "UPDATE test_helpers_query SET id = ?, name = ? WHERE id = ?"

--- a/tests/core/test_helpers_query.py
+++ b/tests/core/test_helpers_query.py
@@ -1,0 +1,27 @@
+import pytest
+from pydantic import BaseModel
+
+from lnbits.helpers import (
+    insert_query,
+    update_query,
+)
+
+
+class TestModel(BaseModel):
+    id: int
+    name: str
+
+
+test = TestModel(id=1, name="test")
+
+
+@pytest.mark.asyncio
+async def test_helpers_insert_query():
+    q = insert_query("test_helpers_query", test)
+    assert q == "INSERT INTO test_helpers_query (id, name) VALUES (?, ?)"
+
+
+@pytest.mark.asyncio
+async def test_helpers_update_query():
+    q = update_query("test_helpers_query", test)
+    assert q == "UPDATE test_helpers_query SET (id = ?, name = ?) WHERE id = ?"


### PR DESCRIPTION
i saw this bits of code all over the codebase, this `helpers.py` tries to abstract that away and make it more readable.

in boltz alone i used this pattern 3 times.
here is the pr utilizing the insert_query.
https://github.com/lnbits/boltz/pull/13

todo:
- [x] tests