### PR TITLE
WIP: load extensions via `LoadExtension` config

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -347,7 +347,6 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
 
         # if the extension returns a LoadExtension model, init the new way
         if load_ext and isinstance(load_ext, LoadExtension):
-
             # # set the extension's settings
             # ext.set_load_ext(load_ext)
 
@@ -355,20 +354,32 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
             if load_ext.routers:
                 for router in load_ext.routers:
                     logger.trace(f"adding route for extension {ext_module}")
-                    prefix = f"/upgrades/{ext.upgrade_hash}" if ext.upgrade_hash != "" else ""
+                    prefix = (
+                        f"/upgrades/{ext.upgrade_hash}"
+                        if ext.upgrade_hash != ""
+                        else ""
+                    )
                     app.include_router(router=router, prefix=prefix)
 
             # register the extension's static files
             if load_ext.static_files:
                 for static in load_ext.static_files:
                     static_dir = Path(
-                        settings.lnbits_extensions_path, "extensions", *static["path"].split("/")
+                        settings.lnbits_extensions_path,
+                        "extensions",
+                        *static["path"].split("/"),
                     )
-                    app.mount(static["path"], StaticFiles(directory=static_dir), static["name"])
+                    app.mount(
+                        static["path"],
+                        StaticFiles(directory=static_dir),
+                        static["name"],
+                    )
 
             if load_ext.redirects:
                 settings.lnbits_extensions_redirects = [
-                    r for r in settings.lnbits_extensions_redirects if r["ext_id"] != ext.code
+                    r
+                    for r in settings.lnbits_extensions_redirects
+                    if r["ext_id"] != ext.code
                 ]
                 for r in load_ext.redirects:
                     r["ext_id"] = ext.code

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -339,17 +339,14 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
     """Register FastAPI routes for extension."""
     ext_module = importlib.import_module(ext.module_name)
 
-    ext_route = getattr(ext_module, f"{ext.code}_ext")
-
     if hasattr(ext_module, f"{ext.code}_start"):
         ext_start_func = getattr(ext_module, f"{ext.code}_start")
         load_ext = ext_start_func()
 
         # if the extension returns a LoadExtension model, init the new way
-        if load_ext and isinstance(load_ext, LoadExtension):
+        if isinstance(load_ext, LoadExtension):
             # # set the extension's settings
             # ext.set_load_ext(load_ext)
-
             # register the extension's routes
             if load_ext.routers:
                 for router in load_ext.routers:
@@ -388,6 +385,7 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
             # exit early, the rest is needed for backwards compatibility
             return None
 
+    # backwards compatibility for old extensions
     if hasattr(ext_module, f"{ext.code}_static_files"):
         ext_statics = getattr(ext_module, f"{ext.code}_static_files")
         for s in ext_statics:
@@ -408,6 +406,7 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
     logger.trace(f"adding route for extension {ext_module}")
 
     prefix = f"/upgrades/{ext.upgrade_hash}" if ext.upgrade_hash != "" else ""
+    ext_route = getattr(ext_module, f"{ext.code}_ext")
     app.include_router(router=ext_route, prefix=prefix)
 
 

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -17,12 +17,23 @@ from .crud import update_migration_version
 async def migrate_extension_database(ext: Extension, current_version):
     try:
         ext_migrations = importlib.import_module(f"{ext.module_name}.migrations")
-        ext_db = importlib.import_module(ext.module_name).db
     except ImportError as e:
         logger.error(e)
         raise ImportError(
             f"Please make sure that the extension `{ext.code}` has a migrations file."
         )
+    try:
+        ext_db = importlib.import_module(f"{ext.module_name}.db").db
+    except ImportError:
+        try:
+            # fallback to old db location inside `__init__.py`
+            ext_db = importlib.import_module(ext.module_name).db
+        except ImportError as exc:
+            logger.error(exc)
+            raise ImportError(
+                f"Please make sure that the extension `{ext.code}` "
+                "has a `Database` model."
+            )
 
     async with ext_db.connect() as ext_conn:
         await run_migration(ext_conn, ext_migrations, ext.code, current_version)

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import os
@@ -10,7 +11,7 @@ from typing import Any, List, NamedTuple, Optional, Tuple
 from urllib import request
 
 import httpx
-from fastapi import HTTPException
+from fastapi import APIRouter, HTTPException
 from loguru import logger
 from packaging import version
 from pydantic import BaseModel
@@ -76,6 +77,13 @@ class ExtensionConfig(BaseModel):
         if not self.min_lnbits_version:
             return True
         return version_parse(self.min_lnbits_version) <= version_parse(settings.version)
+
+
+class LoadExtension(BaseModel):
+    routers: Optional[List] = None
+    static_files: Optional[List[dict]] = None
+    redirects: Optional[List[dict]] = None
+    scheduled_tasks: Optional[List] = None
 
 
 def download_url(url, save_path):

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 import json
 import os
@@ -11,7 +10,7 @@ from typing import Any, List, NamedTuple, Optional, Tuple
 from urllib import request
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import HTTPException
 from loguru import logger
 from packaging import version
 from pydantic import BaseModel


### PR DESCRIPTION
WIP, idea on how to load extensions differently. this could also handle stuff like, disabling extensions scheduled tasks if you pass them back via the `LoadExtension` model. this currently done via calling a http route. overall this would make life easier for extension developers because the don't need to take care of it. 

inside the extension `__init__.py` it would look something like that.
this change is 100% backwards compabtible

```py
from lnbits.extension_manager import LoadExtension

from .tasks import init_tasks
from .views import html_router
from .views_api import api_router


def boltz_start() -> LoadExtension:
    tasks = init_tasks()
    return LoadExtension(
        routers=[html_router, api_router],
        scheduled_tasks=tasks,
        static_files=[{
            "path": "/boltz/static",
            "name": "boltz_static",
        }]
    )

```