### PR TITLE
refactor: remove unused webhook handler for wallets

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -61,7 +61,6 @@ from .tasks import (
     check_pending_payments,
     internal_invoice_listener,
     invoice_listener,
-    webhook_handler,
 )
 
 
@@ -465,10 +464,6 @@ def get_db_vendor_name():
 
 
 def register_async_tasks(app):
-    @app.route("/wallet/webhook")
-    async def webhook_listener():
-        return await webhook_handler()
-
     @app.on_event("startup")
     async def listeners():
         create_permanent_task(check_pending_payments)

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -6,7 +6,6 @@ import uuid
 from http import HTTPStatus
 from typing import Dict, List, Optional
 
-from fastapi.exceptions import HTTPException
 from loguru import logger
 from py_vapid import Vapid
 from pywebpush import WebPushException, webpush
@@ -77,17 +76,6 @@ def register_invoice_listener(send_chan: asyncio.Queue, name: Optional[str] = No
 
     logger.trace(f"registering invoice listener `{name}`")
     invoice_listeners[name] = send_chan
-
-
-async def webhook_handler():
-    """
-    Returns the webhook_handler for the selected wallet if present. Used by API.
-    """
-    WALLET = get_wallet_class()
-    handler = getattr(WALLET, "webhook_listener", None)
-    if handler:
-        return await handler()
-    raise HTTPException(status_code=HTTPStatus.NO_CONTENT)
 
 
 internal_invoice_queue: asyncio.Queue = asyncio.Queue(0)

--- a/lnbits/wallets/alby.py
+++ b/lnbits/wallets/alby.py
@@ -126,7 +126,3 @@ class AlbyWallet(Wallet):
         while True:
             value = await self.queue.get()
             yield value
-
-    async def webhook_listener(self):
-        logger.error("Alby webhook listener disabled")
-        return

--- a/lnbits/wallets/lnpay.py
+++ b/lnbits/wallets/lnpay.py
@@ -147,28 +147,3 @@ class LNPayWallet(Wallet):
         while True:
             value = await self.queue.get()
             yield value
-
-    async def webhook_listener(self):
-        logger.error("LNPay webhook listener disabled.")
-        return
-        # TODO: request.get_data is undefined, was it something with Flask or quart?
-        # probably issue introduced when refactoring?
-        # text: str = await request.get_data()
-        # try:
-        #     data = json.loads(text)
-        # except json.decoder.JSONDecodeError:
-        #     logger.error(f"error on lnpay webhook endpoint: {text[:200]}")
-        #     data = None
-        # if (
-        #     type(data) is not dict
-        #     or "event" not in data
-        #     or data["event"].get("name") != "wallet_receive"
-        # ):
-        #     raise HTTPException(status_code=HTTPStatus.NO_CONTENT)
-
-        # lntx_id = data["data"]["wtx"]["lnTx"]["id"]
-        # r = await self.client.get(f"/lntx/{lntx_id}?fields=settled")
-        # data = r.json()
-        # if data["settled"]:
-        #     await self.queue.put(lntx_id)
-        # raise HTTPException(status_code=HTTPStatus.NO_CONTENT)

--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -80,7 +80,6 @@ class OpenNodeWallet(Wallet):
             json={
                 "amount": amount,
                 "description": memo or "",
-                # "callback_url": url_for("/webhook_listener", _external=True),
             },
             timeout=40,
         )
@@ -144,22 +143,3 @@ class OpenNodeWallet(Wallet):
         while True:
             value = await self.queue.get()
             yield value
-
-    async def webhook_listener(self):
-        logger.error("webhook listener for opennode is disabled.")
-        return
-        # TODO: request.form is undefined, was it something with Flask or quart?
-        # probably issue introduced when refactoring?
-        # data = await request.form  # type: ignore
-        # if "status" not in data or data["status"] != "paid":
-        #     raise HTTPException(status_code=HTTPStatus.NO_CONTENT)
-
-        # charge_id = data["id"]
-        # x = hmac.new(self.key.encode("ascii"), digestmod="sha256")
-        # x.update(charge_id.encode("ascii"))
-        # if x.hexdigest() != data["hashed_order"]:
-        #     logger.error("invalid webhook, not from opennode")
-        #     raise HTTPException(status_code=HTTPStatus.NO_CONTENT)
-
-        # await self.queue.put(charge_id)
-        # raise HTTPException(status_code=HTTPStatus.NO_CONTENT)


### PR DESCRIPTION
it was only used in lnpay, opennode and alby which all had it disabled anayways with a pretty old TODO, so i guess the feature is disabled for a y ear now and nobody used it, so i just removed it