### PR TITLE
feat: deprecate get_current_extension_name

### DIFF
--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -92,6 +92,10 @@ def template_renderer(additional_folders: Optional[List] = None) -> Jinja2Templa
 
 def get_current_extension_name() -> str:
     """
+    DEPRECATED: Use the repo name instead, will be removed in the future
+    before: `register_invoice_listener(invoice_queue, get_current_extension_name())`
+    after: `register_invoice_listener(invoice_queue, "my-extension")`
+
     Returns the name of the extension that calls this method.
     """
     import inspect

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -86,6 +86,8 @@ class SseListenersDict(dict):
 invoice_listeners: Dict[str, asyncio.Queue] = SseListenersDict("invoice_listeners")
 
 
+# TODO: name should not be optional
+# some extensions still dont use a name, but they should
 def register_invoice_listener(send_chan: asyncio.Queue, name: Optional[str] = None):
     """
     A method intended for extensions (and core/tasks.py) to call when they want to be


### PR DESCRIPTION
    DEPRECATED: Use the repo name instead, will be removed in the future
    before: `register_invoice_listener(invoice_queue, get_current_extension_name())`
    after: `register_invoice_listener(invoice_queue, "my-extension")`