### PR TITLE
fix issue with displaying languages

### DIFF
--- a/lnbits/core/templates/core/extensions.html
+++ b/lnbits/core/templates/core/extensions.html
@@ -240,11 +240,10 @@
             class="float-right"
           >
             <q-badge>
-              {% raw %}{{ extension.installedRelease.version }}{% endraw
-              %}<q-tooltip
-                >{%raw%}{{ $t('extension_installed_version')
-                }}{%endraw%}</q-tooltip
-              >
+              {% raw %}{{ extension.installedRelease.version }}{% endraw %}
+              <q-tooltip>
+                <span v-text="$t('extension_installed_version')"></span>
+              </q-tooltip>
             </q-badge>
           </div>
         </div>

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -84,8 +84,8 @@
                 :label="$t('scan')"
               >
                 <q-tooltip
-                  >{% raw %}{{$t('camera_tooltip')}}{% endraw %}</q-tooltip
-                >
+                  ><span v-text="$t('camera_tooltip')"></span
+                ></q-tooltip>
               </q-btn>
             </div>
           </div>
@@ -118,9 +118,9 @@
                   color="grey"
                   @click="showChart"
                 >
-                  <q-tooltip
-                    >{% raw %}{{$t('chart_tooltip')}}{% endraw %}</q-tooltip
-                  >
+                  <q-tooltip>
+                    <span v-text="$t('chart_tooltip')"></span
+                  ></q-tooltip>
                 </q-btn>
               </div>
             </div>
@@ -760,11 +760,11 @@
                   class="q-mt-xs q-ml-sm q-mr-auto"
                   v-if="parse.copy.show"
                   @click="pasteToTextArea"
-                  ><q-tooltip
-                    >{% raw %}{{$t('paste_from_clipboard')}}{% endraw
-                    %}</q-tooltip
-                  ></q-icon
                 >
+                  <q-tooltip>
+                    <span v-text="$t('paste_from_clipboard')"></span>
+                  </q-tooltip>
+                </q-icon>
                 <q-btn
                   v-close-popup
                   flat

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -60,8 +60,12 @@
             {%endif%}{% endblock %}
           </q-toolbar-title>
           {% block beta %} {% if VOIDWALLET %}
-          <q-badge color="red" text-color="black" class="q-mr-md">
-            {% raw %}{{ $t('voidwallet_active') }}{% endraw %}
+          <q-badge
+            v-text="$t('voidwallet_active')"
+            color="red"
+            text-color="black"
+            class="q-mr-md"
+          >
           </q-badge>
           {%endif%}
           <q-badge
@@ -242,9 +246,7 @@
             :icon="($q.dark.isActive) ? 'brightness_3' : 'wb_sunny'"
             size="sm"
           >
-            <q-tooltip
-              >{% raw %}{{ $t('toggle_darkmode') }}{% endraw %}</q-tooltip
-            >
+            <q-tooltip><span v-text="$t('toggle_darkmode')"></span></q-tooltip>
           </q-btn>
         </q-toolbar>
       </q-header>
@@ -283,9 +285,8 @@
             {{ SITE_TITLE }}, {{SITE_TAGLINE}}
             <br />
             <small
-              >{% raw %}{{ $t('lnbits_version') }}{% endraw %}:
-              {{LNBITS_VERSION}}
-            </small>
+              v-text="$t('lnbits_version') + ': {{LNBITS_VERSION}}'"
+            ></small>
           </q-toolbar-title>
           <q-space></q-space>
           <q-btn
@@ -296,11 +297,11 @@
             href="/docs"
             target="_blank"
             rel="noopener"
+            v-text="$t('api_docs')"
           >
-            {% raw %}{{ $t('api_docs') }}{% endraw %}
             <q-tooltip
-              >{% raw %}{{ $t('view_swagger_docs') }}{% endraw %}</q-tooltip
-            >
+              ><span v-text="$t('view_swagger_docs')"></span
+            ></q-tooltip>
           </q-btn>
           <q-btn
             flat
@@ -312,7 +313,7 @@
             target="_blank"
             rel="noopener"
           >
-            <q-tooltip>{% raw %}{{ $t('view_github') }}{% endraw %}</q-tooltip>
+            <q-tooltip><span v-text="$t('view_github')"></span></q-tooltip>
           </q-btn>
         </q-toolbar>
       </q-footer>

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -127,6 +127,7 @@
                   <q-item-label
                     v-text="lang.display ?? lang.value.toUpperCase()"
                   ></q-item-label>
+                  <q-tooltip><span v-text="lang.label"></span></q-tooltip>
                 </q-item-section>
               </q-item>
             </q-list>

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -124,12 +124,9 @@
                 :active="activeLanguage(lang.value)"
                 @click="changeLanguage(lang.value)"
                 ><q-item-section>
-                  {% raw %}
                   <q-item-label
-                    >{{lang.display ?? lang.value.toUpperCase()}}</q-item-label
-                  >
-                  <q-tooltip>{{lang.label}}</q-tooltip>
-                  {% endraw %}
+                    v-text="lang.display ?? lang.value.toUpperCase()"
+                  ></q-item-label>
                 </q-item-section>
               </q-item>
             </q-list>

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -297,8 +297,8 @@
             href="/docs"
             target="_blank"
             rel="noopener"
-            v-text="$t('api_docs')"
           >
+            <span v-text="$t('api_docs')"></span>
             <q-tooltip
               ><span v-text="$t('view_swagger_docs')"></span
             ></q-tooltip>


### PR DESCRIPTION
When using `delimiters` to avoid the `{% raw %}` stuff, the toolbar, which is rendered on the base html doesn't display languages correctly.

- refactored the language list to show correctly