### PR TITLE
refactor: extract `encrypt_internal_message` and `decrypt_internal_message`

### DIFF
--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -14,6 +14,7 @@ from lnbits.jinja2_templating import Jinja2Templates
 from lnbits.nodes import get_node_class
 from lnbits.requestvars import g
 from lnbits.settings import settings
+from lnbits.utils.crypto import AESCipher
 
 from .db import FilterModel
 from .extension_manager import get_valid_extensions
@@ -187,3 +188,17 @@ def create_access_token(data: dict):
     to_encode = data.copy()
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, settings.auth_secret_key, "HS256")
+
+
+def encrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
+    """Encrypt message with the internal secret key"""
+    if not m:
+        return None
+    return AESCipher(key=settings.auth_secret_key).encrypt(m.encode())
+
+
+def decrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
+    """Decrypt message with the internal secret key"""
+    if not m:
+        return None
+    return AESCipher(key=settings.auth_secret_key).decrypt(m)


### PR DESCRIPTION
### Summary
Small refactoring that allows extensions also to encrypt messages using the default auth secret.

One use-case is exposing secret endpoints that can only be used between extensions.

### Example

```py
@nostrclient_ext.websocket("/api/v1/{id}")
```

If the decrypted value of `id` is `"relay"` then the connection is allowed (made by another extension). Otherwise the connection is dropped.