### PR TITLE
fix: regtest use new docker hub address

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -33,8 +33,8 @@ jobs:
         with:
             context: .
             push: false
-            tags: lnbitsdocker/lnbits-legend:latest
-            cache-from: type=registry,ref=lnbitsdocker/lnbits-legend:latest
+            tags: lnbits/lnbits:latest
+            cache-from: type=registry,ref=lnbits/lnbits:latest
             cache-to: type=inline
 
       - name: Setup Regtest
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create fake admin
         if: ${{ inputs.backend-wallet-class == 'LNbitsWallet' }}
-        run: docker exec lnbits-legend-lnbits-1 poetry run python tools/create_fake_admin.py
+        run: docker exec lnbits-lnbits-1 poetry run python tools/create_fake_admin.py
 
       - name: Run Tests
         env:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,7 +36,7 @@ is_regtest: bool = not is_fake
 docker_lightning_cli = [
     "docker",
     "exec",
-    "lnbits-legend-lnd-1-1",
+    "lnbits-lnd-1-1",
     "lncli",
     "--network",
     "regtest",
@@ -46,7 +46,7 @@ docker_lightning_cli = [
 docker_bitcoin_cli = [
     "docker",
     "exec",
-    "lnbits-legend-bitcoind-1-1" "bitcoin-cli",
+    "lnbits-bitcoind-1-1" "bitcoin-cli",
     "-rpcuser=lnbits",
     "-rpcpassword=lnbits",
     "-regtest",
@@ -56,7 +56,7 @@ docker_bitcoin_cli = [
 docker_lightning_unconnected_cli = [
     "docker",
     "exec",
-    "lnbits-legend-lnd-2-1",
+    "lnbits-lnd-2-1",
     "lncli",
     "--network",
     "regtest",


### PR DESCRIPTION
regtest not uses `lnbits/lnbits` aswell