### PR TITLE
fix: pending property for PaymentStatus

### DIFF
--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -35,7 +35,7 @@ class PaymentStatus(NamedTuple):
 
     @property
     def pending(self) -> bool:
-        return self.paid is not True
+        return self.paid is None
 
     @property
     def failed(self) -> bool:

--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -19,9 +19,11 @@ from lnbits.settings import settings
 
 from .base import (
     InvoiceResponse,
+    PaymentFailedStatus,
     PaymentPendingStatus,
     PaymentResponse,
     PaymentStatus,
+    PaymentSuccessStatus,
     StatusResponse,
     Wallet,
 )
@@ -118,8 +120,11 @@ class FakeWallet(Wallet):
             )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
-        paid = checking_id in self.paid_invoices
-        return PaymentStatus(paid)
+        if checking_id in self.paid_invoices:
+            return PaymentSuccessStatus()
+        if checking_id in list(self.payment_secrets.keys()):
+            return PaymentPendingStatus()
+        return PaymentFailedStatus()
 
     async def get_payment_status(self, _: str) -> PaymentStatus:
         return PaymentPendingStatus()

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -127,7 +127,7 @@ class LNbitsWallet(Wallet):
             data = r.json()
             details = data.get("details", None)
 
-            if details and details.get("pending", False):
+            if details and details.get("pending", False) is True:
                 return PaymentPendingStatus()
             if data.get("paid", False) is True:
                 return PaymentSuccessStatus()

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -9,6 +9,7 @@ from lnbits.settings import settings
 
 from .base import (
     InvoiceResponse,
+    PaymentFailedStatus,
     PaymentPendingStatus,
     PaymentResponse,
     PaymentStatus,
@@ -121,9 +122,16 @@ class LNbitsWallet(Wallet):
             r = await self.client.get(
                 url=f"/api/v1/payments/{checking_id}",
             )
-            if r.is_error:
+            r.raise_for_status()
+
+            data = r.json()
+            details = data.get("details", None)
+
+            if details and details.get("pending", False):
                 return PaymentPendingStatus()
-            return PaymentStatus(r.json()["paid"])
+            if data.get("paid", False) is True:
+                return PaymentSuccessStatus()
+            return PaymentFailedStatus()
         except Exception:
             return PaymentPendingStatus()
 


### PR DESCRIPTION
A payment status is pending when the `paid` value is none.

In the old implementation if a payment was failed (`paid == False`) then the `pending` property would be `True` (which is incorrect)