### PR TITLE
bug: releasing docker image had invalid credentials

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,11 @@ on:
       tag:
         default: latest
         type: string
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
 
 jobs:
   push_to_dockerhub:
@@ -43,16 +48,6 @@ jobs:
             context: .
             push: true
             tags: ${{ secrets.DOCKER_USERNAME }}/lnbits:${{ inputs.tag }}
-            platforms: linux/amd64,linux/arm64
-            cache-from: type=local,src=/tmp/.buildx-cache
-            cache-to: type=local,dest=/tmp/.buildx-cache
-
-      - name: Build and push latest tag
-        uses: docker/build-push-action@v5
-        with:
-            context: .
-            push: true
-            tags: ${{ secrets.DOCKER_USERNAME }}/lnbits:latest
             platforms: linux/amd64,linux/arm64
             cache-from: type=local,src=/tmp/.buildx-cache
             cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,6 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       tag: ${{ github.ref_name }}
+    secrets:
+      username: ${{ secrets.DOCKER_USERNAME }}
+      password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,5 +27,5 @@ jobs:
     with:
       tag: ${{ github.ref_name }}
     secrets:
-      username: ${{ secrets.DOCKER_USERNAME }}
-      password: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
closes #2345

also removed the duplicate dockerhub upload for latest. that was kinda dump (i introduced it), because you could also manually tag a special release which would than always push to latest tag aswell which makes no sense.