### PR TITLE
chore: update to node 20.x on workflows

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: "1.7.0"
   node-version:
     description: "Node Version"
-    default: "18.x"
+    default: "20.x"
   npm:
     description: "use npm"
     default: false

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         # cache poetry install via pip

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -38,7 +38,7 @@ runs:
         poetry config virtualenvs.create true --local
         poetry config virtualenvs.in-project true --local
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: Define a cache for the virtual environment based on the dependencies lock file
       with:
         path: ./.venv

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -50,11 +50,11 @@ runs:
 
     - name: Use Node.js ${{ inputs.node-version }}
       if: ${{ (inputs.npm == 'true') }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: ${{ (inputs.npm == 'true') }}
       name: Define a cache for the npm based on the dependencies lock file
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       python-version: ${{ matrix.python-version }}
-      codecov-token: "${{ secrets.CODECOV_TOKEN }}"
+      codecov-token: secrets.CODECOV_TOKEN
 
   migrations:
     needs: [ lint ]
@@ -32,7 +32,7 @@ jobs:
     with:
       make: test-migration
       db-name: migration
-      codecov-token: "${{ secrets.CODECOV_TOKEN }}"
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   openapi:
     needs: [ lint ]
@@ -50,7 +50,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
-      codecov-token: "${{ secrets.CODECOV_TOKEN }}"
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   jmeter:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       python-version: ${{ matrix.python-version }}
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      codecov-token: "${{ secrets.CODECOV_TOKEN }}"
 
   migrations:
     needs: [ lint ]
@@ -32,7 +32,7 @@ jobs:
     with:
       make: test-migration
       db-name: migration
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      codecov-token: "${{ secrets.CODECOV_TOKEN }}"
 
   openapi:
     needs: [ lint ]
@@ -50,7 +50,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      codecov-token: "${{ secrets.CODECOV_TOKEN }}"
 
   jmeter:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     with:
       make: test-migration
       db-name: migration
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      codecov-token: secrets.CODECOV_TOKEN
 
   openapi:
     needs: [ lint ]
@@ -50,7 +50,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      codecov-token: secrets.CODECOV_TOKEN
 
   jmeter:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       python-version: ${{ matrix.python-version }}
-      codecov-token: secrets.CODECOV_TOKEN
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   migrations:
     needs: [ lint ]
@@ -32,7 +32,7 @@ jobs:
     with:
       make: test-migration
       db-name: migration
-      codecov-token: secrets.CODECOV_TOKEN
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   openapi:
     needs: [ lint ]
@@ -50,7 +50,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
-      codecov-token: secrets.CODECOV_TOKEN
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   jmeter:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       python-version: ${{ matrix.python-version }}
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   migrations:
     needs: [ lint ]
@@ -31,6 +32,7 @@ jobs:
     with:
       make: test-migration
       db-name: migration
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   openapi:
     needs: [ lint ]
@@ -48,6 +50,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   jmeter:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/tests.yml
     with:
       python-version: ${{ matrix.python-version }}
+    secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   migrations:
@@ -32,6 +33,7 @@ jobs:
     with:
       make: test-migration
       db-name: migration
+    secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   openapi:
@@ -50,6 +52,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
+    secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   jmeter:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       python-version: ${{ matrix.python-version }}
     secrets:
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   migrations:
     needs: [ lint ]
@@ -34,7 +34,7 @@ jobs:
       make: test-migration
       db-name: migration
     secrets:
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   openapi:
     needs: [ lint ]
@@ -53,7 +53,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
       backend-wallet-class: ${{ matrix.backend-wallet-class }}
     secrets:
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   jmeter:
     strategy:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - run: git checkout HEAD^2

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -18,7 +18,7 @@ jobs:
   action_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
@@ -88,7 +88,7 @@ jobs:
           done
 
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: jmeter-test-results

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Python ${{ inputs.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
           cache: "pip"
@@ -95,4 +95,3 @@ jobs:
           path: |
             reports/
             logs/
-

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: ["18.x"]
     runs-on: ${{ matrix.os-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
     secrets:
-      codecov-token:
+      CODECOV_TOKEN:
         required: true
 
 jobs:
@@ -81,5 +81,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: ${{ secrets.codecov-token }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -15,6 +15,9 @@ on:
       backend-wallet-class:
         required: true
         type: string
+      codecov-token:
+        required: true
+        type: string
 
 jobs:
   regtest:
@@ -78,5 +81,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ input.codecov_token }}
+          verbose: true

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -81,5 +81,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: ${{ input.codecov-token }}
+          token: input.codecov-token
           verbose: true

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ inputs.os-version }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         if: ${{ inputs.backend-wallet-class == 'LNbitsWallet' }}

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -75,7 +75,7 @@ jobs:
         run: make test-real-wallet
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -81,5 +81,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: ${{ input.codecov_token }}
+          token: ${{ input.codecov-token }}
           verbose: true

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -25,11 +25,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: ${{ inputs.backend-wallet-class == 'LNbitsWallet' }}
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         if: ${{ inputs.backend-wallet-class == 'LNbitsWallet' }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
             context: .
             push: false
@@ -77,5 +77,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -15,9 +15,9 @@ on:
       backend-wallet-class:
         required: true
         type: string
+    secrets:
       codecov-token:
         required: true
-        type: string
 
 jobs:
   regtest:
@@ -81,5 +81,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: ${{ inputs.codecov-token }}
+          token: ${{ secrets.codecov-token }}
           verbose: true

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -81,5 +81,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: input.codecov-token
+          token: ${{ inputs.codecov-token }}
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create github release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,9 @@ on:
       db-name:
         default: "lnbits"
         type: string
+      codecov-token:
+        required: true
+        type: string
 
 jobs:
   tests:
@@ -55,5 +58,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ input.codecov_token }}
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,9 @@ on:
       db-name:
         default: "lnbits"
         type: string
+    secrets:
       codecov-token:
         required: true
-        type: string
 
 jobs:
   tests:
@@ -58,5 +58,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: ${{ inputs.codecov-token }}
+          token: ${{ secrets.codecov-token }}
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,5 +54,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,5 +58,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: input.codecov-token
+          token: ${{ inputs.codecov-token }}
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ on:
         default: "lnbits"
         type: string
     secrets:
-      codecov-token:
+      CODECOV_TOKEN:
         required: true
 
 jobs:
@@ -58,5 +58,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: ${{ secrets.codecov-token }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ./.github/actions/prepare
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         run: make ${{ inputs.make }}
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,5 +58,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: ${{ input.codecov_token }}
+          token: ${{ input.codecov-token }}
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,5 +58,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
-          token: ${{ input.codecov-token }}
+          token: input.codecov-token
           verbose: true


### PR DESCRIPTION
gets rid of deprecating warnings in actions.

![screenshot-1711452714](https://github.com/lnbits/lnbits/assets/1743657/e9e69a45-751c-47e6-935e-e6e7e1e41ea3)
