### PR TITLE
Add Greenlight partner certificate settings to Breez SDK wallet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 ######################################
 
 # which fundingsources are allowed in the admin ui
-LNBITS_ALLOWED_FUNDING_SOURCES="VoidWallet, FakeWallet, CoreLightningWallet, CoreLightningRestWallet, LndRestWallet, EclairWallet, LndWallet, LnTipsWallet, LNPayWallet, LNbitsWallet, AlbyWallet, OpenNodeWallet"
+LNBITS_ALLOWED_FUNDING_SOURCES="VoidWallet, FakeWallet, CoreLightningWallet, CoreLightningRestWallet, LndRestWallet, EclairWallet, LndWallet, LnTipsWallet, LNPayWallet, LNbitsWallet, AlbyWallet, OpenNodeWallet, BreezSdkWallet"
 
 LNBITS_BACKEND_WALLET_CLASS=VoidWallet
 # VoidWallet is just a fallback that works without any actual Lightning capabilities,
@@ -81,8 +81,10 @@ LNTIPS_API_ENDPOINT=https://ln.tips
 # BreezSdkWallet
 BREEZ_API_KEY=KEY
 BREEZ_GREENLIGHT_SEED=SEED
-# a GreenLight certificate can be used directly instead of a Breez/GreenLight invite code
+# A Greenlight invite code or Greenlight partner certificate/key can be used
 BREEZ_GREENLIGHT_INVITE_CODE=CODE
+BREEZ_GREENLIGHT_DEVICE_KEY="/path/to/breezsdk/device.pem"  # or BASE64/HEXSTRING
+BREEZ_GREENLIGHT_DEVICE_CERT="/path/to/breezsdk/device.crt"  # or BASE64/HEXSTRING
 
 ######################################
 ########### Admin Settings ###########

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ LNbits can run on top of any Lightning funding source. It currently supports the
 - OpenNode
 - Alby
 - LightningTipBot
+- Breez SDK (Greenlight)
 
 See [LNbits manual](https://docs.lnbits.org/guide/wallets.html) for more detailed documentation about each funding source.
 

--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -89,10 +89,14 @@ For the invoice to work you must have a publicly accessible URL in your LNbits. 
 
 ### Breez SDK
 
+A Greenlight invite code or Greenlight partner certificate/key can be used to register a new node with Greenlight. If the Greenlight node already exists, neither are required.
+
 - `LNBITS_BACKEND_WALLET_CLASS`: **BreezSdkWallet**
 - `BREEZ_API_KEY`: ...
 - `BREEZ_GREENLIGHT_SEED`: ...
-- `BREEZ_GREENLIGHT_INVITE_CODE`: ... (a GreenLight certificate can be used directly instead of a Breez/GreenLight invite code)
+- `BREEZ_GREENLIGHT_INVITE_CODE`: ...
+- `BREEZ_GREENLIGHT_DEVICE_KEY`: /path/to/breezsdk/device.pem or Base64/Hex
+- `BREEZ_GREENLIGHT_DEVICE_CERT`: /path/to/breezsdk/device.crt or Base64/Hex
 
 ### Cliche Wallet
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -214,6 +214,8 @@ class BreezSdkFundingSource(LNbitsSettings):
     breez_api_key: Optional[str] = Field(default=None)
     breez_greenlight_seed: Optional[str] = Field(default=None)
     breez_greenlight_invite_code: Optional[str] = Field(default=None)
+    breez_greenlight_device_key: Optional[str] = Field(default=None)
+    breez_greenlight_device_cert: Optional[str] = Field(default=None)
 
 
 class LightningSettings(LNbitsSettings):


### PR DESCRIPTION
Loads Greenlight partner certificate and key from either file/hex/base64 settings for use in the Breez SDK wallet.