### PR TITLE
feat: add PEP561 marker for types

### DIFF
--- a/lnbits/py.typed
+++ b/lnbits/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561


### PR DESCRIPTION
tasks.py:8: error: Skipping analyzing "lnbits.tasks": module is installed, but missing library stubs or py.typed marker [import-untyped]

https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports