### PR TITLE
refactor: generalize SSO auth

### DIFF
--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -1097,6 +1097,8 @@ async def get_admin_settings(is_super_user: bool = False) -> Optional[AdminSetti
         return None
     row_dict = dict(sets)
     row_dict.pop("super_user")
+    row_dict.pop("auth_all_methods")
+
     admin_settings = AdminSettings(
         is_super_user=is_super_user,
         lnbits_allowed_funding_sources=settings.lnbits_allowed_funding_sources,

--- a/lnbits/core/views/auth_api.py
+++ b/lnbits/core/views/auth_api.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Optional
+from typing import Callable, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -325,7 +325,7 @@ def _new_sso(provider: str) -> Optional[SSOBase]:
     return None
 
 
-def _find_auth_provider_class(provider: str) -> Optional[SSOBase]:
+def _find_auth_provider_class(provider: str) -> Callable:
     sso_modules = ["lnbits.core.sso", "fastapi_sso.sso"]
     for module in sso_modules:
         try:

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -282,18 +282,10 @@ class GoogleAuthSettings(LNbitsSettings):
     google_client_id: str = Field(default="")
     google_client_secret: str = Field(default="")
 
-    @property
-    def is_google_auth_configured(self):
-        return self.google_client_id != "" and self.google_client_secret != ""
-
 
 class GitHubAuthSettings(LNbitsSettings):
     github_client_id: str = Field(default="")
     github_client_secret: str = Field(default="")
-
-    @property
-    def is_github_auth_configured(self):
-        return self.github_client_id != "" and self.github_client_secret != ""
 
 
 class EditableSettings(


### PR DESCRIPTION
closes #2212 

### Summary

See issue https://github.com/lnbits/lnbits/issues/2212 . Prepare to allow more SSO providers (eg: [Authentik](https://goauthentik.io/), [Keycloak](https://www.keycloak.org/) or [Authelia](https://www.authelia.com/).) 

The `/auth` endpoint now does not explicitly uses `google` or `github`. Any number of SSO Providers can be used now.

In order to add a new provider one must:
1. Implement the `ProviderSSO` class (eg: `KeycloakSSO`)
  - this class must be added in the `lnbits.core.sso.provider`. The full namespace is `lnbits.core.sso.provider.ProviderSSO`
  - several implementation examples can be found here: https://github.com/tomasvotava/fastapi-sso/tree/master/fastapi_sso/sso
  - ideally the new implementation is accepted by `fastapi-sso`. Please also  open a PR to the above repo  (`fastapi-sso`) with the new implementation. 

2. Create a settings class for the new Provider (eg: `KeycloakAuthSettings`). See `GitHubAuthSettings` as an example. Then add this class to `EditableSettings`.
  - don't forget to update the `env.example` file

3. Add the new provider to `AuthMethods` enum
4. Update the Login UI with the new auth provider