### PR TITLE
cln: allow amountless invoices in node tx list

### DIFF
--- a/lnbits/nodes/cln.py
+++ b/lnbits/nodes/cln.py
@@ -312,8 +312,12 @@ class CoreLightningNode(Node):
                 NodeInvoice(
                     bolt11=invoice.get("bolt11") or invoice.get("bolt12"),
                     amount=(
+                        # normal invoice
                         invoice.get("amount_msat")
+                        # keysend or paid amountless invoice
                         or invoice.get("amount_received_msat")
+                        # unpaid amountless invoice
+                        or 0
                     ),
                     preimage=invoice.get("payment_preimage"),
                     memo=invoice.get("description"),


### PR DESCRIPTION
Bolt11 allows for invoices to have no amount, allowing the sender to select the amount to send. At least core lightning and LND support this.

When looking through my invoices on the node page, I get an error when it tries to fetch an unpaid invoice with no amount:

```
Nov 30 19:59:56 wilfrid poetry[2788777]:   File "/mnt/bitcoin/git/lnbits-legend/lnbits/nodes/cln.py", line 46, in wrapper
Nov 30 19:59:56 wilfrid poetry[2788777]:     return await f(*args, **kwargs)
Nov 30 19:59:56 wilfrid poetry[2788777]:   File "/mnt/bitcoin/git/lnbits-legend/lnbits/nodes/cln.py", line 311, in get_invoices
Nov 30 19:59:56 wilfrid poetry[2788777]:     data=[
Nov 30 19:59:56 wilfrid poetry[2788777]:   File "/mnt/bitcoin/git/lnbits-legend/lnbits/nodes/cln.py", line 312, in <listcomp>
Nov 30 19:59:56 wilfrid poetry[2788777]:     NodeInvoice(
Nov 30 19:59:56 wilfrid poetry[2788777]:   File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
Nov 30 19:59:56 wilfrid poetry[2788777]: pydantic.error_wrappers.ValidationError: 1 validation error for NodeInvoice
Nov 30 19:59:56 wilfrid poetry[2788777]: amount
Nov 30 19:59:56 wilfrid poetry[2788777]:   none is not an allowed value (type=type_error.none.not_allowed)
Nov 30 19:59:56 wilfrid poetry[2788777]: 2023-11-30 19:59:56.65 | ERROR | Exception: 1 validation error for NodeInvoice
Nov 30 19:59:56 wilfrid poetry[2788777]: amount
Nov 30 19:59:56 wilfrid poetry[2788777]:   none is not an allowed value (type=type_error.none.not_allowed)
Nov 30 19:59:56 wilfrid poetry[2788777]: 2023-11-30 19:59:56.65 | INFO | 92.60.40.221:0 - "GET /node/api/v1/invoices?limit=50&offset=0&usr=XXXXXXXXXXXXXXXXXXXXXXXXXX HTTP/1.1" 500
```

This PR fixes that issue by making `NodeInvoice.amount` optional. This causes the invoice to show amount 0 in the UI. I think this is acceptable. Ideally it should say "any" or something similar.