### PR TITLE
[main/fix] fix docs/guide/installation

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -16,8 +16,8 @@ Mininum poetry version has is ^1.2, but it is recommended to use latest poetry. 
 
 ```sh
 git clone https://github.com/lnbits/lnbits.git
-git checkout main
 cd lnbits
+git checkout main
 
 # for making sure python 3.9 is installed, skip if installed. To check your installed version: python3 --version
 sudo apt update


### PR DESCRIPTION
Fix install instructions after #2052 and #2060

Also these have been merged to `main`, not to `dev`, so this is also targeted to `main`. We will then merge `main` into `dev`.