### PR TITLE
Deactivate all extensions flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,9 @@ LNBITS_ADMIN_USERS=""
 # Extensions only admin can access
 LNBITS_ADMIN_EXTENSIONS="ngrok, admin"
 
+# Start LNbits core only. The extensions are not loaded.
+LNBITS_EXTENSIONS_DEACTIVATE_ALL=true
+
 # Disable account creation for new users
 # LNBITS_ALLOW_NEW_ACCOUNTS=false
 

--- a/.env.example
+++ b/.env.example
@@ -142,7 +142,7 @@ LNBITS_ADMIN_USERS=""
 LNBITS_ADMIN_EXTENSIONS="ngrok, admin"
 
 # Start LNbits core only. The extensions are not loaded.
-LNBITS_EXTENSIONS_DEACTIVATE_ALL=true
+# LNBITS_EXTENSIONS_DEACTIVATE_ALL=true
 
 # Disable account creation for new users
 # LNBITS_ALLOW_NEW_ACCOUNTS=false

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -112,7 +112,6 @@ def create_app() -> FastAPI:
     add_ratelimit_middleware(app)
 
     register_startup(app)
-    register_routes(app)
     register_async_tasks(app)
     register_exception_handlers(app)
     register_shutdown(app)
@@ -390,6 +389,9 @@ def register_startup(app: FastAPI):
 
             # check extensions after restart
             await check_installed_extensions(app)
+
+            # register core and extension routes
+            register_routes(app)
 
             if settings.lnbits_admin_ui:
                 initialize_server_logger()

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -188,7 +188,6 @@ async def check_installed_extensions(app: FastAPI):
     persist state. Zips that are missing will be re-downloaded.
     """
     shutil.rmtree(os.path.join("lnbits", "upgrades"), True)
-    await load_disabled_extension_list()
     installed_extensions = await build_all_installed_extensions_list(False)
 
     for ext in installed_extensions:
@@ -370,6 +369,8 @@ def register_startup(app: FastAPI):
     @app.on_event("startup")
     async def lnbits_startup():
         try:
+            await load_disabled_extension_list()
+
             # wait till migration is done
             await migrate_databases()
 

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -35,7 +35,7 @@ from lnbits.tasks import cancel_all_tasks, create_permanent_task
 from lnbits.utils.cache import cache
 from lnbits.wallets import get_wallet_class, set_wallet_class
 
-from .commands import db_versions, load_disabled_extension_list, migrate_databases
+from .commands import db_versions, migrate_databases
 from .core import init_core_routers
 from .core.db import core_app_extra
 from .core.services import check_admin_settings, check_webpush_settings
@@ -369,8 +369,6 @@ def register_startup(app: FastAPI):
     @app.on_event("startup")
     async def lnbits_startup():
         try:
-            await load_disabled_extension_list()
-
             # wait till migration is done
             await migrate_databases()
 

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -244,7 +244,11 @@ async def build_all_installed_extensions_list(
     if settings.lnbits_extensions_deactivate_all:
         return []
 
-    return [e for e in installed_extensions if e.id not in settings.lnbits_deactivated_extensions]
+    return [
+        e
+        for e in installed_extensions
+        if e.id not in settings.lnbits_deactivated_extensions
+    ]
 
 
 def check_installed_extension_files(ext: InstallableExtension) -> bool:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -136,6 +136,10 @@ async def migrate_databases():
         core_version = current_versions.get("core", 0)
         await run_migration(conn, core_migrations, "core", core_version)
 
+    # here is the first place we can be sure that the
+    # `installed_extensions` table has been created
+    await load_disabled_extension_list()
+
     for ext in get_valid_extensions(False):
         current_version = current_versions.get(ext.code, 0)
         try:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -136,7 +136,7 @@ async def migrate_databases():
         core_version = current_versions.get("core", 0)
         await run_migration(conn, core_migrations, "core", core_version)
 
-    for ext in get_valid_extensions():
+    for ext in get_valid_extensions(False):
         current_version = current_versions.get(ext.code, 0)
         try:
             await migrate_extension_database(ext, current_version)

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -54,8 +54,6 @@ async def stop_extension_background_work(
     """
     Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
     Extensions SHOULD expose a DELETE enpoint at the root level of their API.
-    This function tries first to call the endpoint using `http`
-    and if it fails it tries using `https`.
     """
     async with httpx.AsyncClient() as client:
         try:

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -604,9 +604,21 @@ class CreateExtension(BaseModel):
     source_repo: str
 
 
-def get_valid_extensions() -> List[Extension]:
-    return [
+def get_valid_extensions(include_deactivated: Optional[bool] = True) -> List[Extension]:
+    valid_extensions = [
         extension for extension in ExtensionManager().extensions if extension.is_valid
+    ]
+
+    if include_deactivated:
+        return valid_extensions
+
+    if settings.lnbits_extensions_deactivate_all:
+        return []
+
+    return [
+        e
+        for e in valid_extensions
+        if e.code not in settings.lnbits_deactivated_extensions
     ]
 
 

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -70,11 +70,7 @@ def template_renderer(additional_folders: Optional[List] = None) -> Jinja2Templa
         settings.lnbits_node_ui and get_node_class() is not None
     )
     t.env.globals["LNBITS_NODE_UI_AVAILABLE"] = get_node_class() is not None
-    t.env.globals["EXTENSIONS"] = [
-        e
-        for e in get_valid_extensions()
-        if e.code not in settings.lnbits_deactivated_extensions
-    ]
+    t.env.globals["EXTENSIONS"] = get_valid_extensions(False)
     if settings.lnbits_custom_logo:
         t.env.globals["USE_CUSTOM_LOGO"] = settings.lnbits_custom_logo
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -347,6 +347,7 @@ class EnvSettings(LNbitsSettings):
     log_rotation: str = Field(default="100 MB")
     log_retention: str = Field(default="3 months")
     server_startup_time: int = Field(default=time())
+    lnbits_extensions_deactivate_all: bool = Field(default=False)
 
     @property
     def has_default_extension_path(self) -> bool:


### PR DESCRIPTION
### Summary
Add the `LNBITS_EXTENSIONS_DEACTIVATE_ALL` flag. If set to true then on server startup the extensions will not be loaded. This will exclude running the migration and  the route mapping.


### Test Scenarios

**Scenario 1**
 - start the server with the flag set to `false` (default)
 - test install/uninstall/upgrade
 - new: if an extension is deactivated at the start-up moment then it will not be loaded

**Scenario 1**
 - start the server with the flag set to `true`
 - expect: 
    - no extension should be loaded
    - the extensions are not visible on the left hand side
    - the extensions are visible on the extensions page (http://localhost:5000/extensions)
    - the extensions can be installed/uninstalled/de-activated
