### PR TITLE
Bump breez-sdk to 0.3.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -313,26 +313,36 @@ secp256k1 = "*"
 
 [[package]]
 name = "breez-sdk"
-version = "0.2.15"
+version = "0.3.6"
 description = "Python language bindings for the Breez SDK"
 optional = true
 python-versions = "*"
 files = [
-    {file = "breez_sdk-0.2.15-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:92e666b60f5fef6f0482bfe49f0d9ba606573110a6f2e0bd79d59c62c8229c11"},
-    {file = "breez_sdk-0.2.15-cp310-cp310-manylinux_2_31_aarch64.whl", hash = "sha256:5bb43f5a2cab368db6c56b383c7aba0d4403cac292b542ef4f1c39c5062ea16d"},
-    {file = "breez_sdk-0.2.15-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:f6294b3fab77cc4f8a03b1a9c8e956b2889bb94e044c76c3efd1bb1aecfdce98"},
-    {file = "breez_sdk-0.2.15-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a4e5cc31201c747e97765e7b91e8a9f47588dcdd98ca55817b8d0b3a21e358a8"},
-    {file = "breez_sdk-0.2.15-cp311-cp311-manylinux_2_31_aarch64.whl", hash = "sha256:ab1542aafe263cf594a133f6919d5865873ef16c957026294c3fa855cb34dda1"},
-    {file = "breez_sdk-0.2.15-cp311-cp311-manylinux_2_31_x86_64.whl", hash = "sha256:0fd135ad1eebd8ed50919a996f6db68b624642158d150a6d5b9b23f5eae8eab5"},
-    {file = "breez_sdk-0.2.15-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:001fbcb817013449130106dcf5401af7834ff4d2863d4f1a0e6c0202044979d8"},
-    {file = "breez_sdk-0.2.15-cp312-cp312-manylinux_2_31_aarch64.whl", hash = "sha256:0c6373454d378f2be11a23060a760a615283f0cc3f7feed8e5875dff0eac9b15"},
-    {file = "breez_sdk-0.2.15-cp312-cp312-manylinux_2_31_x86_64.whl", hash = "sha256:7e62b99ef504db8771b8338f83ddf8e7737fa473ce9cd21536ac4d287709edc2"},
-    {file = "breez_sdk-0.2.15-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:de3a88c3c209373d72afa35b716f06661a552805c0002e76da10c28cff8f0d86"},
-    {file = "breez_sdk-0.2.15-cp38-cp38-manylinux_2_31_aarch64.whl", hash = "sha256:7a283a6e80680c167cc4aa73a2f2dffaeab98444f52f49d8ce88910aee78867f"},
-    {file = "breez_sdk-0.2.15-cp38-cp38-manylinux_2_31_x86_64.whl", hash = "sha256:beebc2dd6d58efe9f6c32de14d9c6d86fd468216166e0022f0045853bb5200f1"},
-    {file = "breez_sdk-0.2.15-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:a2aadfc55cf546d5a8a964b0b99352d3193a224372ff5b924dc183d8a1c67ca3"},
-    {file = "breez_sdk-0.2.15-cp39-cp39-manylinux_2_31_aarch64.whl", hash = "sha256:67f75e8e74b818dd39b9e0070a446a4ff4d08cfafa61887787aa8a89751b0ba6"},
-    {file = "breez_sdk-0.2.15-cp39-cp39-manylinux_2_31_x86_64.whl", hash = "sha256:e399273b21861622f6e921e328305ec6e01ecf83a67f8a0ec9b665a46a62d939"},
+    {file = "breez_sdk-0.3.6-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:fda11da29ad960eacef1c797091c9b5c8159bb71327a84a6d302d27531c6a21b"},
+    {file = "breez_sdk-0.3.6-cp310-cp310-manylinux_2_31_aarch64.whl", hash = "sha256:4f0c141df239e374efe48e43557be9f5898151920444cacbc764412385b2278f"},
+    {file = "breez_sdk-0.3.6-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:d1963ff06745c12a66747957759e5c00f5af83f24e2163ef29358a401870252c"},
+    {file = "breez_sdk-0.3.6-cp310-cp310-win32.whl", hash = "sha256:19588c827428c58386cd9c2a428e8f6a118dd2dfde6d1fedc1fa3fdae337b0c4"},
+    {file = "breez_sdk-0.3.6-cp310-cp310-win_amd64.whl", hash = "sha256:4a8986cf4da49fe2dd7e441acf72f9e883b270438775e7d9cc79291c429ca311"},
+    {file = "breez_sdk-0.3.6-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:2938815e98c19bfbb51900bc55e80a7a2bc6e54e80df4197c818256506f04b37"},
+    {file = "breez_sdk-0.3.6-cp311-cp311-manylinux_2_31_aarch64.whl", hash = "sha256:336ac33b7ed1f9fc385e717f677d6ee4f6b9f8ad6d0b6620af8e4bed23d4ae19"},
+    {file = "breez_sdk-0.3.6-cp311-cp311-manylinux_2_31_x86_64.whl", hash = "sha256:cad4030e375a1f2e97b3e4b3f15cb7cb6128a5cf7700413fff25e297fdfeb555"},
+    {file = "breez_sdk-0.3.6-cp311-cp311-win32.whl", hash = "sha256:7da9ddbbea8bd00ed4eb3dae850378ac5811f629217d53b17df04f4cfa462831"},
+    {file = "breez_sdk-0.3.6-cp311-cp311-win_amd64.whl", hash = "sha256:02b39768e7f4719a6f65e907970628bce8082cd27faa3b816ee96e789a767ba7"},
+    {file = "breez_sdk-0.3.6-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:5b70b93d3f66ee04347ba0da36915514be9ddd1fc34969d0b460c2b96102f905"},
+    {file = "breez_sdk-0.3.6-cp312-cp312-manylinux_2_31_aarch64.whl", hash = "sha256:f1aae0a9ae243c800c9b1f0430b28777521fb1da54c8e5530c5071351bbf1b09"},
+    {file = "breez_sdk-0.3.6-cp312-cp312-manylinux_2_31_x86_64.whl", hash = "sha256:1e20f7cc9ccc5b6fb7172b4f76e78f41fdc869fa280127c362fd0ab34c74fbc3"},
+    {file = "breez_sdk-0.3.6-cp312-cp312-win32.whl", hash = "sha256:fac364c8db200a9516f87b05295c532c78233f05e52175abfe237b079b7f6f42"},
+    {file = "breez_sdk-0.3.6-cp312-cp312-win_amd64.whl", hash = "sha256:f0e0993e8458f1b7b372c46510bcc14f4ad21e90d0e3fccefff4f8c0dfa8f7e3"},
+    {file = "breez_sdk-0.3.6-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1cd09eb1815c7ec9e99bb9b662ae8d9bcccfb65083cfd4312634de6b60c52bd1"},
+    {file = "breez_sdk-0.3.6-cp38-cp38-manylinux_2_31_aarch64.whl", hash = "sha256:6554152eaf5bd934ba9c5222fa3f92ad6e039d9c494d531aba0ea41a70847c50"},
+    {file = "breez_sdk-0.3.6-cp38-cp38-manylinux_2_31_x86_64.whl", hash = "sha256:84d72b5e204e544e6a289feb5a8752cc67667cd90feea2c2f554a57a1d645c25"},
+    {file = "breez_sdk-0.3.6-cp38-cp38-win32.whl", hash = "sha256:50a7c6d9a98543bb7bf1055b90dc43990b8e4d8fd6e1580d6f671c0a831f41a1"},
+    {file = "breez_sdk-0.3.6-cp38-cp38-win_amd64.whl", hash = "sha256:afdc503cf1d59706139558fd3ccb984693d2191d96b8338206adf2a6f8ac16e8"},
+    {file = "breez_sdk-0.3.6-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:085456393cac9e71141d96498009f36b518b6134523a43944e3de0fbc319d7f7"},
+    {file = "breez_sdk-0.3.6-cp39-cp39-manylinux_2_31_aarch64.whl", hash = "sha256:6d5d210be5f3e2fe2bca64bed57fef5eeec939a51f65a232e01edb39eb3c9717"},
+    {file = "breez_sdk-0.3.6-cp39-cp39-manylinux_2_31_x86_64.whl", hash = "sha256:97ae91b765b6c0f8a6ecab19bd89f071b975c94f2d97bff34bdcbb8aeb77f35f"},
+    {file = "breez_sdk-0.3.6-cp39-cp39-win32.whl", hash = "sha256:73765c8139731184913c15faef0a4162db920c63e34d5086f31bcd33ff5b7c7b"},
+    {file = "breez_sdk-0.3.6-cp39-cp39-win_amd64.whl", hash = "sha256:05aa79b0a28ee843b7d17721ef8bbfb80265c037c499291554e089fd8c72e734"},
 ]
 
 [[package]]
@@ -1283,6 +1293,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2012,6 +2032,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -2019,8 +2040,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -2037,6 +2066,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -2044,6 +2074,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -2887,4 +2918,4 @@ liquid = ["wallycore"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10 | ^3.9"
-content-hash = "2d7f796c2e26728531de9a28b1388e6d6916c9409150f5a3cde6882548389f10"
+content-hash = "4b500dc6fbd2ee248425207dd05c2259aa8f47aede68f0a9640fc260b3c55f26"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ python-crontab = "3.0.0"
 # needed for liquid support boltz
 wallycore = {version = "^1.0.0", optional = true}
 # needed for breez funding source
-breez-sdk = {version = "0.2.15", optional = true}
+breez-sdk = {version = "0.3.6", optional = true}
 
 [tool.poetry.extras]
 breez = ["breez-sdk"]


### PR DESCRIPTION
Bumping the Breez SDK to v0.3.6 mainly to upgrade the VLS signer to v0.11