### PR TITLE
fix: redirect for all paths of the extension (not only for `/api`)

### DIFF
--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -25,7 +25,8 @@ class InstalledExtensionMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if "path" not in scope:
+        path = scope.get("path", "/")
+        if path == "/":
             await self.app(scope, receive, send)
             return
 

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -29,18 +29,18 @@ class InstalledExtensionMiddleware:
             await self.app(scope, receive, send)
             return
 
-        path_name, *rest = [p for p in scope["path"].split("/") if p]
+        top_path, *rest = [p for p in scope["path"].split("/") if p]
         headers = scope.get("headers", [])
 
         # block path for all users if the extension is disabled
-        if path_name in settings.lnbits_deactivated_extensions:
+        if top_path in settings.lnbits_deactivated_extensions:
             response = self._response_by_accepted_type(
-                headers, f"Extension '{path_name}' disabled", HTTPStatus.NOT_FOUND
+                headers, f"Extension '{top_path}' disabled", HTTPStatus.NOT_FOUND
             )
             await response(scope, receive, send)
             return
 
-        if not self._user_allowed_to_extension(path_name, scope):
+        if not self._user_allowed_to_extension(top_path, scope):
             response = self._response_by_accepted_type(
                 headers, "User not authorized.", HTTPStatus.FORBIDDEN
             )
@@ -51,7 +51,7 @@ class InstalledExtensionMiddleware:
             (
                 e
                 for e in settings.lnbits_upgraded_extensions
-                if e.endswith(f"/{path_name}")
+                if e.endswith(f"/{top_path}")
             ),
             None,
         )

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -25,12 +25,12 @@ class InstalledExtensionMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        path = scope.get("path", "/")
-        if path == "/":
+        full_path = scope.get("path", "/")
+        if full_path == "/":
             await self.app(scope, receive, send)
             return
 
-        top_path, *rest = [p for p in scope["path"].split("/") if p]
+        top_path, *rest = [p for p in full_path.split("/") if p]
         headers = scope.get("headers", [])
 
         # block path for all users if the extension is disabled

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -56,7 +56,7 @@ class InstalledExtensionMiddleware:
             ),
             None,
         )
-        # re-route API trafic if the extension has been upgraded
+        # re-route all trafic if the extension has been upgraded
         if upgrade_path:
             tail = "/".join(rest)
             scope["path"] = f"/upgrades/{upgrade_path}/{tail}"

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -48,6 +48,11 @@ class InstalledExtensionMiddleware:
             await response(scope, receive, send)
             return
 
+        # static resources do not require redirect
+        if rest[0:1] == ["static"]:
+            await self.app(scope, receive, send)
+            return
+
         upgrade_path = next(
             (
                 e


### PR DESCRIPTION
### Summary
There is a middleware called `InstalledExtensionMiddleware` and this middleware is great! But it had a bug.
A middleware (in general) intercepts all HTTP calls and does some pre/post processing on the request.

The main job of this middleware is to:
 - check if an extension is upgraded
 - if so, then redirect the calls to the latest upgraded version by re-writing the HTTP path

Static resources do not require redirect so in the old version only the paths for the `/api` calls were redirected.

However, the public pages (like http://127.0.0.1:5000/tpos/9BKt3SCEtLMmwXSh6sxjsp) are not `/api` and are not static resources, therefore they were not redirected (this is the bug).

The changes in this PR simplify the middleware by:
 - explicitly check if the path is a static resource (and skip redirect)
 - explicitly check if the extension is upgraded. If true then redirect for all paths (except `static`)

### Testing Scenarios
**Scenario 1 (regression bugs):**
- smoke test the core functionality (wallet, admin) pages. All HTTP calls go trough the middleware.
- smoke test a random extension

**Scenario 2 (ext upgrade):**
- install an extension. A good example is TPOS (version 0.4.3)
- create some data in the extension
- upgrade the extension (TPOS 0.5.1)
- check that the UI is upgraded both on the main page `/tpos` and on the public pages `/tpos/{some_id}`
  - previously the public page failed

**Scenario 3 (static fiels)**
- the TPOS ext serves no static files
- install `watchonly` extension and upgrade it (it has many static files)
- check that it works fine

**Notes**
When an extension is installed all the files (`.py`, `.html`, `.js`, etc) in `lnbits/extensions/myext` are replaced by the new version. 
For the static resources, the client will be served the new (updated) files. These resources are loaded via [static_url_for()](https://github.com/lnbits/lnbits/blob/dev/lnbits/helpers.py#L32) function).  The `"static"` path for static files is configured [here](https://github.com/lnbits/lnbits/blob/dev/lnbits/app.py#L84-L87).
On the other hand the logic in the python modules is not automatically reloaded when the files are updated, and the redirecting is needed. 