### PR TITLE
Upadte to c-lightning-REST v0.10.5

### DIFF
--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -125,7 +125,9 @@ class CoreLightningRestWallet(Wallet):
         data = r.json()
         assert "payment_hash" in data
         assert "bolt11" in data
-        return InvoiceResponse(True, data["payment_hash"], data["bolt11"], None)
+        # NOTE: use payment_hash when corelightning-rest updates and supports it
+        # return InvoiceResponse(True, data["payment_hash"], data["bolt11"], None)
+        return InvoiceResponse(True, label, data["bolt11"], None)
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         try:
@@ -170,9 +172,13 @@ class CoreLightningRestWallet(Wallet):
         )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
+        # get invoice bolt11 from checking_id
+        # corelightning-rest wants the "label" here....
+        # NOTE: We can get rid of all labels and use payment_hash when
+        # corelightning-rest updates and supports it
         r = await self.client.get(
             f"{self.url}/v1/invoice/listInvoices",
-            params={"payment_hash": checking_id},
+            params={"label": checking_id},
         )
         try:
             r.raise_for_status()
@@ -186,9 +192,14 @@ class CoreLightningRestWallet(Wallet):
             return PaymentStatus(None)
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
+        from lnbits.core.services import get_standalone_payment
+
+        payment = await get_standalone_payment(checking_id)
+        if not payment:
+            raise ValueError(f"Payment with checking_id {checking_id} not found")
         r = await self.client.get(
             f"{self.url}/v1/pay/listPays",
-            params={"payment_hash": checking_id},
+            params={"invoice": payment.bolt11},
         )
         try:
             r.raise_for_status()
@@ -230,19 +241,19 @@ class CoreLightningRestWallet(Wallet):
                         except Exception:
                             continue
                         logger.trace(f"paid invoice: {inv}")
-                        yield inv["label"]
+                        # yield inv["label"]
                         # NOTE: use payment_hash when corelightning-rest updates
                         # and supports it
                         # payment_hash = inv["payment_hash"]
                         # yield payment_hash
                         # hack to return payment_hash if the above shouldn't work
-                        # r = await self.client.get(
-                        #     f"{self.url}/v1/invoice/listInvoices",
-                        #     params={"label": inv["label"]},
-                        # )
-                        # paid_invoce = r.json()
-                        # logger.trace(f"paid invoice: {paid_invoce}")
-                        # yield paid_invoce["invoices"][0]["payment_hash"]
+                        r = await self.client.get(
+                            f"{self.url}/v1/invoice/listInvoices",
+                            params={"label": inv["label"]},
+                        )
+                        paid_invoice = r.json()
+                        logger.trace(f"paid invoice: {paid_invoice}")
+                        yield paid_invoice["invoices"][0]["payment_hash"]
 
             except Exception as exc:
                 logger.debug(

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -125,9 +125,7 @@ class CoreLightningRestWallet(Wallet):
         data = r.json()
         assert "payment_hash" in data
         assert "bolt11" in data
-        # NOTE: use payment_hash when corelightning-rest updates and supports it
-        # return InvoiceResponse(True, data["payment_hash"], data["bolt11"], None)
-        return InvoiceResponse(True, label, data["bolt11"], None)
+        return InvoiceResponse(True, data["payment_hash"], data["bolt11"], None)
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         try:
@@ -172,13 +170,9 @@ class CoreLightningRestWallet(Wallet):
         )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
-        # get invoice bolt11 from checking_id
-        # corelightning-rest wants the "label" here....
-        # NOTE: We can get rid of all labels and use payment_hash when
-        # corelightning-rest updates and supports it
         r = await self.client.get(
             f"{self.url}/v1/invoice/listInvoices",
-            params={"label": checking_id},
+            params={"payment_hash": checking_id},
         )
         try:
             r.raise_for_status()
@@ -192,14 +186,9 @@ class CoreLightningRestWallet(Wallet):
             return PaymentStatus(None)
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
-        from lnbits.core.services import get_standalone_payment
-
-        payment = await get_standalone_payment(checking_id)
-        if not payment:
-            raise ValueError(f"Payment with checking_id {checking_id} not found")
         r = await self.client.get(
             f"{self.url}/v1/pay/listPays",
-            params={"invoice": payment.bolt11},
+            params={"payment_hash": checking_id},
         )
         try:
             r.raise_for_status()
@@ -251,9 +240,9 @@ class CoreLightningRestWallet(Wallet):
                             f"{self.url}/v1/invoice/listInvoices",
                             params={"label": inv["label"]},
                         )
-                        paid_invoice = r.json()
-                        logger.trace(f"paid invoice: {paid_invoice}")
-                        yield paid_invoice["invoices"][0]["payment_hash"]
+                        paid_invoce = r.json()
+                        logger.trace(f"paid invoice: {paid_invoce}")
+                        yield paid_invoce["invoices"][0]["payment_hash"]
 
             except Exception as exc:
                 logger.debug(

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -230,9 +230,9 @@ class CoreLightningRestWallet(Wallet):
                         except Exception:
                             continue
                         logger.trace(f"paid invoice: {inv}")
-                        # yield inv["label"]
-                        # NOTE: use payment_hash when corelightning-rest updates
-                        # and supports it
+
+                        # NOTE: use payment_hash when corelightning-rest returns it
+                        # when using waitAnyInvoice
                         # payment_hash = inv["payment_hash"]
                         # yield payment_hash
                         # hack to return payment_hash if the above shouldn't work
@@ -242,6 +242,11 @@ class CoreLightningRestWallet(Wallet):
                         )
                         paid_invoce = r.json()
                         logger.trace(f"paid invoice: {paid_invoce}")
+                        assert self.statuses[
+                            paid_invoce["invoices"][0]["status"]
+                        ], "streamed invoice not paid"
+                        assert "invoices" in paid_invoce, "no invoices in response"
+                        assert len(paid_invoce["invoices"]), "no invoices in response"
                         yield paid_invoce["invoices"][0]["payment_hash"]
 
             except Exception as exc:

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -240,14 +240,14 @@ class CoreLightningRestWallet(Wallet):
                             f"{self.url}/v1/invoice/listInvoices",
                             params={"label": inv["label"]},
                         )
-                        paid_invoce = r.json()
-                        logger.trace(f"paid invoice: {paid_invoce}")
+                        paid_invoice = r.json()
+                        logger.trace(f"paid invoice: {paid_invoice}")
                         assert self.statuses[
-                            paid_invoce["invoices"][0]["status"]
+                            paid_invoice["invoices"][0]["status"]
                         ], "streamed invoice not paid"
-                        assert "invoices" in paid_invoce, "no invoices in response"
-                        assert len(paid_invoce["invoices"]), "no invoices in response"
-                        yield paid_invoce["invoices"][0]["payment_hash"]
+                        assert "invoices" in paid_invoice, "no invoices in response"
+                        assert len(paid_invoice["invoices"]), "no invoices in response"
+                        yield paid_invoice["invoices"][0]["payment_hash"]
 
             except Exception as exc:
                 logger.debug(


### PR DESCRIPTION
Updates to the new CLN-REST interface which now can use `payment_hash` for looking up payments and invoices. 

Feature requests in https://github.com/Ride-The-Lightning/c-lightning-REST/issues/184 are included in the latest release.