### PR TITLE
chore: remove CACHE_VERSION from service-worker.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ bak:
 sass:
 	npm run sass
 
-bundle_no_bump:
+bundle:
 	npm install
 	npm run sass
 	npm run vendor_copy
@@ -97,16 +97,10 @@ bundle_no_bump:
 	npm run vendor_bundle_js
 	npm run vendor_minify_js
 
-bundle:
-	make bundle_no_bump
-	# increment serviceworker version
-	awk '/CACHE_VERSION =/ {sub(/[0-9]+$$/, $$NF+1)} 1' lnbits/static/js/service-worker.js > lnbits/static/js/service-worker.js.new
-	mv lnbits/static/js/service-worker.js.new lnbits/static/js/service-worker.js
-
 checkbundle:
 	cp lnbits/static/bundle.min.js lnbits/static/bundle.min.js.old
 	cp lnbits/static/bundle.min.css lnbits/static/bundle.min.css.old
-	make bundle_no_bump
+	make bundle
 	diff -q lnbits/static/bundle.min.js lnbits/static/bundle.min.js.old || exit 1
 	diff -q lnbits/static/bundle.min.css lnbits/static/bundle.min.css.old || exit 1
 	@echo "Bundle is OK"

--- a/lnbits/core/templates/service-worker.js
+++ b/lnbits/core/templates/service-worker.js
@@ -1,7 +1,6 @@
 // update cache version every time there is a new deployment
 // so the service worker reinitializes the cache
-const CACHE_VERSION = 123
-const CURRENT_CACHE = `lnbits-${CACHE_VERSION}-`
+const CURRENT_CACHE = 'lnbits-{{ cache_version }}-'
 
 const getApiKey = request => {
   let api_key = request.headers.get('X-Api-Key')
@@ -17,8 +16,7 @@ self.addEventListener('activate', evt =>
     caches.keys().then(cacheNames => {
       return Promise.all(
         cacheNames.map(cacheName => {
-          const currentCacheVersion = cacheName.split('-').slice(-2, 2)
-          if (currentCacheVersion !== CACHE_VERSION) {
+          if (!cacheName.startsWith(CURRENT_CACHE)) {
             return caches.delete(cacheName)
           }
         })

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -352,9 +352,16 @@ async def lnurlwallet(request: Request):
     )
 
 
-@generic_router.get("/service-worker.js", response_class=FileResponse)
-async def service_worker():
-    return FileResponse(Path("lnbits", "static", "js", "service-worker.js"))
+@generic_router.get("/service-worker.js")
+async def service_worker(request: Request):
+    return template_renderer().TemplateResponse(
+        "service-worker.js",
+        {
+            "request": request,
+            "cache_version": settings.server_startup_time,
+        },
+        media_type="text/javascript",
+    )
 
 
 @generic_router.get("/manifest/{usr}.webmanifest")


### PR DESCRIPTION
use server_startup_time as the version
(the same trick we use for static files)

I have no idea how to test this, so please do test!