### PR TITLE
feat: remember last active wallet

### DIFF
--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -175,7 +175,7 @@ async def wallet(
         wallet = await create_wallet(user_id=user.id)
         user = await get_user(user_id=user.id) or user
         wallet_id = wallet.id
-    elif user.get_wallet(lnbits_last_active_wallet):
+    elif lnbits_last_active_wallet and user.get_wallet(lnbits_last_active_wallet):
         wallet_id = lnbits_last_active_wallet
     else:
         wallet_id = user.wallets[0].id


### PR DESCRIPTION
### Summary
Store last active wallet as a cookie. When the user re-opens the tab it will have the last active wallet selected.
Before this PR the first wallet was the selected one.


https://github.com/lnbits/lnbits/assets/2951406/91bb032f-e71d-4dae-beb4-ef53f71b598c

