### PR TITLE
Enable Node Management via .env without activating admin-UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,13 @@ LNBITS_ADMIN_EXTENSIONS="ngrok, admin"
 # Disable this to make LNbits use this config file again.
 LNBITS_ADMIN_UI=false
 
+# Enable Node Management without activating the LNBITS Admin GUI
+# by setting the following variables to true.
+LNBITS_NODE_UI=false
+LNBITS_PUBLIC_NODE_UI=false
+# Enabling the transactions tab can cause crashes on large Core Lightning nodes.
+LNBITS_NODE_UI_TRANSACTIONS=false
+
 LNBITS_DEFAULT_WALLET_NAME="LNbits wallet"
 
 # Ad space description


### PR DESCRIPTION
The recent Node Management feature is only available if you set `LNBITS_ADMIN_UI=true`. 
For LNBITS users who keep running their instance managing their `.env` file, the following PR would allow them to use the feature and adjust settings without the UI.

This can be looked up at the boolean settings blurp [over here](https://github.com/lnbits/lnbits/blob/fed2d411399a0f3f46c1fffe5f6f67942e56b2e7/lnbits/settings.py#L236), and has been tested on a production node.

What is missing is the "Node" menu entry on the left navigation bar. The overview can be retrieved by browsing to https://yourdomain.com/**node**?user=1233434555564, but adding this navigation bar  as soon one of 
```
LNBITS_NODE_UI=false 
LNBITS_PUBLIC_NODE_UI=false
LNBITS_NODE_UI_TRANSACTIONS=false
```
is `true` would make the usability much more elegant. But this isn't included in the PR and would need to be added into the UI Templates