### PR TITLE
fix: extension stop background work

### DIFF
--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -64,21 +64,20 @@ async def stop_extension_background_work(
 
 
 async def _stop_extension_background_work(ext_id) -> bool:
+    upgrade_hash = settings.extension_upgrade_hash(ext_id) or ""
+    ext = Extension(ext_id, True, False, upgrade_hash=upgrade_hash)
+
     try:
         logger.info(f"Stopping background work for extension '{ext.module_name}'.")
-
-        upgrade_hash = settings.extension_upgrade_hash(ext_id) or ""
-        ext = Extension(ext_id, True, False, upgrade_hash=upgrade_hash)
         old_module = importlib.import_module(ext.module_name)
         await old_module.api_stop()
-
         logger.info(f"Stopped background work for extension '{ext.module_name}'.")
-        return True
     except Exception as ex:
         logger.warning(f"Failed to stop background work for '{ext.module_name}'.")
         logger.warning(ex)
+        return False
 
-    return False
+    return True
 
 
 async def _stop_extension_background_work_via_api(ext_id, user, access_token):

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -824,8 +824,9 @@ async def api_install_extension(
 
         await add_installed_extension(ext_info)
 
-        # call stop while the old routes are still active
-        await stop_extension_background_work(data.ext_id, user.id, access_token)
+        if extension.is_upgrade_extension:
+            # call stop while the old routes are still active
+            await stop_extension_background_work(data.ext_id, user.id, access_token)
 
         if data.ext_id not in settings.lnbits_deactivated_extensions:
             settings.lnbits_deactivated_extensions += [data.ext_id]

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -68,6 +68,16 @@ class InstalledExtensionsSettings(LNbitsSettings):
     # list of redirects that extensions want to perform
     lnbits_extensions_redirects: List[Any] = Field(default=[])
 
+    def extension_upgrade_path(self, ext_id: str) -> Optional[str]:
+        return next(
+            (e for e in self.lnbits_upgraded_extensions if e.endswith(f"/{ext_id}")),
+            None,
+        )
+
+    def extension_upgrade_hash(self, ext_id: str) -> Optional[str]:
+        path = settings.extension_upgrade_path(ext_id)
+        return path.split("/")[0] if path else None
+
 
 class ThemesSettings(LNbitsSettings):
     lnbits_site_title: str = Field(default="LNbits")


### PR DESCRIPTION
Related to:
 - https://github.com/lnbits/splitpayments/issues/14
 - https://github.com/lnbits/scrub/issues/7
 - https://github.com/lnbits/lnbits/pull/2278

When an extension is uninstalled/upgraded the background tasks have to be stopped.

Issue:
 - the background tasks were being stopped by calling a REST API endpoint on `localhost`
 - `localhost` is not always accessible (docker container for example)

Solution:
 - first try to call the `stop` logic using a normal python function call