### PR TITLE
update nix ci action to use cachix to cache results

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,15 +1,21 @@
 name: LNbits CI / nix
 
+# - run   : on main, dev, nix and cachix branches when relevant files change
+# - cache : on main, dev and cachix branches when relevant files change
+
 on:
   push:
     branches:
       - main
       - dev
+      - nix
+      - cachix
     paths:
       - 'flake.nix'
       - 'flake.lock'
       - 'pyproject.toml'
       - 'poetry.lock'
+      - '.github/workflows/nix.yml'
   pull_request:
     paths:
       - 'flake.nix'
@@ -21,8 +27,15 @@ jobs:
   nix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v23
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v24
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix build
+          nix_path: nixpkgs=channel:nixos-23.11
+      - uses: cachix/cachix-action@v13
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/cachix'
+        with:
+          name: lnbits
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: nix build -L
+      - run: cachix push lnbits ./result
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/cachix'


### PR DESCRIPTION
- this should reduce the build time needed in the CI
- this should reduce the build time needed when deploying LNbits - users just need to call `cachix use lnbits` before calling `nix build`