### PR TITLE
bug: docker upload workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,11 @@
 name: docker
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        default: latest
+        type: string
   workflow_call:
     inputs:
       tag:
@@ -38,7 +43,7 @@ jobs:
             context: .
             push: true
             tags: ${{ secrets.DOCKER_USERNAME }}/lnbits:${{ inputs.tag }}
-            platforms: [ linux/amd64, linux/arm64 ]
+            platforms: linux/amd64,linux/arm64
             cache-from: type=local,src=/tmp/.buildx-cache
             cache-to: type=local,dest=/tmp/.buildx-cache
 
@@ -48,6 +53,6 @@ jobs:
             context: .
             push: true
             tags: ${{ secrets.DOCKER_USERNAME }}/lnbits:latest
-            platforms: [ linux/amd64, linux/arm64 ]
+            platforms: linux/amd64,linux/arm64
             cache-from: type=local,src=/tmp/.buildx-cache
             cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
something changed in the docker-build-push action.

added `workflow_dispatch` to be able to manually run those docker releases via github