### PR TITLE
refactor: move webpush to its own router

### DIFF
--- a/lnbits/core/__init__.py
+++ b/lnbits/core/__init__.py
@@ -9,6 +9,7 @@ from .views.generic import generic_router, update_user_extension
 from .views.node_api import node_router, public_node_router, super_node_router
 from .views.public_api import public_router
 from .views.tinyurl_api import tinyurl_router
+from .views.webpush_api import webpush_router
 
 # backwards compatibility for extensions
 core_app = APIRouter(tags=["Core"])
@@ -24,3 +25,4 @@ def init_core_routers(app):
     app.include_router(public_node_router)
     app.include_router(admin_router)
     app.include_router(tinyurl_router)
+    app.include_router(webpush_router)

--- a/lnbits/core/views/webpush_api.py
+++ b/lnbits/core/views/webpush_api.py
@@ -1,0 +1,60 @@
+import base64
+import json
+from http import HTTPStatus
+from urllib.parse import unquote, urlparse
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    Request,
+)
+
+from lnbits.core.models import (
+    CreateWebPushSubscription,
+    WebPushSubscription,
+)
+from lnbits.decorators import (
+    WalletTypeInfo,
+    require_admin_key,
+)
+
+from ..crud import (
+    create_webpush_subscription,
+    delete_webpush_subscription,
+    get_webpush_subscription,
+)
+
+webpush_router = APIRouter(prefix="/api/v1/webpush", tags=["webpush"])
+
+
+@webpush_router.post("/", status_code=HTTPStatus.CREATED)
+async def api_create_webpush_subscription(
+    request: Request,
+    data: CreateWebPushSubscription,
+    wallet: WalletTypeInfo = Depends(require_admin_key),
+) -> WebPushSubscription:
+    subscription = json.loads(data.subscription)
+    endpoint = subscription["endpoint"]
+    host = urlparse(str(request.url)).netloc
+
+    subscription = await get_webpush_subscription(endpoint, wallet.wallet.user)
+    if subscription:
+        return subscription
+    else:
+        return await create_webpush_subscription(
+            endpoint,
+            wallet.wallet.user,
+            data.subscription,
+            host,
+        )
+
+
+@webpush_router.delete("/", status_code=HTTPStatus.OK)
+async def api_delete_webpush_subscription(
+    request: Request,
+    wallet: WalletTypeInfo = Depends(require_admin_key),
+):
+    endpoint = unquote(
+        base64.b64decode(str(request.query_params.get("endpoint"))).decode("utf-8")
+    )
+    await delete_webpush_subscription(endpoint, wallet.wallet.user)


### PR DESCRIPTION
refactor to make `views/api.py` cleaner