### PR TITLE
doc: add `SUPER_USER` field

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ LNBITS_BLOCKED_IPS=""
 # if set new users will not be able to create accounts
 LNBITS_ALLOWED_USERS=""
 LNBITS_ADMIN_USERS=""
+# ID of the super user. The user ID must exist.
+# SUPER_USER=""
+
 # Extensions only admin can access
 LNBITS_ADMIN_EXTENSIONS="ngrok, admin"
 


### PR DESCRIPTION
The `.env.example` was missing the example for `SUPER_USER`