### PR TITLE
refactor: tiny url to use require decorators and `wallet.id`

### DIFF
--- a/lnbits/core/views/tinyurl_api.py
+++ b/lnbits/core/views/tinyurl_api.py
@@ -9,7 +9,8 @@ from starlette.responses import RedirectResponse
 
 from lnbits.decorators import (
     WalletTypeInfo,
-    get_key_type,
+    require_admin_key,
+    require_invoice_key,
 )
 
 from ..crud import (
@@ -28,15 +29,15 @@ tinyurl_router = APIRouter()
     description="creates a tinyurl",
 )
 async def api_create_tinyurl(
-    url: str, endless: bool = False, wallet: WalletTypeInfo = Depends(get_key_type)
+    url: str, endless: bool = False, wallet: WalletTypeInfo = Depends(require_admin_key)
 ):
     tinyurls = await get_tinyurl_by_url(url)
     try:
         for tinyurl in tinyurls:
             if tinyurl:
-                if tinyurl.wallet == wallet.wallet.inkey:
+                if tinyurl.wallet == wallet.wallet.id:
                     return tinyurl
-        return await create_tinyurl(url, endless, wallet.wallet.inkey)
+        return await create_tinyurl(url, endless, wallet.wallet.id)
     except Exception:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST, detail="Unable to create tinyurl"
@@ -49,12 +50,12 @@ async def api_create_tinyurl(
     description="get a tinyurl by id",
 )
 async def api_get_tinyurl(
-    tinyurl_id: str, wallet: WalletTypeInfo = Depends(get_key_type)
+    tinyurl_id: str, wallet: WalletTypeInfo = Depends(require_invoice_key)
 ):
     try:
         tinyurl = await get_tinyurl(tinyurl_id)
         if tinyurl:
-            if tinyurl.wallet == wallet.wallet.inkey:
+            if tinyurl.wallet == wallet.wallet.id:
                 return tinyurl
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN, detail="Wrong key provided."
@@ -71,12 +72,12 @@ async def api_get_tinyurl(
     description="delete a tinyurl by id",
 )
 async def api_delete_tinyurl(
-    tinyurl_id: str, wallet: WalletTypeInfo = Depends(get_key_type)
+    tinyurl_id: str, wallet: WalletTypeInfo = Depends(require_admin_key)
 ):
     try:
         tinyurl = await get_tinyurl(tinyurl_id)
         if tinyurl:
-            if tinyurl.wallet == wallet.wallet.inkey:
+            if tinyurl.wallet == wallet.wallet.id:
                 await delete_tinyurl(tinyurl_id)
                 return {"deleted": True}
         raise HTTPException(


### PR DESCRIPTION
- also use `wallet.wallet.id` as key instead of `wallet.wallet.inkey`