### PR TITLE
pass custom extra on payment out

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -332,9 +332,13 @@ async def api_payments_create_invoice(data: CreateInvoice, wallet: Wallet):
     }
 
 
-async def api_payments_pay_invoice(bolt11: str, wallet: Wallet):
+async def api_payments_pay_invoice(
+    bolt11: str, wallet: Wallet, extra: Optional[dict] = None
+):
     try:
-        payment_hash = await pay_invoice(wallet_id=wallet.id, payment_request=bolt11)
+        payment_hash = await pay_invoice(
+            wallet_id=wallet.id, payment_request=bolt11, extra=extra
+        )
     except ValueError as e:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
     except PermissionError as e:
@@ -375,7 +379,7 @@ async def api_payments_create(
                 detail="BOLT11 string is invalid or not given",
             )
         return await api_payments_pay_invoice(
-            invoiceData.bolt11, wallet.wallet
+            invoiceData.bolt11, wallet.wallet, invoiceData.extra
         )  # admin key
     elif not invoiceData.out:
         # invoice key


### PR DESCRIPTION
Allow `extra` to get passed when making a payment.

```
{
  "unit": "sat",
  "out": true,
  "extra": {
      "orderId":"3l4k23j4k2l3j34",
      "tag":"FEES"
  },
  "bolt11": "lnbc10u...0p8da5"
}
``` 

on the payments will show:
```
{
  "paid": true,
  "preimage": "0...000",
  "details": {
    "checking_id": "ede3426...93bb8d6",
    "pending": false,
    "amount": -1000000,
    ...
    "expiry": 1699445241,
    "extra": {
      "orderId": "3l4k23j4k2l3j34",
      "tag": "FEES"
    },
    ...
  }
}
```

Closes #2082