### PR TITLE
fix: check if key present in `settings` before updating

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -709,11 +709,14 @@ async def check_webpush_settings():
 
 def update_cached_settings(sets_dict: dict):
     for key, value in sets_dict.items():
-        if key not in readonly_variables:
-            try:
-                setattr(settings, key, value)
-            except Exception:
-                logger.warning(f"Failed overriding setting: {key}, value: {value}")
+        if key in readonly_variables:
+            continue
+        if key not in settings.dict().keys():
+            continue
+        try:
+            setattr(settings, key, value)
+        except Exception:
+            logger.warning(f"Failed overriding setting: {key}, value: {value}")
     if "super_user" in sets_dict:
         setattr(settings, "super_user", sets_dict["super_user"])
 


### PR DESCRIPTION
An warning message is shown in the logs when users update the settings:
```log
| WARNING | lnbits.core.services:update_cached_settings:716 | Failed overriding setting: is_super_user, value: True
```

This PR fixes the warning message.