### PR TITLE
fix: docker image invoice listener were not stopping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10-slim-bullseye
 
 RUN apt-get clean
 RUN apt-get update
-RUN apt-get install -y curl pkg-config build-essential
+RUN apt-get install -y curl pkg-config build-essential libnss-myhostname
 
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:$PATH"


### PR DESCRIPTION
because it could not resolve localhost