### PR TITLE
bug: Fix regression. Admin-users and allowed-users can now be removed through the web interface

### DIFF
--- a/lnbits/core/templates/admin/_tab_users.html
+++ b/lnbits/core/templates/admin/_tab_users.html
@@ -16,7 +16,6 @@
           <q-btn @click="addAdminUser" dense flat icon="add"></q-btn>
         </q-input>
         <div>
-          {% raw %}
           <q-chip
             v-for="user in formData.lnbits_admin_users"
             :key="user"
@@ -25,9 +24,8 @@
             color="primary"
             text-color="white"
           >
-            {{ user }}
+            <span v-text="user" />
           </q-chip>
-          {% endraw %}
         </div>
         <br />
       </div>
@@ -44,7 +42,6 @@
           <q-btn @click="addAllowedUser" dense flat icon="add"></q-btn>
         </q-input>
         <div>
-          {% raw %}
           <q-chip
             v-for="user in formData.lnbits_allowed_users"
             :key="user"
@@ -53,9 +50,8 @@
             color="primary"
             text-color="white"
           >
-            {{ user }}
+            <span v-text="user" />
           </q-chip>
-          {% endraw %}
         </div>
         <br />
         <q-item tag="label" v-ripple>

--- a/lnbits/core/templates/admin/_tab_users.html
+++ b/lnbits/core/templates/admin/_tab_users.html
@@ -16,6 +16,7 @@
           <q-btn @click="addAdminUser" dense flat icon="add"></q-btn>
         </q-input>
         <div>
+          {% raw %}
           <q-chip
             v-for="user in formData.lnbits_admin_users"
             :key="user"
@@ -23,9 +24,10 @@
             @remove="removeAdminUser(user)"
             color="primary"
             text-color="white"
-            v-text="user"
           >
+            {{ user }}
           </q-chip>
+          {% endraw %}
         </div>
         <br />
       </div>
@@ -42,6 +44,7 @@
           <q-btn @click="addAllowedUser" dense flat icon="add"></q-btn>
         </q-input>
         <div>
+          {% raw %}
           <q-chip
             v-for="user in formData.lnbits_allowed_users"
             :key="user"
@@ -49,9 +52,10 @@
             @remove="removeAllowedUser(user)"
             color="primary"
             text-color="white"
-            v-text="user"
           >
+            {{ user }}
           </q-chip>
+          {% endraw %}
         </div>
         <br />
         <q-item tag="label" v-ripple>


### PR DESCRIPTION
In the server administration, more precisely on the “Users” tab, `admin-users` and `allowed-users` cannot be removed. This was originally reported on https://github.com/lnbits/lnbits/issues/2297.

After a quick search through recent commits, the problem seems to have been created as part of a recent PR (https://github.com/lnbits/lnbits/pull/2252). 

This PR reverts some of those changes, in order for this functionality to work again.