### PR TITLE
bug: cln paymentstate check on error

### DIFF
--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -280,18 +280,11 @@ class Payment(FromRowModel):
                 f"expired {expiration_date}"
             )
             await self.delete(conn)
-        # wait at least 15 minutes before deleting failed outgoing payments
         elif self.is_out and status.failed:
-            if self.time + 900 < int(time.time()):
-                logger.warning(
-                    f"Deleting outgoing failed payment {self.checking_id}: {status}"
-                )
-                await self.delete(conn)
-            else:
-                logger.warning(
-                    f"Tried to delete outgoing payment {self.checking_id}: "
-                    "skipping because it's not old enough"
-                )
+            logger.info(
+                f"Deleting outgoing failed payment {self.checking_id}: {status}"
+            )
+            await self.delete(conn)
         elif not status.pending:
             logger.info(
                 f"Marking '{'in' if self.is_in else 'out'}' "

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -139,8 +139,6 @@ class CoreLightningWallet(Wallet):
                     f" '{exc.error.get('message') or exc.error}'."  # type: ignore
                 )
             return PaymentResponse(False, None, None, None, error_message)
-        except Exception as exc:
-            return PaymentResponse(False, None, None, None, str(exc))
 
         fee_msat = -int(r["amount_sent_msat"] - r["amount_msat"])
         return PaymentResponse(
@@ -173,11 +171,8 @@ class CoreLightningWallet(Wallet):
             r: dict = self.ln.listpays(payment_hash=checking_id)  # type: ignore
         except Exception:
             return PaymentStatus(None)
-        if "pays" not in r:
+        if "pays" not in r or not r["pays"]:
             return PaymentStatus(None)
-        if not r["pays"]:
-            # no payment with this payment_hash is found
-            return PaymentStatus(False)
 
         payment_resp = r["pays"][-1]
 

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -162,9 +162,6 @@ class CoreLightningRestWallet(Wallet):
 
         data = r.json()
 
-        if data["status"] != "complete":
-            return PaymentResponse(False, None, None, None, "payment failed")
-
         checking_id = data["payment_hash"]
         preimage = data["payment_preimage"]
         fee_msat = data["msatoshi_sent"] - data["msatoshi"]


### PR DESCRIPTION
Payment state check should *only* return False if the payment 100% failed. Uncheckable entries should not enter the db in the first place, which we will be working on next.