### PR TITLE
Added extra field to wallets db

### DIFF
--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -393,3 +393,7 @@ async def m015_create_push_notification_subscriptions_table(db):
         );
     """
     )
+
+
+async def m016_add_extra_wallets(db):
+    await db.execute("ALTER TABLE wallets ADD COLUMN extra TEXT")


### PR DESCRIPTION
I need for the goofy animations pr, but I imagine is useful for things like people using LNbits in their stack, if apipayments, wallets and accounts have "extra" fields.
Note: apipayments already has and accounts will get "extra" with Vlads login pr.