### PR TITLE
fix: correct invoice expiry for lndrest

### DIFF
--- a/lnbits/nodes/lndrest.py
+++ b/lnbits/nodes/lndrest.py
@@ -369,7 +369,7 @@ class LndRestNode(Node):
                 memo=invoice["memo"],
                 pending=invoice["state"] == "OPEN",
                 paid_at=invoice["settle_date"],
-                expiry=invoice["creation_date"] + invoice["expiry"],
+                expiry=int(invoice["creation_date"]) + int(invoice["expiry"]),
                 preimage=_decode_bytes(invoice["r_preimage"]),
                 bolt11=invoice["payment_request"],
             )


### PR DESCRIPTION
closes: #2258

The LND api returns the timestamps as strings which wasnt caught because strings can be appended and pydantic just converted it to an integer by itself.