### PR TITLE
refactor: split GET payments endpoint into public and private

### DIFF
--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -415,7 +415,7 @@ async def api_public_payment(payment_hash: str):
 
 @payment_router.get("/{payment_hash}")
 async def api_payment(
-    payment_hash: str, key_type: WalletTypeInfo = Depends(require_admin_key)
+    payment_hash: str, key_type: WalletTypeInfo = Depends(require_invoice_key)
 ):
     wallet_id = key_type.wallet.id
     payment = await get_standalone_payment(payment_hash, wallet_id=wallet_id)


### PR DESCRIPTION
also why do we check the status of the payment directly there twice, once through `check_transaction_status` and once through `fundingsource.check_status()` and should not do that on get? it probably was a safety mechanism, but it bit us already in the past.

its also our most spammed endpoint on legend, it should not be that expernsive to run!