### PR TITLE
typo in phoenixd ws

### DIFF
--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -216,7 +216,7 @@ class PhoenixdWallet(Wallet):
                     while settings.lnbits_running:
                         message = await ws.recv()
                         message_json = json.loads(message)
-                        if message_json and message_json["type"] == "payment-received":
+                        if message_json and message_json["type"] == "payment_received":
                             logger.info(
                                 f'payment-received: {message_json["paymentHash"]}'
                             )

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -216,7 +216,7 @@ class PhoenixdWallet(Wallet):
                     while settings.lnbits_running:
                         message = await ws.recv()
                         message_json = json.loads(message)
-                        if message_json and message_json["type"] == "payment_received":
+                        if message_json and message_json.get("type") == "payment_received":
                             logger.info(
                                 f'payment-received: {message_json["paymentHash"]}'
                             )

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -216,7 +216,10 @@ class PhoenixdWallet(Wallet):
                     while settings.lnbits_running:
                         message = await ws.recv()
                         message_json = json.loads(message)
-                        if message_json and message_json.get("type") == "payment_received":
+                        if (
+                            message_json
+                            and message_json.get("type") == "payment_received"
+                        ):
                             logger.info(
                                 f'payment-received: {message_json["paymentHash"]}'
                             )


### PR DESCRIPTION
There's a typo in phoenixd wallet's stream.

According to docs, is `payment_received` instead of `payment-received`

https://phoenix.acinq.co/server/api#payments-websocket 