### PR TITLE
test: remove warnings for `TemplateResponse`

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -497,7 +497,7 @@ def register_exception_handlers(app: FastAPI):
             and "text/html" in request.headers["accept"]
         ):
             return template_renderer().TemplateResponse(
-                "error.html", {"request": request, "err": f"Error: {str(exc)}"}
+                request, "error.html", {"err": f"Error: {str(exc)}"}
             )
 
         return JSONResponse(
@@ -519,8 +519,9 @@ def register_exception_handlers(app: FastAPI):
             and "text/html" in request.headers["accept"]
         ):
             return template_renderer().TemplateResponse(
+                request,
                 "error.html",
-                {"request": request, "err": f"Error: {str(exc)}"},
+                {"err": f"Error: {str(exc)}"},
             )
 
         return JSONResponse(
@@ -547,6 +548,7 @@ def register_exception_handlers(app: FastAPI):
                 return response
 
             return template_renderer().TemplateResponse(
+                request,
                 "error.html",
                 {
                     "request": request,

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -49,7 +49,7 @@ async def favicon():
 @generic_router.get("/", response_class=HTMLResponse)
 async def home(request: Request, lightning: str = ""):
     return template_renderer().TemplateResponse(
-        "core/index.html", {"request": request, "lnurl": lightning}
+        request, "core/index.html", {"lnurl": lightning}
     )
 
 
@@ -57,15 +57,15 @@ async def home(request: Request, lightning: str = ""):
 async def first_install(request: Request):
     if not settings.first_install:
         return template_renderer().TemplateResponse(
+            request,
             "error.html",
             {
-                "request": request,
                 "err": "Super user account has already been configured.",
             },
         )
     return template_renderer().TemplateResponse(
+        request,
         "core/first_install.html",
-        {"request": request},
     )
 
 
@@ -170,9 +170,9 @@ async def extensions_install(
         user = await get_user(user.id) or user
 
         return template_renderer().TemplateResponse(
+            request,
             "core/extensions.html",
             {
-                "request": request,
                 "user": user.dict(),
                 "extensions": extensions,
             },
@@ -207,13 +207,13 @@ async def wallet(
     user_wallet = user.get_wallet(wallet_id)
     if not user_wallet or user_wallet.deleted:
         return template_renderer().TemplateResponse(
-            "error.html", {"request": request, "err": "Wallet not found"}
+            request, "error.html", {"err": "Wallet not found"}
         )
 
     resp = template_renderer().TemplateResponse(
+        request,
         "core/wallet.html",
         {
-            "request": request,
             "user": user.dict(),
             "wallet": user_wallet.dict(),
             "currencies": allowed_currencies(),
@@ -236,9 +236,9 @@ async def account(
     user: User = Depends(check_user_exists),
 ):
     return template_renderer().TemplateResponse(
+        request,
         "core/account.html",
         {
-            "request": request,
             "user": user.dict(),
         },
     )
@@ -356,9 +356,9 @@ async def lnurlwallet(request: Request):
 @generic_router.get("/service-worker.js")
 async def service_worker(request: Request):
     return template_renderer().TemplateResponse(
+        request,
         "service-worker.js",
         {
-            "request": request,
             "cache_version": settings.server_startup_time,
         },
         media_type="text/javascript",
@@ -457,9 +457,9 @@ async def node(request: Request, user: User = Depends(check_admin)):
     _, balance = await WALLET.status()
 
     return template_renderer().TemplateResponse(
+        request,
         "node/index.html",
         {
-            "request": request,
             "user": user.dict(),
             "settings": settings.dict(),
             "balance": balance,
@@ -477,9 +477,9 @@ async def node_public(request: Request):
     _, balance = await WALLET.status()
 
     return template_renderer().TemplateResponse(
+        request,
         "node/public.html",
         {
-            "request": request,
             "settings": settings.dict(),
             "balance": balance,
         },
@@ -495,9 +495,9 @@ async def index(request: Request, user: User = Depends(check_admin)):
     _, balance = await WALLET.status()
 
     return template_renderer().TemplateResponse(
+        request,
         "admin/index.html",
         {
-            "request": request,
             "user": user.dict(),
             "settings": settings.dict(),
             "balance": balance,

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -79,6 +79,7 @@ class InstalledExtensionMiddleware:
         )
 
         if "text/html" in [a for a in accept_header.split(",")]:
+            # TODO: figure that out where is `request` here?
             return HTMLResponse(
                 status_code=status_code,
                 content=template_renderer()

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -35,7 +35,7 @@ class InstalledExtensionMiddleware:
         # block path for all users if the extension is disabled
         if top_path in settings.lnbits_deactivated_extensions:
             response = self._response_by_accepted_type(
-                headers, f"Extension '{top_path}' disabled", HTTPStatus.NOT_FOUND
+                scope, headers, f"Extension '{top_path}' disabled", HTTPStatus.NOT_FOUND
             )
             await response(scope, receive, send)
             return
@@ -61,7 +61,7 @@ class InstalledExtensionMiddleware:
         await self.app(scope, receive, send)
 
     def _response_by_accepted_type(
-        self, headers: List[Any], msg: str, status_code: HTTPStatus
+        self, scope: Scope, headers: List[Any], msg: str, status_code: HTTPStatus
     ) -> Union[HTMLResponse, JSONResponse]:
         """
         Build an HTTP response containing the `msg` as HTTP body and the `status_code`
@@ -79,11 +79,10 @@ class InstalledExtensionMiddleware:
         )
 
         if "text/html" in [a for a in accept_header.split(",")]:
-            # TODO: figure that out where is `request` here?
             return HTMLResponse(
                 status_code=status_code,
                 content=template_renderer()
-                .TemplateResponse("error.html", {"request": {}, "err": msg})
+                .TemplateResponse(Request(scope), "error.html", {"err": msg})
                 .body,
             )
 


### PR DESCRIPTION
removes warnings
```
tests/core/views/test_generic.py::test_core_views_generic
tests/core/views/test_generic.py::test_get_wallet_with_user_and_wallet
tests/core/views/test_generic.py::test_get_extensions
tests/core/views/test_public_api.py::test_core_views_generic
  /home/dni/.cache/pypoetry/virtualenvs/lnbits-XeqO4Z-j-py3.10/lib/python3.10/site-packages/starlette/templating.py:178: DeprecationWarning: The `name` is not the first para
meter anymore. The first parameter should be the `Request` instance.
  Replace `TemplateResponse(name, {"request": request})` by `TemplateResponse(request, name)`.
    warnings.warn(
```