### PR TITLE
fix: show installed extensions when manifest cannot be reached

### DIFF
--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -95,11 +95,10 @@ async def extensions_install(
         installed_exts: List["InstallableExtension"] = await get_installed_extensions()
         installed_exts_ids = [e.id for e in installed_exts]
 
-        installable_exts: List[
-            InstallableExtension
-        ] = await InstallableExtension.get_installable_extensions()
+        installable_exts = await InstallableExtension.get_installable_extensions()
+        installable_exts_ids = [e.id for e in installable_exts]
         installable_exts += [
-            e for e in installed_exts if e.id not in installed_exts_ids
+            e for e in installed_exts if e.id not in installable_exts_ids
         ]
 
         for e in installable_exts:


### PR DESCRIPTION
Report from @callebtc:

> I noticed a bug in the extension manager: if the internet connection doesn't work (or possibly if the github token is invalid), lnbits doesn't load up any extensions at all. there should probably be some sort of timeout in during which the extension manifest is polled and if it fails, the extensions should still be visible in the extension manager. I've noticed this because I had a firewall on that silently blocked requests from lnbits and no extensions showed up even though I had them installed.

The logic was there, but due to a bug the wrong filtering took place.