### PR TITLE
fix: fastapi status import

### DIFF
--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import (
     List,
     Optional,
@@ -8,9 +9,6 @@ from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
-)
-from fastapi import (
-    status as HTTPStatus,
 )
 from loguru import logger
 


### PR DESCRIPTION
should use `from http import HTTPStatus`