### PR TITLE
perf: cln faster init

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -26,7 +26,7 @@ from starlette.responses import JSONResponse
 from lnbits.core.crud import (
     get_dbversions,
     get_installed_extensions,
-    get_last_incomming_payment,
+    get_last_incoming_payment,
 )
 from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.services import websocketUpdater
@@ -461,7 +461,7 @@ def log_server_info():
 
 async def init_latest_payment_hash():
     try:
-        last_payment = await get_last_incomming_payment()
+        last_payment = await get_last_incoming_payment()
         if last_payment:
             settings.last_payment_hash_on_start = last_payment.checking_id
     except Exception as e:

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -466,7 +466,7 @@ async def init_latest_payment_hash():
             settings.last_payment_hash_on_start = last_payment.checking_id
     except Exception as e:
         logger.error(str(e))
-        raise ImportError("Failed to fetch latest incomming payment.")
+        raise ImportError("Failed to fetch latest incoming payment.")
 
 
 def get_db_vendor_name():

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -645,7 +645,6 @@ async def get_wallet_payment(
 async def get_last_incoming_payment(
     conn: Optional[Connection] = None,
 ) -> Optional[Payment]:
-    # todo: check SQLite time
     row = await (conn or db).fetchone(
         """
         SELECT *

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -642,6 +642,24 @@ async def get_wallet_payment(
     return Payment.from_row(row) if row else None
 
 
+async def get_last_incomming_payment(
+    conn: Optional[Connection] = None,
+) -> Optional[Payment]:
+    # todo: check SQLite time
+    row = await (conn or db).fetchone(
+        """
+        SELECT *
+        FROM apipayments
+        WHERE amount > 0
+        ORDER BY time DESC
+        LIMIT 1
+        """,
+        (),
+    )
+
+    return Payment.from_row(row) if row else None
+
+
 async def get_latest_payments_by_extension(ext_name: str, ext_id: str, limit: int = 5):
     rows = await db.fetchall(
         f"""

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -642,7 +642,7 @@ async def get_wallet_payment(
     return Payment.from_row(row) if row else None
 
 
-async def get_last_incomming_payment(
+async def get_last_incoming_payment(
     conn: Optional[Connection] = None,
 ) -> Optional[Payment]:
     # todo: check SQLite time

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -424,7 +424,7 @@ class TransientSettings(InstalledExtensionsSettings):
 
     # the last payment hash found at the server init time
     # helps the funding sources know where they left off
-    last_payment_hash_on_start: Optional[str] = ""
+    last_payment_hash_on_start: Optional[str] = None
 
     @classmethod
     def readonly_fields(cls):

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -422,6 +422,10 @@ class TransientSettings(InstalledExtensionsSettings):
     #  - are cleared on server restart
     first_install: bool = Field(default=False)
 
+    # the last payment hash found at the server init time
+    # helps the funding sources know where they left off
+    last_payment_hash_on_start: Optional[str] = ""
+
     @classmethod
     def readonly_fields(cls):
         return [f for f in inspect.signature(cls).parameters if not f.startswith("_")]

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -45,11 +45,13 @@ class CoreLightningWallet(Wallet):
 
         # check last payindex so we can listen from that point on
         self.last_pay_index = 0
-        invoices: dict = self.ln.listinvoices()  # type: ignore
-        for inv in invoices["invoices"][::-1]:
-            if "pay_index" in inv:
-                self.last_pay_index = inv["pay_index"]
-                break
+
+        ########### Performance issue
+        # invoices: dict = self.ln.listinvoices()  # type: ignore
+        # for inv in invoices["invoices"][::-1]:
+        #     if "pay_index" in inv:
+        #         self.last_pay_index = inv["pay_index"]
+        #         break
 
     async def status(self) -> StatusResponse:
         try:

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -49,7 +49,7 @@ class CoreLightningWallet(Wallet):
         payment_hash = settings.last_payment_hash_on_start
         data: dict = self.ln.listinvoices(payment_hash=payment_hash)  # type: ignore
         if len(data["invoices"]) == 0:
-            logger.warning("Last payment hash was not fund on the funding source.")
+            logger.warning("Last payment hash was not found on the Core Lightning Node.")
             logger.warning("Listing all invoices, this might take serveral minutes.")
 
             data = self.ln.listinvoices()  # type: ignore

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -50,7 +50,7 @@ class CoreLightningWallet(Wallet):
         data: dict = self.ln.listinvoices(payment_hash=payment_hash)  # type: ignore
         if len(data["invoices"]) == 0:
             logger.warning("Last payment hash was not found on the Core Lightning Node.")
-            logger.warning("Listing all invoices, this might take serveral minutes.")
+            logger.warning("Listing all invoices, this can take some minutes...")
 
             data = self.ln.listinvoices()  # type: ignore
         for inv in data["invoices"][::-1]:

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -49,7 +49,9 @@ class CoreLightningWallet(Wallet):
         payment_hash = settings.last_payment_hash_on_start
         data: dict = self.ln.listinvoices(payment_hash=payment_hash)  # type: ignore
         if len(data["invoices"]) == 0:
-            logger.warning("Last payment hash was not found on the Core Lightning Node.")
+            logger.warning(
+                "Last payment hash was not found on the Core Lightning Node."
+            )
             logger.warning("Listing all invoices, this can take some minutes...")
 
             data = self.ln.listinvoices()  # type: ignore


### PR DESCRIPTION
The call`data = self.ln.listinvoices()` lists all invoices on the CLN node. This takes ~10min on a big node like legend.

The solution is to fetch the last created invoice from the DB and call `listinvoices` for that respective hash (which should be much faster)
