### PR TITLE
feat: emulate behaviour of paid_invoices_stream for wallets that dont support it

### DIFF
--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, AsyncGenerator, Coroutine, NamedTuple, Optional
+
+from loguru import logger
 
 if TYPE_CHECKING:
     from lnbits.nodes.base import Node
@@ -93,6 +96,9 @@ class Wallet(ABC):
 
     __node_cls__: Optional[type[Node]] = None
 
+    def __init__(self) -> None:
+        self.pending_invoices: list[str] = []
+
     @abstractmethod
     async def cleanup(self):
         pass
@@ -130,9 +136,19 @@ class Wallet(ABC):
     ) -> Coroutine[None, None, PaymentStatus]:
         pass
 
-    @abstractmethod
-    def paid_invoices_stream(self) -> AsyncGenerator[str, None]:
-        pass
+    async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:
+        while True:
+            for invoice in self.pending_invoices:
+                try:
+                    status = await self.get_invoice_status(invoice)
+                    if status.paid:
+                        yield invoice
+                        self.pending_invoices.remove(invoice)
+                    elif status.failed:
+                        self.pending_invoices.remove(invoice)
+                except Exception as exc:
+                    logger.error(f"could not get status of invoice {invoice}: '{exc}' ")
+            await asyncio.sleep(5)
 
     def normalize_endpoint(self, endpoint: str, add_proto=True) -> str:
         endpoint = endpoint[:-1] if endpoint.endswith("/") else endpoint

--- a/lnbits/wallets/lnpay.py
+++ b/lnbits/wallets/lnpay.py
@@ -28,6 +28,7 @@ class LNPayWallet(Wallet):
         if not settings.lnpay_api_key:
             raise ValueError("cannot initialize LNPayWallet: missing lnpay_api_key")
 
+        super().__init__()
         wallet_key = settings.lnpay_wallet_key or settings.lnpay_admin_key
         if not wallet_key:
             raise ValueError(
@@ -35,7 +36,6 @@ class LNPayWallet(Wallet):
                 "missing lnpay_wallet_key or lnpay_admin_key"
             )
         self.wallet_key = wallet_key
-
         self.endpoint = self.normalize_endpoint(settings.lnpay_api_endpoint)
 
         headers = {
@@ -101,6 +101,8 @@ class LNPayWallet(Wallet):
         if ok:
             data = r.json()
             checking_id, payment_request = data["id"], data["payment_request"]
+
+            self.pending_invoices.append(checking_id)
 
         return InvoiceResponse(ok, checking_id, payment_request, error_message)
 

--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -25,6 +25,7 @@ class OpenNodeWallet(Wallet):
             raise ValueError(
                 "cannot initialize OpenNodeWallet: missing opennode_api_endpoint"
             )
+        super().__init__()
         key = (
             settings.opennode_key
             or settings.opennode_admin_key
@@ -92,6 +93,7 @@ class OpenNodeWallet(Wallet):
         data = r.json()["data"]
         checking_id = data["id"]
         payment_request = data["lightning_invoice"]["payreq"]
+        self.pending_invoices.append(checking_id)
         return InvoiceResponse(True, checking_id, payment_request, None)
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:


### PR DESCRIPTION
Possible solution to #2045.

Instead of optionally polling on the frontend we can just emulate the behaviour of the invoices stream by regulary polling the currently pending invoices. It shouldnt be too big of a difference in regards to rate limiting because whether the browser or the invoice task polls doesnt matter.