### PR TITLE
[draft] feat: set `samesite="none", secure=True` for cookies

### DIFF
--- a/lnbits/core/views/auth_api.py
+++ b/lnbits/core/views/auth_api.py
@@ -292,7 +292,9 @@ def _auth_success_response(
         data={"sub": username or "", "usr": user_id, "email": email}
     )
     response = JSONResponse({"access_token": access_token, "token_type": "bearer"})
-    response.set_cookie("cookie_access_token", access_token, httponly=True)
+    response.set_cookie(
+        "cookie_access_token", access_token, httponly=True, samesite="none", secure=True
+    )
     response.set_cookie(
         "is_lnbits_user_authorized", "true", samesite="none", secure=True
     )
@@ -304,7 +306,9 @@ def _auth_success_response(
 def _auth_redirect_response(path: str, email: str) -> RedirectResponse:
     access_token = create_access_token(data={"sub": "" or "", "email": email})
     response = RedirectResponse(path)
-    response.set_cookie("cookie_access_token", access_token, httponly=True)
+    response.set_cookie(
+        "cookie_access_token", access_token, httponly=True, samesite="none", secure=True
+    )
     response.set_cookie(
         "is_lnbits_user_authorized", "true", samesite="none", secure=True
     )


### PR DESCRIPTION
### Summary
 - this change is in order to allow the LNbits site to be **securely** embedded as an iFrame in 3rd party sites
 - this is required for browser extension but can be used in other contexts as well
 

https://github.com/lnbits/lnbits/assets/2951406/65fc6527-a8de-4868-a4b7-811d7df388f2

The main question is if `samesite="none"` will introduce any vulnerability/risk (given that `httponly=True` and `secure=True` are set).

It is important for the cookie containing the auth-token not be accessible by 3rd party sites. This cookie now (with this PR) has these 3 attributes: `httponly=True, samesite="none", secure=True`

More details about `HttpOnly` and `Secure` attributes [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies). `SameSite attribute` described on the same page below (no anchor available)

Other Reading:
 - https://vercel.com/guides/understanding-the-samesite-attribute
 - https://www.invicti.com/learn/cookie-security-flags/
 - https://0xn3va.gitbook.io/cheat-sheets/web-application/cookie-security