### PR TITLE
add "nix build" to GitHub CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,28 @@
+name: LNbits CI / nix
+
+on:
+  push:
+    branches:
+        - main
+        - dev
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v23
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix build

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,8 +3,8 @@ name: LNbits CI / nix
 on:
   push:
     branches:
-        - main
-        - dev
+      - main
+      - dev
     paths:
       - 'flake.nix'
       - 'flake.lock'
@@ -21,8 +21,8 @@ jobs:
   nix:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v23
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - run: nix build
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v23
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix build


### PR DESCRIPTION
builds on top of https://github.com/lnbits/lnbits/pull/2027 which is needed for the successful nix build

The `nix build` action in the CI [takes around **~36** minutes](https://github.com/lnbits/lnbits/actions/runs/6473111117/job/17575129639?pr=2026), so it is run only if run only when poetry/flake files are changed