### PR TITLE
fix: remove custom dev shells from the flake file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,14 +18,6 @@
       projectName = "lnbits";
     in
     {
-      devShells = forAllSystems (system: pkgs: {
-        default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            nodePackages.prettier
-            poetry-core
-          ];
-        };
-      });
       overlays = {
         default = final: prev: {
           ${projectName} = self.packages.${prev.stdenv.hostPlatform.system}.${projectName};


### PR DESCRIPTION
The definition of the dev shell in the flake file had issues when opening a development shell. However, defining the custom dev shell is unnecessary anyway as mkPoetryApplication already creates a default working dev shell.