### PR TITLE
fix the url for js libs

### DIFF
--- a/lnbits/templates/print.html
+++ b/lnbits/templates/print.html
@@ -34,7 +34,7 @@
     </q-layout>
 
     {% for url in INCLUDED_JS %}
-    <script src="{{ url }}"></script>
+    <script src="{{ static_url_for('static', url) }}"></script>
     {% endfor %}
     <!---->
     {% block scripts %}{% endblock %}


### PR DESCRIPTION
This fixes, for example, printing LNURLw vouchers.