### PR TITLE
test: fix TestModel warning

### DIFF
--- a/tests/core/test_helpers_query.py
+++ b/tests/core/test_helpers_query.py
@@ -7,12 +7,12 @@ from lnbits.helpers import (
 )
 
 
-class TestModel(BaseModel):
+class DbTestModel(BaseModel):
     id: int
     name: str
 
 
-test = TestModel(id=1, name="test")
+test = DbTestModel(id=1, name="test")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
```PytestCollectionWarning: cannot collect test class 'TestModel' because it has a __init__ constructor (from: tests/core/test_helpers_query.py)```