### PR TITLE
Fix extension navigation

### DIFF
--- a/lnbits/core/templates/core/extensions.html
+++ b/lnbits/core/templates/core/extensions.html
@@ -185,7 +185,7 @@
               flat
               color="primary"
               type="a"
-              :href="extension.id"
+              :href="extension.id + '/'"
               >{%raw%}{{ $t('open') }}{%endraw%}</q-btn
             >
             <q-btn

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -168,7 +168,7 @@ async def extensions_install(
         )
 
         # refresh user state. Eg: enabled extensions.
-        user = await get_user(user.id)
+        user = await get_user(user.id) or user
 
         return template_renderer().TemplateResponse(
             "core/extensions.html",

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -167,6 +167,9 @@ async def extensions_install(
             )
         )
 
+        # refresh user state. Eg: enabled extensions.
+        user = await get_user(user.id)
+
         return template_renderer().TemplateResponse(
             "core/extensions.html",
             {


### PR DESCRIPTION
### Summary
This PR solves two small issues:

**Withdraw extension link**
Opening the `LNURLp` extension from the extension page will result in an error page. Works fine from the left-side menu.
The reason is that there is a path conflict with an endpoint defined in `lnbits/core/views/generic.py`. Adding an `/` suffix solves the issue.

**Enable/Disable extension**
When enabling/disabling an extension the state of the extension is not updated (`enabled/disabled`). A refresh or performing the action again is required.
    