### PR TITLE
feat: add get endpoint for user wallets

### DIFF
--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -21,14 +21,17 @@ from lnbits.wallets import get_wallet_class
 from lnbits.wallets.base import PaymentStatus
 
 
-class Wallet(BaseModel):
+class BaseWallet(BaseModel):
     id: str
     name: str
-    user: str
     adminkey: str
     inkey: str
-    currency: Optional[str]
     balance_msat: int
+
+
+class Wallet(BaseWallet):
+    user: str
+    currency: Optional[str]
     deleted: bool
     created_at: Optional[int] = None
     updated_at: Optional[int] = None

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -32,6 +32,7 @@ from lnbits.core.helpers import (
     stop_extension_background_work,
 )
 from lnbits.core.models import (
+    BaseWallet,
     ConversionData,
     CreateInvoice,
     CreateLnurl,
@@ -127,17 +128,8 @@ async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
 
 
 @api_router.get("/api/v1/wallets")
-async def api_wallets(user: User = Depends(check_user_exists)):
-    return [
-        {
-            "id": w.id,
-            "name": w.name,
-            "adminkey": w.adminkey,
-            "inkey": w.inkey,
-            "balance": w.balance_msat,
-        }
-        for w in user.wallets
-    ]
+async def api_wallets(user: User = Depends(check_user_exists)) -> List[BaseWallet]:
+    return [BaseWallet(**w.dict()) for w in user.wallets]
 
 
 @api_router.put("/api/v1/wallet/{new_name}")

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -127,8 +127,17 @@ async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
 
 
 @api_router.get("/api/v1/wallets")
-async def api_wallet(user: User = Depends(check_user_exists)):
-    return user.wallets
+async def api_wallets(user: User = Depends(check_user_exists)):
+    return [
+        {
+            "id": w.id,
+            "name": w.name,
+            "adminkey": w.adminkey,
+            "inkey": w.inkey,
+            "balance": w.balance_msat,
+        }
+        for w in user.wallets
+    ]
 
 
 @api_router.put("/api/v1/wallet/{new_name}")

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -127,7 +127,11 @@ async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
         return {"name": wallet.wallet.name, "balance": wallet.wallet.balance_msat}
 
 
-@api_router.get("/api/v1/wallets")
+@api_router.get(
+    "/api/v1/wallets",
+    name="Wallets",
+    description="Get basic info for all of user's wallets.",
+)
 async def api_wallets(user: User = Depends(check_user_exists)) -> List[BaseWallet]:
     return [BaseWallet(**w.dict()) for w in user.wallets]
 

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -51,6 +51,7 @@ from lnbits.decorators import (
     WalletTypeInfo,
     check_access_token,
     check_admin,
+    check_user_exists,
     get_key_type,
     parse_filters,
     require_admin_key,
@@ -123,6 +124,11 @@ async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
         }
     else:
         return {"name": wallet.wallet.name, "balance": wallet.wallet.balance_msat}
+
+
+@api_router.get("/api/v1/wallets")
+async def api_wallet(user: User = Depends(check_user_exists)):
+    return user.wallets
 
 
 @api_router.put("/api/v1/wallet/{new_name}")


### PR DESCRIPTION
Required while testing the APIs, but can be useful in general.

The new endpoint uses `check_user_exists` access level, so full user permissions is required to get all wallets.
