### PR TITLE
hotfix: initial currency conversion on balance

### DIFF
--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -818,10 +818,8 @@ new Vue({
     }
   },
   watch: {
-    payments: function (_, oldVal) {
-      if (oldVal && oldVal.length !== 0) {
-        this.fetchBalance()
-      }
+    payments: function () {
+      this.fetchBalance()
     },
     'paymentsChart.group': function () {
       this.showChart()

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -837,7 +837,6 @@ new Vue({
       this.mobileSimple = true
     }
     this.fetchPayments()
-    this.balance = Math.floor(window.wallet.balance_msat / 1000)
 
     this.update.name = this.g.wallet.name
     this.update.currency = this.g.wallet.currency


### PR DESCRIPTION
fiat amount not shown in balance on initial pageload, lets reintroduce the first fetch_balance to fix it.

maybe in the future balance call and wallet itself should give the current fiat value if the wallet uses fiat tracking so you dont need the extra conversion call