### PR TITLE
Fix login logout on safari

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -535,9 +535,7 @@ def register_exception_handlers(app: FastAPI):
                 response = RedirectResponse("/")
                 response.delete_cookie("cookie_access_token")
                 response.delete_cookie("is_lnbits_user_authorized")
-                response.set_cookie(
-                    "is_access_token_expired", "true", samesite="none", secure=True
-                )
+                response.set_cookie("is_access_token_expired", "true")
                 return response
 
             return template_renderer().TemplateResponse(

--- a/lnbits/core/views/auth_api.py
+++ b/lnbits/core/views/auth_api.py
@@ -142,6 +142,8 @@ async def logout() -> JSONResponse:
     response.delete_cookie("cookie_access_token")
     response.delete_cookie("is_lnbits_user_authorized")
     response.delete_cookie("is_access_token_expired")
+    response.delete_cookie("lnbits_last_active_wallet")
+
     return response
 
 

--- a/lnbits/core/views/auth_api.py
+++ b/lnbits/core/views/auth_api.py
@@ -286,9 +286,7 @@ def _auth_success_response(
     )
     response = JSONResponse({"access_token": access_token, "token_type": "bearer"})
     response.set_cookie("cookie_access_token", access_token, httponly=True)
-    response.set_cookie(
-        "is_lnbits_user_authorized", "true", samesite="none", secure=True
-    )
+    response.set_cookie("is_lnbits_user_authorized", "true")
     response.delete_cookie("is_access_token_expired")
 
     return response
@@ -298,9 +296,7 @@ def _auth_redirect_response(path: str, email: str) -> RedirectResponse:
     access_token = create_access_token(data={"sub": "" or "", "email": email})
     response = RedirectResponse(path)
     response.set_cookie("cookie_access_token", access_token, httponly=True)
-    response.set_cookie(
-        "is_lnbits_user_authorized", "true", samesite="none", secure=True
-    )
+    response.set_cookie("is_lnbits_user_authorized", "true")
     response.delete_cookie("is_access_token_expired")
     return response
 

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -221,9 +221,7 @@ async def wallet(
             "web_manifest": f"/manifest/{user.id}.webmanifest",
         },
     )
-    resp.set_cookie(
-        "lnbits_last_active_wallet", wallet_id, samesite="none", secure=True
-    )
+    resp.set_cookie("lnbits_last_active_wallet", wallet_id)
     return resp
 
 


### PR DESCRIPTION
Fixes:
 - the account icon is not visible on Safari & Firefox
 - the active wallet cookie not removed after logout

Before:
![image](https://github.com/lnbits/lnbits/assets/2951406/473a26c8-a76c-431b-8aa5-830cb0f9610d)

After:
![image](https://github.com/lnbits/lnbits/assets/2951406/7225e9a0-346a-4fb7-a93d-f0d405fc60b5)
