### PR TITLE
feat: reduce initial requests on wallet page

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -71,7 +71,7 @@ from lnbits.helpers import generate_filter_params_openapi, url_for
 from lnbits.lnurl import decode as lnurl_decode
 from lnbits.settings import settings
 from lnbits.utils.exchange_rates import (
-    currencies,
+    allowed_currencies,
     fiat_amount_as_satoshis,
     satoshis_amount_as_fiat,
 )
@@ -722,14 +722,8 @@ async def api_perform_lnurlauth(
 
 
 @api_router.get("/api/v1/currencies")
-async def api_list_currencies_available():
-    if len(settings.lnbits_allowed_currencies) > 0:
-        return [
-            item
-            for item in currencies.keys()
-            if item.upper() in settings.lnbits_allowed_currencies
-        ]
-    return list(currencies.keys())
+async def api_list_currencies_available() -> List[str]:
+    return allowed_currencies()
 
 
 @api_router.post("/api/v1/conversion")

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -21,7 +21,7 @@ from lnbits.settings import settings
 from lnbits.wallets import get_wallet_class
 
 from ...extension_manager import InstallableExtension, get_valid_extensions
-from ...utils.exchange_rates import currencies
+from ...utils.exchange_rates import allowed_currencies, currencies
 from ..crud import (
     create_account,
     create_wallet,
@@ -216,6 +216,7 @@ async def wallet(
             "request": request,
             "user": user.dict(),
             "wallet": user_wallet.dict(),
+            "currencies": allowed_currencies(),
             "service_fee": settings.lnbits_service_fee,
             "service_fee_max": settings.lnbits_service_fee_max,
             "web_manifest": f"/manifest/{user.id}.webmanifest",

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -126,6 +126,7 @@ new Vue({
           camera: 'auto'
         }
       },
+      initial_fetch: true,
       payments: [],
       paymentsTable: {
         columns: [
@@ -819,7 +820,12 @@ new Vue({
   },
   watch: {
     payments: function () {
-      this.fetchBalance()
+      if (this.initial_fetch === false) {
+        this.fetchBalance()
+      } else {
+        this.initial_fetch = false
+        this.balance = Math.floor(window.wallet.balance_msat / 1000)
+      }
     },
     'paymentsChart.group': function () {
       this.showChart()
@@ -840,15 +846,7 @@ new Vue({
 
     this.update.name = this.g.wallet.name
     this.update.currency = this.g.wallet.currency
-
-    LNbits.api
-      .request('GET', '/api/v1/currencies')
-      .then(response => {
-        this.receive.units = ['sat', ...response.data]
-      })
-      .catch(err => {
-        LNbits.utils.notifyApiError(err)
-      })
+    this.receive.units = ['sat', ...window.currencies]
   },
   mounted: function () {
     // show disclaimer

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -126,7 +126,6 @@ new Vue({
           camera: 'auto'
         }
       },
-      skip_balance_check: true,
       payments: [],
       paymentsTable: {
         columns: [
@@ -819,13 +818,8 @@ new Vue({
     }
   },
   watch: {
-    payments: function (newVal, oldVal) {
-      console.log('payments', newVal)
-      console.log('oldVal', oldVal)
-      if (this.skip_balance_check === true) {
-        this.skip_balance_check = false
-        this.balance = Math.floor(window.wallet.balance_msat / 1000)
-      } else {
+    payments: function (_, oldVal) {
+      if (oldVal && oldVal.length !== 0) {
         this.fetchBalance()
       }
     },
@@ -845,6 +839,7 @@ new Vue({
       this.mobileSimple = true
     }
     this.fetchPayments()
+    this.balance = Math.floor(window.wallet.balance_msat / 1000)
 
     this.update.name = this.g.wallet.name
     this.update.currency = this.g.wallet.currency

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -126,7 +126,7 @@ new Vue({
           camera: 'auto'
         }
       },
-      initial_fetch: true,
+      skip_balance_check: true,
       payments: [],
       paymentsTable: {
         columns: [
@@ -819,12 +819,14 @@ new Vue({
     }
   },
   watch: {
-    payments: function () {
-      if (this.initial_fetch === false) {
-        this.fetchBalance()
-      } else {
-        this.initial_fetch = false
+    payments: function (newVal, oldVal) {
+      console.log('payments', newVal)
+      console.log('oldVal', oldVal)
+      if (this.skip_balance_check === true) {
+        this.skip_balance_check = false
         this.balance = Math.floor(window.wallet.balance_msat / 1000)
+      } else {
+        this.fetchBalance()
       }
     },
     'paymentsChart.group': function () {

--- a/lnbits/templates/macros.jinja
+++ b/lnbits/templates/macros.jinja
@@ -1,6 +1,9 @@
 {% macro window_vars(user, wallet) -%}
   <script>
     window.extensions = {{ EXTENSIONS | tojson | safe }};
+    {% if currencies %}
+      window.currencies = {{ currencies | tojson | safe }};
+    {% endif %}
     {% if user %}
       window.user = {{ user | tojson | safe }};
     {% endif %}

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -176,6 +176,16 @@ currencies = {
 }
 
 
+def allowed_currencies():
+    if len(settings.lnbits_allowed_currencies) > 0:
+        return [
+            item
+            for item in currencies.keys()
+            if item.upper() in settings.lnbits_allowed_currencies
+        ]
+    return list(currencies.keys())
+
+
 class Provider(NamedTuple):
     name: str
     domain: str


### PR DESCRIPTION
- refactor allowed_currencies into function to use in generic and api.
- remove currencies request in frontend move it to generic
- dont request balance on first payments fetch