### PR TITLE
chore: update to version 0.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lnbits"
-version = "0.11.2"
+version = "0.11.3"
 description = "LNbits, free and open-source Lightning wallet and accounts system."
 authors = ["Alan Bits <alan@lnbits.com>"]
 


### PR DESCRIPTION
It seems there are many small improvements we want to release as part of 0.11.3 that is before merging big features to 0.12.0.

Let's merge PRs from [Milestone 0.11.3](https://github.com/lnbits/lnbits/milestone/10) and do the release now-ish.

We can do 0.12.0 later in January.