### PR TITLE
fix: use `get_dbversions` instead of `db_versions`

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -23,7 +23,7 @@ from slowapi.util import get_remote_address
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import JSONResponse
 
-from lnbits.core.crud import get_installed_extensions
+from lnbits.core.crud import get_dbversions, get_installed_extensions
 from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.services import websocketUpdater
 from lnbits.core.tasks import (  # register_watchdog,; unregister_watchdog,
@@ -35,7 +35,7 @@ from lnbits.tasks import cancel_all_tasks, create_permanent_task
 from lnbits.utils.cache import cache
 from lnbits.wallets import get_wallet_class, set_wallet_class
 
-from .commands import db_versions, migrate_databases
+from .commands import migrate_databases
 from .core import init_core_routers
 from .core.db import core_app_extra
 from .core.services import check_admin_settings, check_webpush_settings
@@ -273,7 +273,7 @@ async def restore_installed_extension(app: FastAPI, ext: InstallableExtension):
     extension = Extension.from_installable_ext(ext)
     register_ext_routes(app, extension)
 
-    current_version = (await db_versions()).get(ext.id, 0)
+    current_version = (await get_dbversions()).get(ext.id, 0)
     await migrate_extension_database(extension, current_version)
 
     # mount routes for the new version


### PR DESCRIPTION
The use of `click` in the app itself is an issue. The `click.echo()` method tries to consume the command line arguments.
In this example `port`:
```sh
poetry run lnbits --port 5555
```

The error was: 
```
click.exceptions.NoSuchOption: No such option: --port
```

This issue was reported for a docker run. 

**Steps**:
 - remove the files of an extension
 - start server with this command `poetry run lnbits --port 5555`

**Actual Result**:
An exception is thrown:
```
Error: No such option: --port
2024-02-09 12:29:34.32 | ERROR | Traceback (most recent call last):
  File "/Users/moto/Library/Caches/pypoetry/virtualenvs/lnbits-_FscvqzI-py3.9/lib/python3.9/site-packages/click/core.py", line 1077, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/Users/moto/Library/Caches/pypoetry/virtualenvs/lnbits-_FscvqzI-py3.9/lib/python3.9/site-packages/click/core.py", line 943, in make_context
    self.parse_args(ctx, args)
  File "/Users/moto/Library/Caches/pypoetry/virtualenvs/lnbits-_FscvqzI-py3.9/lib/python3.9/site-packages/click/core.py", line 1405, in parse_args
    opts, args, param_order = parser.parse_args(args=args)
  File "/Users/moto/Library/Caches/pypoetry/virtualenvs/lnbits-_FscvqzI-py3.9/lib/python3.9/site-packages/click/parser.py", line 337, in parse_args
    self._process_args_for_options(state)
  File "/Users/moto/Library/Caches/pypoetry/virtualenvs/lnbits-_FscvqzI-py3.9/lib/python3.9/site-packages/click/parser.py", line 364, in _process_args_for_options
    self._process_opts(arg, state)
  File "/Users/moto/Library/Caches/pypoetry/virtualenvs/lnbits-_FscvqzI-py3.9/lib/python3.9/site-packages/click/parser.py", line 514, in _process_opts
    self._match_long_opt(norm_long_opt, explicit_value, state)
  File "/Users/moto/Library/Caches/pypoetry/virtualenvs/lnbits-_FscvqzI-py3.9/lib/python3.9/site-packages/click/parser.py", line 398, in _match_long_opt
    raise NoSuchOption(opt, possibilities=possibilities, ctx=self.ctx)
click.exceptions.NoSuchOption: No such option: --port
```

**Expected Result**:
 - server starts normally (with the fix in this PR)