### PR TITLE
Update the GET /wallet endpoint to correctly handle an empty state

### DIFF
--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -165,11 +165,16 @@ async def extensions_install(
 )
 async def wallet(
     request: Request,
-    usr: UUID4 = Query(...),
+    usr: UUID4 = Query(None),
     wal: Optional[UUID4] = Query(None),
 ):
-    user_id = usr.hex
-    user = await get_user(user_id)
+    if not usr:
+        new_user = await create_account()
+        user = await get_user(new_user.id)
+        user_id = new_user.id
+    else:
+        user_id = usr.hex
+        user = await get_user(user_id)
 
     if not user:
         return template_renderer().TemplateResponse(


### PR DESCRIPTION
In this PR: https://github.com/lnbits/lnbits/pull/1932

It broke the situation where someone just load ups the `/wallet` endpoint and it would create a new wallet. We would get the error:

```
Error: [{'loc': ('query', 'usr'), 'msg': 'field required', 'type': 'value_error.missing'}]
```

This is because it's expecting the User to be defined which it isn't in this case of just loading the page. So we need to add back in the create user call if the user isn't defined. 