### PR TITLE
feat: payment updates fallback

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -467,6 +467,7 @@ async def subscribe_wallet_invoices(request: Request, wallet: Wallet):
     payment_queue: asyncio.Queue[Payment] = asyncio.Queue(0)
 
     uid = register_invoice_listener(payment_queue, this_wallet_id)
+    assert uid, "invoice listeners not supported"
     logger.debug(f"added sse listener for wallet {this_wallet_id}: {uid}")
 
     try:

--- a/lnbits/core/views/public_api.py
+++ b/lnbits/core/views/public_api.py
@@ -6,8 +6,8 @@ from loguru import logger
 
 from lnbits import bolt11
 
+from ...tasks import register_invoice_listener
 from ..crud import get_standalone_payment
-from ..tasks import api_invoice_listeners
 
 public_router = APIRouter()
 
@@ -35,7 +35,7 @@ async def api_public_payment_longpolling(payment_hash):
     payment_queue = asyncio.Queue(0)
 
     logger.debug(f"adding standalone invoice listener for hash: {payment_hash}")
-    api_invoice_listeners[payment_hash] = payment_queue
+    register_invoice_listener(payment_queue, payment_hash)
 
     response = None
 

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -83,6 +83,7 @@ def register_invoice_listener(
         logger.trace(f"registering invoice listener {name_unique}")
         invoice_listeners[name_unique] = send_chan
         return name_unique
+    return None
 
 
 def unregister_invoice_listener(name_unique: str):

--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -91,9 +91,8 @@ class Wallet(ABC):
     ) -> Coroutine[None, None, PaymentStatus]:
         pass
 
-    @abstractmethod
     def paid_invoices_stream(self) -> AsyncGenerator[str, None]:
-        pass
+        raise NotImplementedError
 
 
 class Unsupported(Exception):


### PR DESCRIPTION
closes: #2045 

This PR makes the sse endpoint return a 503 status if the wallet backend does not support sse, which the frontend detects. 

I also simplified the internal invoice structure by removing the `api_invoice_listeners` layer, which was a bit confusing to me. `SseListenersDict` also seems unnecessary if it only has one usage now.

I'm also not sure if we really need the count of listeners in the frontend, I think that could be removed aswell.