### PR TITLE
fix: explicitly specify the DB name when migrating

### DIFF
--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -89,7 +89,7 @@ async def migrate_databases():
 
         current_versions = await get_dbversions(conn)
         core_version = current_versions.get("core", 0)
-        await run_migration(conn, core_migrations, core_version)
+        await run_migration(conn, core_migrations, "core", core_version)
 
     for ext in get_valid_extensions():
         current_version = current_versions.get(ext.code, 0)

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -25,12 +25,13 @@ async def migrate_extension_database(ext: Extension, current_version):
         )
 
     async with ext_db.connect() as ext_conn:
-        await run_migration(ext_conn, ext_migrations, current_version)
+        await run_migration(ext_conn, ext_migrations, ext.code, current_version)
 
 
-async def run_migration(db: Connection, migrations_module: Any, current_version: int):
+async def run_migration(
+    db: Connection, migrations_module: Any, db_name: str, current_version: int
+):
     matcher = re.compile(r"^m(\d\d\d)_")
-    db_name = migrations_module.__name__.split(".")[-2]
     for key, migrate in migrations_module.__dict__.items():
         match = matcher.match(key)
         if match:


### PR DESCRIPTION
### Summary
Each extension has a DB version stored in the `dbversions` table. When an extension is upgraded this version can change if there are new scripts in `migration.py` file.

The bug is on extension upgrade. The temp upgraded module name was used for the `dbversions` table:
![image](https://github.com/lnbits/lnbits/assets/2951406/e0614186-ead0-457e-a9e8-44f1de6c3edc)

The fix uses the explicit DB name.

**Test Steps**:
 - install an extension with a lower version (eg: satspay v0.2.3)
 - upgrade to a higher version (eg: satspay v0.2.5)

**Actual Result**:
 - two entries for `satspay` are now in the `dbversions` (see screenshot)

**Expected Result**:
 - the `satspay` entry gets updated to version `7`
 - no new `satspay` entry in `dbversions`

**Note**:
 - I suspect this bug was introduced with this PR https://github.com/lnbits/lnbits/pull/1940 