### PR TITLE
fix: cannot change user password

### DIFF
--- a/lnbits/static/js/account.js
+++ b/lnbits/static/js/account.js
@@ -54,6 +54,13 @@ new Vue({
       }
     },
     updatePassword: async function () {
+      if (!this.user.username) {
+        this.$q.notify({
+          type: 'warning',
+          message: 'Please set a username first.'
+        })
+        return
+      }
       try {
         const {data} = await LNbits.api.request(
           'PUT',
@@ -61,6 +68,7 @@ new Vue({
           null,
           {
             user_id: this.user.id,
+            username: this.user.username,
             password_old: this.passwordData.oldPassword,
             password: this.passwordData.newPassword,
             password_repeat: this.passwordData.newPasswordRepeat
@@ -77,6 +85,13 @@ new Vue({
       }
     },
     showChangePassword: function () {
+      if (!this.user.username) {
+        this.$q.notify({
+          type: 'warning',
+          message: 'Please set a username first.'
+        })
+        return
+      }
       this.passwordData = {
         show: true,
         oldPassword: null,


### PR DESCRIPTION
### Summary
Check for `username` before allowing password change

**Steps**:
 - create a new account
 - go to Account page an try to change the password

**Actual Result**:
 - an error message is displayed: `[{'loc': ('body', 'username'), 'msg': 'field required', 'type': 'value_error.missing'}]` 

**Expected Result**:
 - a nice message is displayed asking the user to set an `username` first
 - username/password login is not possible without a username

![image](https://github.com/lnbits/lnbits/assets/2951406/38437764-4759-4da3-af1d-32b8216fe58c)

**Workaround**:
 - set a username before changing the password

**Cause**: 
 - regression bug from "Install wizard on first launch" feature
