### PR TITLE
feat: `cleanup-wallets` cli command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,5 +216,4 @@ LOG_ROTATION="100 MB"
 LOG_RETENTION="3 months"
 
 # for database cleanup commands
-# 3 month in seconds 60 * 60 * 24 * 30 * 3
-# CLEANUP_WALLETS_DELTA=7776000
+# CLEANUP_WALLETS_DAYS=90

--- a/.env.example
+++ b/.env.example
@@ -214,3 +214,7 @@ ENABLE_LOG_TO_FILE=true
 # https://loguru.readthedocs.io/en/stable/api/logger.html#file
 LOG_ROTATION="100 MB"
 LOG_RETENTION="3 months"
+
+# for database cleanup commands
+# 3 month in seconds 60 * 60 * 24 * 30 * 3
+# CLEANUP_WALLETS_DELTA=7776000

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -162,7 +162,7 @@ async def db_versions():
 
 
 @db.command("cleanup-wallets")
-@click.argument("delta", required=False)
+@click.argument("delta", type=int, required=False)
 @coro
 async def database_cleanup_wallets(delta: Optional[int] = None):
     """Delete all wallets that never had any transaction"""
@@ -179,7 +179,7 @@ async def database_cleanup_deleted_wallets():
 
 
 @db.command("cleanup-accounts")
-@click.argument("delta", required=False)
+@click.argument("delta", type=int, required=False)
 @coro
 async def database_cleanup_accounts(delta: Optional[int] = None):
     """Delete all accounts that have no wallets"""

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -162,12 +162,12 @@ async def db_versions():
 
 
 @db.command("cleanup-wallets")
-@click.argument("cleanup_wallets_days", type=int, required=False)
+@click.argument("days", type=int, required=False)
 @coro
-async def database_cleanup_wallets(cleanup_wallets_days: Optional[int] = None):
+async def database_cleanup_wallets(days: Optional[int] = None):
     """Delete all wallets that never had any transaction"""
     async with core_db.connect() as conn:
-        delta = cleanup_wallets_days or settings.cleanup_wallets_days
+        delta = days or settings.cleanup_wallets_days
         delta = delta * 24 * 60 * 60
         await delete_unused_wallets(delta, conn)
 
@@ -181,12 +181,12 @@ async def database_cleanup_deleted_wallets():
 
 
 @db.command("cleanup-accounts")
-@click.argument("cleanup_wallets_days", type=int, required=False)
+@click.argument("days", type=int, required=False)
 @coro
-async def database_cleanup_accounts(cleanup_wallets_days: Optional[int] = None):
+async def database_cleanup_accounts(days: Optional[int] = None):
     """Delete all accounts that have no wallets"""
     async with core_db.connect() as conn:
-        delta = cleanup_wallets_days or settings.cleanup_wallets_days
+        delta = days or settings.cleanup_wallets_days
         delta = delta * 24 * 60 * 60
         await delete_unused_wallets(delta, conn)
 

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -162,12 +162,14 @@ async def db_versions():
 
 
 @db.command("cleanup-wallets")
-@click.argument("delta", type=int, required=False)
+@click.argument("cleanup_wallets_days", type=int, required=False)
 @coro
-async def database_cleanup_wallets(delta: Optional[int] = None):
+async def database_cleanup_wallets(cleanup_wallets_days: Optional[int] = None):
     """Delete all wallets that never had any transaction"""
     async with core_db.connect() as conn:
-        await delete_unused_wallets(delta or settings.cleanup_wallets_delta, conn)
+        delta = cleanup_wallets_days or settings.cleanup_wallets_days
+        delta = delta * 24 * 60 * 60
+        await delete_unused_wallets(delta, conn)
 
 
 @db.command("cleanup-deleted-wallets")
@@ -179,12 +181,14 @@ async def database_cleanup_deleted_wallets():
 
 
 @db.command("cleanup-accounts")
-@click.argument("delta", type=int, required=False)
+@click.argument("cleanup_wallets_days", type=int, required=False)
 @coro
-async def database_cleanup_accounts(delta: Optional[int] = None):
+async def database_cleanup_accounts(cleanup_wallets_days: Optional[int] = None):
     """Delete all accounts that have no wallets"""
     async with core_db.connect() as conn:
-        await delete_accounts_no_wallets(delta or settings.cleanup_wallets_delta, conn)
+        delta = cleanup_wallets_days or settings.cleanup_wallets_days
+        delta = delta * 24 * 60 * 60
+        await delete_unused_wallets(delta, conn)
 
 
 async def load_disabled_extension_list() -> None:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -158,7 +158,7 @@ async def migrate_databases():
 async def database_versions():
     """Show current database versions"""
     async with core_db.connect() as conn:
-        return await get_dbversions(conn)
+        await get_dbversions(conn)
 
 
 @db.command("cleanup-wallets")
@@ -166,7 +166,7 @@ async def database_versions():
 async def database_cleanup_wallets():
     """Delete all wallets that never had any transaction"""
     async with core_db.connect() as conn:
-        return await delete_unused_wallets(settings.cleanup_wallets_delta, conn)
+        await delete_unused_wallets(settings.cleanup_wallets_delta, conn)
 
 
 @db.command("cleanup-deleted-wallets")
@@ -174,7 +174,7 @@ async def database_cleanup_wallets():
 async def database_cleanup_deleted_wallets():
     """Delete all wallets that has been marked deleted"""
     async with core_db.connect() as conn:
-        return await remove_deleted_wallets(conn)
+        await remove_deleted_wallets(conn)
 
 
 @db.command("cleanup-accounts")
@@ -182,7 +182,7 @@ async def database_cleanup_deleted_wallets():
 async def database_cleanup_accounts():
     """Delete all accounts that have no wallets"""
     async with core_db.connect() as conn:
-        return await delete_accounts_no_wallets(settings.cleanup_wallets_delta, conn)
+        await delete_accounts_no_wallets(settings.cleanup_wallets_delta, conn)
 
 
 async def load_disabled_extension_list() -> None:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -158,15 +158,16 @@ async def migrate_databases():
 async def db_versions():
     """Show current database versions"""
     async with core_db.connect() as conn:
-        await get_dbversions(conn)
+        click.echo(await get_dbversions(conn))
 
 
 @db.command("cleanup-wallets")
+@click.argument("delta", required=False)
 @coro
-async def database_cleanup_wallets():
+async def database_cleanup_wallets(delta: Optional[int] = None):
     """Delete all wallets that never had any transaction"""
     async with core_db.connect() as conn:
-        await delete_unused_wallets(settings.cleanup_wallets_delta, conn)
+        await delete_unused_wallets(delta or settings.cleanup_wallets_delta, conn)
 
 
 @db.command("cleanup-deleted-wallets")
@@ -178,11 +179,12 @@ async def database_cleanup_deleted_wallets():
 
 
 @db.command("cleanup-accounts")
+@click.argument("delta", required=False)
 @coro
-async def database_cleanup_accounts():
+async def database_cleanup_accounts(delta: Optional[int] = None):
     """Delete all accounts that have no wallets"""
     async with core_db.connect() as conn:
-        await delete_accounts_no_wallets(settings.cleanup_wallets_delta, conn)
+        await delete_accounts_no_wallets(delta or settings.cleanup_wallets_delta, conn)
 
 
 async def load_disabled_extension_list() -> None:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -154,50 +154,33 @@ async def migrate_databases():
 
 
 @db.command("versions")
-def database_versions():
-    """Show current database versions"""
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(db_versions())
-
-
-async def db_versions():
+@coro
+async def database_versions():
     """Show current database versions"""
     async with core_db.connect() as conn:
         return await get_dbversions(conn)
 
 
 @db.command("cleanup-wallets")
-def database_cleanup_wallets():
+@coro
+async def database_cleanup_wallets():
     """Delete all wallets that never had any transaction"""
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(cleanup_wallets())
-
-
-async def cleanup_wallets():
     async with core_db.connect() as conn:
         return await delete_unused_wallets(settings.cleanup_wallets_delta, conn)
 
 
 @db.command("cleanup-deleted-wallets")
-def database_cleanup_deleted_wallets():
+@coro
+async def database_cleanup_deleted_wallets():
     """Delete all wallets that has been marked deleted"""
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(cleanup_deleted_wallets())
-
-
-async def cleanup_deleted_wallets():
     async with core_db.connect() as conn:
         return await remove_deleted_wallets(conn)
 
 
 @db.command("cleanup-accounts")
-def database_cleanup_accounts():
+@coro
+async def database_cleanup_accounts():
     """Delete all accounts that have no wallets"""
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(cleanup_accounts())
-
-
-async def cleanup_accounts():
     async with core_db.connect() as conn:
         return await delete_accounts_no_wallets(settings.cleanup_wallets_delta, conn)
 

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -18,6 +18,8 @@ from lnbits.settings import settings
 from .core import db as core_db
 from .core import migrations as core_migrations
 from .core.crud import (
+    delete_accounts_no_wallets,
+    delete_deleted_wallets,
     delete_unused_wallets,
     get_dbversions,
     get_inactive_extensions,
@@ -174,6 +176,30 @@ def database_cleanup_wallets():
 async def cleanup_wallets():
     async with core_db.connect() as conn:
         return await delete_unused_wallets(conn)
+
+
+@db.command("cleanup-deleted-wallets")
+def database_cleanup_deleted_wallets():
+    """Delete all wallets that has been marked deleted"""
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(cleanup_deleted_wallets())
+
+
+async def cleanup_deleted_wallets():
+    async with core_db.connect() as conn:
+        return await delete_deleted_wallets(conn)
+
+
+@db.command("cleanup-accounts")
+def database_cleanup_accounts():
+    """Delete all accounts that have no wallets"""
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(cleanup_accounts())
+
+
+async def cleanup_accounts():
+    async with core_db.connect() as conn:
+        return await delete_accounts_no_wallets(conn)
 
 
 async def load_disabled_extension_list() -> None:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -188,7 +188,7 @@ async def database_cleanup_accounts(days: Optional[int] = None):
     async with core_db.connect() as conn:
         delta = days or settings.cleanup_wallets_days
         delta = delta * 24 * 60 * 60
-        await delete_unused_wallets(delta, conn)
+        await delete_accounts_no_wallets(delta, conn)
 
 
 async def load_disabled_extension_list() -> None:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -18,6 +18,7 @@ from lnbits.settings import settings
 from .core import db as core_db
 from .core import migrations as core_migrations
 from .core.crud import (
+    delete_unused_wallets,
     get_dbversions,
     get_inactive_extensions,
     get_installed_extension,
@@ -161,6 +162,18 @@ async def db_versions():
     """Show current database versions"""
     async with core_db.connect() as conn:
         return await get_dbversions(conn)
+
+
+@db.command("cleanup-wallets")
+def database_cleanup_wallets():
+    """Delete all wallets that never had any transaction"""
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(cleanup_wallets())
+
+
+async def cleanup_wallets():
+    async with core_db.connect() as conn:
+        return await delete_unused_wallets(conn)
 
 
 async def load_disabled_extension_list() -> None:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -175,7 +175,7 @@ def database_cleanup_wallets():
 
 async def cleanup_wallets():
     async with core_db.connect() as conn:
-        return await delete_unused_wallets(conn)
+        return await delete_unused_wallets(settings.cleanup_wallets_delta, conn)
 
 
 @db.command("cleanup-deleted-wallets")
@@ -199,7 +199,7 @@ def database_cleanup_accounts():
 
 async def cleanup_accounts():
     async with core_db.connect() as conn:
-        return await delete_accounts_no_wallets(conn)
+        return await delete_accounts_no_wallets(settings.cleanup_wallets_delta, conn)
 
 
 async def load_disabled_extension_list() -> None:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -155,7 +155,7 @@ async def migrate_databases():
 
 @db.command("versions")
 @coro
-async def database_versions():
+async def db_versions():
     """Show current database versions"""
     async with core_db.connect() as conn:
         await get_dbversions(conn)

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -19,12 +19,12 @@ from .core import db as core_db
 from .core import migrations as core_migrations
 from .core.crud import (
     delete_accounts_no_wallets,
-    delete_deleted_wallets,
     delete_unused_wallets,
     get_dbversions,
     get_inactive_extensions,
     get_installed_extension,
     get_installed_extensions,
+    remove_deleted_wallets,
 )
 from .core.helpers import migrate_extension_database, run_migration
 from .db import COCKROACH, POSTGRES, SQLITE
@@ -187,7 +187,7 @@ def database_cleanup_deleted_wallets():
 
 async def cleanup_deleted_wallets():
     async with core_db.connect() as conn:
-        return await delete_deleted_wallets(conn)
+        return await remove_deleted_wallets(conn)
 
 
 @db.command("cleanup-accounts")

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -491,6 +491,17 @@ async def delete_wallet(
     )
 
 
+async def delete_unused_wallets(conn: Optional[Connection] = None) -> None:
+    await (conn or db).execute(
+        """
+        DELETE FROM wallets
+        WHERE (
+            SELECT COUNT(*) FROM apipayments WHERE wallet = wallets.id
+        ) = 0
+        """
+    )
+
+
 async def get_wallet(
     wallet_id: str, conn: Optional[Connection] = None
 ) -> Optional[Wallet]:

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -502,7 +502,7 @@ async def delete_wallet(
     )
 
 
-async def delete_deleted_wallets(conn: Optional[Connection] = None) -> None:
+async def remove_deleted_wallets(conn: Optional[Connection] = None) -> None:
     await (conn or db).execute("DELETE FROM wallets WHERE deleted = true")
 
 

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -158,6 +158,17 @@ async def get_account(
     return User(**row) if row else None
 
 
+async def delete_accounts_no_wallets(conn: Optional[Connection] = None) -> None:
+    await (conn or db).execute(
+        """
+        DELETE FROM accounts
+        WHERE NOT EXISTS (
+            SELECT wallets.id FROM wallets WHERE wallets.user = accounts.id
+        )
+        """
+    )
+
+
 async def get_user_password(user_id: str) -> Optional[str]:
     row = await db.fetchone(
         "SELECT pass FROM accounts WHERE id = ?",
@@ -489,6 +500,10 @@ async def delete_wallet(
         """,
         (now, wallet_id, user_id),
     )
+
+
+async def delete_deleted_wallets(conn: Optional[Connection] = None) -> None:
+    await (conn or db).execute("DELETE FROM wallets WHERE deleted = true")
 
 
 async def delete_unused_wallets(conn: Optional[Connection] = None) -> None:

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -162,7 +162,7 @@ async def delete_accounts_no_wallets(
     time_delta: int,
     conn: Optional[Connection] = None,
 ) -> None:
-    await (conn or db).fetchone(
+    await (conn or db).execute(
         f"""
         DELETE FROM accounts
         WHERE NOT EXISTS (

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -348,7 +348,7 @@ class EnvSettings(LNbitsSettings):
     log_retention: str = Field(default="3 months")
     server_startup_time: int = Field(default=time())
     lnbits_extensions_deactivate_all: bool = Field(default=False)
-    cleanup_wallets_delta: int = Field(default=7776000)
+    cleanup_wallets_days: int = Field(default=90)
 
     @property
     def has_default_extension_path(self) -> bool:

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -348,6 +348,7 @@ class EnvSettings(LNbitsSettings):
     log_retention: str = Field(default="3 months")
     server_startup_time: int = Field(default=time())
     lnbits_extensions_deactivate_all: bool = Field(default=False)
+    cleanup_wallets_delta: int = Field(default=7776000)
 
     @property
     def has_default_extension_path(self) -> bool:


### PR DESCRIPTION
`lnbits-cli db cleanup-wallets` removes all wallets that never had an transaction. this helps against spammers creating random wallets, eventually slowing down the db.