### PR TITLE
fix: pay invoice status

### DIFF
--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -80,3 +80,8 @@ jobs:
           file: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+
+      - name: docker lnbits logs
+        if: ${{ inputs.backend-wallet-class == 'LNbitsWallet' }}
+        run: |
+          docker logs lnbits-lnbits-1

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -38,8 +38,6 @@ jobs:
             context: .
             push: false
             tags: lnbits/lnbits:latest
-            cache-from: type=registry,ref=lnbits/lnbits:latest
-            cache-to: type=inline
 
       - name: Setup Regtest
         run: |

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: docker build
+        if: ${{ inputs.backend-wallet-class == 'LNbitsWallet' }}
         run: |
           docker build -t lnbits/lnbits .
 

--- a/.github/workflows/regtest.yml
+++ b/.github/workflows/regtest.yml
@@ -27,17 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        if: ${{ inputs.backend-wallet-class == 'LNbitsWallet' }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        if: ${{ inputs.backend-wallet-class == 'LNbitsWallet' }}
-        uses: docker/build-push-action@v5
-        with:
-            context: .
-            push: false
-            tags: lnbits/lnbits:latest
+      - name: docker build
+        run: |
+          docker build -t lnbits/lnbits .
 
       - name: Setup Regtest
         run: |

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -348,6 +348,7 @@ async def pay_invoice(
             )
 
         logger.debug(f"backend: pay_invoice finished {temp_id}")
+        logger.debug(f"backend: pay_invoice response {payment}")
         if payment.checking_id and payment.ok is not False:
             # payment.ok can be True (paid) or None (pending)!
             logger.debug(f"updating payment {temp_id}")

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -249,7 +249,7 @@ async def pay_invoice(
         # we check if an internal invoice exists that has already been paid
         # (not pending anymore)
         if not await check_internal_pending(invoice.payment_hash, conn=conn):
-            raise PaymentError("Internal invoice already paid.", status="paid")
+            raise PaymentError("Internal invoice already paid.", status="failed")
 
         # check_internal() returns the checking_id of the invoice we're waiting for
         # (pending only)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -63,11 +63,15 @@ from .models import Payment, UserConfig, Wallet
 
 
 class PaymentError(Exception):
-    pass
+    def __init__(self, message: str, status: str = "pending"):
+        self.message = message
+        self.status = status
 
 
 class InvoiceError(Exception):
-    pass
+    def __init__(self, message: str, status: str = "pending"):
+        self.message = message
+        self.status = status
 
 
 async def calculate_fiat_amounts(
@@ -123,11 +127,11 @@ async def create_invoice(
     conn: Optional[Connection] = None,
 ) -> Tuple[str, str]:
     if not amount > 0:
-        raise InvoiceError("Amountless invoices not supported.")
+        raise InvoiceError("Amountless invoices not supported.", status="failed")
 
     user_wallet = await get_wallet(wallet_id, conn=conn)
     if not user_wallet:
-        raise InvoiceError(f"Could not fetch wallet '{wallet_id}'.")
+        raise InvoiceError(f"Could not fetch wallet '{wallet_id}'.", status="failed")
 
     invoice_memo = None if description_hash else memo
 
@@ -142,8 +146,9 @@ async def create_invoice(
         user_wallet.balance_msat / 1000 + amount_sat
     ):
         raise InvoiceError(
-            f"Wallet balance  cannot exceed "
-            f"{settings.lnbits_wallet_limit_max_balance} sats."
+            f"Wallet balance cannot exceed "
+            f"{settings.lnbits_wallet_limit_max_balance} sats.",
+            status="failed",
         )
 
     (
@@ -159,7 +164,9 @@ async def create_invoice(
         expiry=expiry or settings.lightning_invoice_expiry,
     )
     if not ok or not payment_request or not checking_id:
-        raise InvoiceError(error_message or "unexpected backend error.")
+        raise InvoiceError(
+            error_message or "unexpected backend error.", status="pending"
+        )
 
     invoice = bolt11_decode(payment_request)
 
@@ -202,12 +209,12 @@ async def pay_invoice(
     try:
         invoice = bolt11_decode(payment_request)
     except Exception as exc:
-        raise InvoiceError("Bolt11 decoding failed.") from exc
+        raise PaymentError("Bolt11 decoding failed.", status="failed") from exc
 
     if not invoice.amount_msat or not invoice.amount_msat > 0:
-        raise InvoiceError("Amountless invoices not supported.")
+        raise PaymentError("Amountless invoices not supported.", status="failed")
     if max_sat and invoice.amount_msat > max_sat * 1000:
-        raise InvoiceError("Amount in invoice is too high.")
+        raise PaymentError("Amount in invoice is too high.", status="failed")
 
     await check_wallet_limits(wallet_id, conn, invoice.amount_msat)
 
@@ -242,7 +249,7 @@ async def pay_invoice(
         # we check if an internal invoice exists that has already been paid
         # (not pending anymore)
         if not await check_internal_pending(invoice.payment_hash, conn=conn):
-            raise PaymentError("Internal invoice already paid.")
+            raise PaymentError("Internal invoice already paid.", status="paid")
 
         # check_internal() returns the checking_id of the invoice we're waiting for
         # (pending only)
@@ -261,7 +268,7 @@ async def pay_invoice(
                 internal_invoice.amount != invoice.amount_msat
                 or internal_invoice.bolt11 != payment_request.lower()
             ):
-                raise PaymentError("Invalid invoice.")
+                raise PaymentError("Invalid invoice.", status="failed")
 
             logger.debug(f"creating temporary internal payment with id {internal_id}")
             # create a new payment from this wallet
@@ -289,7 +296,7 @@ async def pay_invoice(
             except Exception as exc:
                 logger.error(f"could not create temporary payment: {exc}")
                 # happens if the same wallet tries to pay an invoice twice
-                raise PaymentError("Could not make payment.") from exc
+                raise PaymentError("Could not make payment.", status="failed") from exc
 
         # do the balance check
         wallet = await get_wallet(wallet_id, conn=conn)
@@ -302,9 +309,10 @@ async def pay_invoice(
             ):
                 raise PaymentError(
                     f"You must reserve at least ({round(fee_reserve_total_msat/1000)}"
-                    "  sat) to cover potential routing fees."
+                    "  sat) to cover potential routing fees.",
+                    status="failed",
                 )
-            raise PermissionError("Insufficient balance.")
+            raise PaymentError("Insufficient balance.", status="failed")
 
     if internal_checking_id:
         service_fee_msat = service_fee(invoice.amount_msat, internal=True)
@@ -370,7 +378,8 @@ async def pay_invoice(
                 await delete_wallet_payment(temp_id, wallet_id, conn=conn)
             raise PaymentError(
                 f"Payment failed: {payment.error_message}"
-                or "Payment failed, but backend didn't give us an error message."
+                or "Payment failed, but backend didn't give us an error message.",
+                status="failed",
             )
         else:
             logger.warning(
@@ -413,8 +422,9 @@ async def check_time_limit_between_transactions(conn, wallet_id):
     if len(payments) == 0:
         return
 
-    raise ValueError(
-        f"The time limit of {limit} seconds between payments has been reached."
+    raise PaymentError(
+        status="failed",
+        message=f"The time limit of {limit} seconds between payments has been reached.",
     )
 
 

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -443,7 +443,7 @@ async def api_payment(payment_hash, x_api_key: Optional[str] = Header(None)):
     if wallet and wallet.id == payment.wallet_id:
         return {
             "paid": not payment.pending,
-            "status": f"{status}",
+            "status": f"{status!s}",
             "preimage": payment.preimage,
             "details": payment,
         }

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -434,7 +434,7 @@ async def api_payment(payment_hash, x_api_key: Optional[str] = Header(None)):
         return {"paid": True, "preimage": payment.preimage}
 
     try:
-        await payment.check_status()
+        status = await payment.check_status()
     except Exception:
         if wallet and wallet.id == payment.wallet_id:
             return {"paid": False, "details": payment}
@@ -443,6 +443,7 @@ async def api_payment(payment_hash, x_api_key: Optional[str] = Header(None)):
     if wallet and wallet.id == payment.wallet_id:
         return {
             "paid": not payment.pending,
+            "failed": status.failed,
             "preimage": payment.preimage,
             "details": payment,
         }

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -443,7 +443,7 @@ async def api_payment(payment_hash, x_api_key: Optional[str] = Header(None)):
     if wallet and wallet.id == payment.wallet_id:
         return {
             "paid": not payment.pending,
-            "failed": status.failed,
+            "status": f"{status}",
             "preimage": payment.preimage,
             "details": payment,
         }

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -171,7 +171,10 @@ async def api_payments_create_invoice(data: CreateInvoice, wallet: Wallet):
             assert payment_db is not None, "payment not found"
             checking_id = payment_db.checking_id
         except InvoiceError as exc:
-            raise HTTPException(status_code=520, detail=str(exc)) from exc
+            return JSONResponse(
+                status_code=520,
+                content={"detail": exc.message, "status": exc.status},
+            )
         except Exception as exc:
             raise exc
 
@@ -217,14 +220,11 @@ async def api_payments_pay_invoice(
         payment_hash = await pay_invoice(
             wallet_id=wallet.id, payment_request=bolt11, extra=extra
         )
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail=str(exc)
-        ) from exc
-    except PermissionError as exc:
-        raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail=str(exc)) from exc
     except PaymentError as exc:
-        raise HTTPException(status_code=520, detail=str(exc)) from exc
+        return JSONResponse(
+            status_code=520,
+            content={"detail": exc.message, "status": exc.status},
+        )
     except Exception as exc:
         raise exc
 

--- a/lnbits/wallets/alby.py
+++ b/lnbits/wallets/alby.py
@@ -129,7 +129,7 @@ class AlbyWallet(Wallet):
 
             if r.is_error:
                 error_message = data["message"] if "message" in data else r.text
-                return PaymentResponse(False, None, None, None, error_message)
+                return PaymentResponse(None, None, None, None, error_message)
 
             checking_id = data["payment_hash"]
             # todo: confirm with bitkarrot that having the minus is fine
@@ -141,18 +141,18 @@ class AlbyWallet(Wallet):
         except KeyError as exc:
             logger.warning(exc)
             return PaymentResponse(
-                False, None, None, None, "Server error: 'missing required fields'"
+                None, None, None, None, "Server error: 'missing required fields'"
             )
         except json.JSONDecodeError as exc:
             logger.warning(exc)
             return PaymentResponse(
-                False, None, None, None, "Server error: 'invalid json response'"
+                None, None, None, None, "Server error: 'invalid json response'"
             )
         except Exception as exc:
             logger.info(f"Failed to pay invoice {bolt11}")
             logger.warning(exc)
             return PaymentResponse(
-                False, None, None, None, f"Unable to connect to {self.endpoint}."
+                None, None, None, None, f"Unable to connect to {self.endpoint}."
             )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:

--- a/lnbits/wallets/alby.py
+++ b/lnbits/wallets/alby.py
@@ -167,6 +167,7 @@ class AlbyWallet(Wallet):
 
             data = r.json()
 
+            # TODO: how can we detect a failed payment?
             statuses = {
                 "CREATED": None,
                 "SETTLED": True,

--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -70,14 +70,11 @@ class PaymentStatus(NamedTuple):
         return self.paid is False
 
     def __str__(self) -> str:
-        if self.paid is True:
-            return "settled"
-        elif self.paid is False:
+        if self.success:
+            return "success"
+        if self.failed:
             return "failed"
-        elif self.paid is None:
-            return "still pending"
-        else:
-            return "unknown (should never happen)"
+        return "pending"
 
 
 class PaymentSuccessStatus(PaymentStatus):

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -167,7 +167,6 @@ class CoreLightningWallet(Wallet):
         except Exception as exc:
             logger.info(f"Failed to pay invoice {bolt11}")
             logger.warning(exc)
-            print("#### 123")
             return PaymentResponse(None, None, None, None, f"Payment failed: '{exc}'.")
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -164,13 +164,14 @@ class CoreLightningWallet(Wallet):
         except RpcError as exc:
             logger.warning(exc)
             try:
-                if exc.error["code"] in self.pay_failure_error_codes:  # type: ignore
-                    error_message = exc.error.get("message", exc.error["code"])  # type: ignore
+                error_code = exc.error.get("code")
+                if error_code in self.pay_failure_error_codes:  # type: ignore
+                    error_message = exc.error.get("message", error_code)  # type: ignore
                     return PaymentResponse(
                         False, None, None, None, f"Payment failed: {error_message}"
                     )
                 else:
-                    error_message = f"RPC '{exc.method}' failed with '{exc.error}'."
+                    error_message = f"Payment failed: {exc.error}"
                     return PaymentResponse(None, None, None, None, error_message)
             except Exception:
                 error_message = f"RPC '{exc.method}' failed with '{exc.error}'."

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -158,16 +158,17 @@ class CoreLightningWallet(Wallet):
                 error_message = exc.error["attempts"][-1]["fail_reason"]  # type: ignore
             except Exception:
                 error_message = f"RPC '{exc.method}' failed with '{exc.error}'."
-            return PaymentResponse(False, None, None, None, error_message)
+            return PaymentResponse(None, None, None, None, error_message)
         except KeyError as exc:
             logger.warning(exc)
             return PaymentResponse(
-                False, None, None, None, "Server error: 'missing required fields'"
+                None, None, None, None, "Server error: 'missing required fields'"
             )
         except Exception as exc:
             logger.info(f"Failed to pay invoice {bolt11}")
             logger.warning(exc)
-            return PaymentResponse(False, None, None, None, f"Payment failed: '{exc}'.")
+            print("#### 123")
+            return PaymentResponse(None, None, None, None, f"Payment failed: '{exc}'.")
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
         try:

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -46,6 +46,15 @@ class CoreLightningWallet(Wallet):
         command = self.ln.help("invoice")["help"][0]["command"]  # type: ignore
         self.supports_description_hash = "deschashonly" in command
 
+        # https://docs.corelightning.org/reference/lightning-pay
+        # 201: Already paid
+        # 203: Permanent failure at destination.
+        # 205: Unable to find a route.
+        # 206: Route too expensive.
+        # 207: Invoice expired.
+        # 210: Payment timed out without a payment in progress.
+        self.pay_failure_error_codes = [201, 203, 205, 206, 207, 210]
+
         # check last payindex so we can listen from that point on
         self.last_pay_index = 0
         invoices: dict = self.ln.listinvoices()  # type: ignore
@@ -155,10 +164,14 @@ class CoreLightningWallet(Wallet):
         except RpcError as exc:
             logger.warning(exc)
             try:
-                error_message = exc.error["attempts"][-1]["fail_reason"]  # type: ignore
-                return PaymentResponse(
-                    False, None, None, None, f"Payment failed: {error_message}"
-                )
+                if exc.error["code"] in self.pay_failure_error_codes:  # type: ignore
+                    error_message = exc.error.get("message", exc.error["code"])  # type: ignore
+                    return PaymentResponse(
+                        False, None, None, None, f"Payment failed: {error_message}"
+                    )
+                else:
+                    error_message = f"RPC '{exc.method}' failed with '{exc.error}'."
+                    return PaymentResponse(None, None, None, None, error_message)
             except Exception:
                 error_message = f"RPC '{exc.method}' failed with '{exc.error}'."
                 return PaymentResponse(None, None, None, None, error_message)

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -156,9 +156,12 @@ class CoreLightningWallet(Wallet):
             logger.warning(exc)
             try:
                 error_message = exc.error["attempts"][-1]["fail_reason"]  # type: ignore
+                return PaymentResponse(
+                    False, None, None, None, f"Payment failed: {error_message}"
+                )
             except Exception:
                 error_message = f"RPC '{exc.method}' failed with '{exc.error}'."
-            return PaymentResponse(None, None, None, None, error_message)
+                return PaymentResponse(None, None, None, None, error_message)
         except KeyError as exc:
             logger.warning(exc)
             return PaymentResponse(

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -177,9 +177,9 @@ class CoreLightningRestWallet(Wallet):
             data = r.json()
 
             if "error" in data:
-                return PaymentResponse(False, None, None, None, data["error"])
+                return PaymentResponse(None, None, None, None, data["error"])
             if r.is_error:
-                return PaymentResponse(False, None, None, None, r.text)
+                return PaymentResponse(None, None, None, None, r.text)
             if (
                 "payment_hash" not in data
                 or "payment_preimage" not in data
@@ -188,7 +188,7 @@ class CoreLightningRestWallet(Wallet):
                 or "status" not in data
             ):
                 return PaymentResponse(
-                    False, None, None, None, "Server error: 'missing required fields'"
+                    None, None, None, None, "Server error: 'missing required fields'"
                 )
 
             checking_id = data["payment_hash"]
@@ -200,13 +200,13 @@ class CoreLightningRestWallet(Wallet):
             )
         except json.JSONDecodeError:
             return PaymentResponse(
-                False, None, None, None, "Server error: 'invalid json response'"
+                None, None, None, None, "Server error: 'invalid json response'"
             )
         except Exception as exc:
             logger.info(f"Failed to pay invoice {bolt11}")
             logger.warning(exc)
             return PaymentResponse(
-                False, None, None, None, f"Unable to connect to {self.url}."
+                None, None, None, None, f"Unable to connect to {self.url}."
             )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -142,9 +142,9 @@ class EclairWallet(Wallet):
             data = r.json()
 
             if "error" in data:
-                return PaymentResponse(False, None, None, None, data["error"])
+                return PaymentResponse(None, None, None, None, data["error"])
             if r.is_error:
-                return PaymentResponse(False, None, None, None, r.text)
+                return PaymentResponse(None, None, None, None, r.text)
 
             if data["type"] == "payment-failed":
                 return PaymentResponse(False, None, None, None, "payment failed")
@@ -154,17 +154,17 @@ class EclairWallet(Wallet):
 
         except json.JSONDecodeError:
             return PaymentResponse(
-                False, None, None, None, "Server error: 'invalid json response'"
+                None, None, None, None, "Server error: 'invalid json response'"
             )
         except KeyError:
             return PaymentResponse(
-                False, None, None, None, "Server error: 'missing required fields'"
+                None, None, None, None, "Server error: 'missing required fields'"
             )
         except Exception as exc:
             logger.info(f"Failed to pay invoice {bolt11}")
             logger.warning(exc)
             return PaymentResponse(
-                False, None, None, None, f"Unable to connect to {self.url}."
+                None, None, None, None, f"Unable to connect to {self.url}."
             )
 
         payment_status: PaymentStatus = await self.get_payment_status(checking_id)

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -180,7 +180,7 @@ class LNbitsWallet(Wallet):
                 return PaymentPendingStatus()
             data = r.json()
 
-            if data.get("failed", False) is True:
+            if data.get("status") == "failed":
                 return PaymentFailedStatus()
 
             if "paid" not in data or not data["paid"]:

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -9,6 +9,7 @@ from lnbits.settings import settings
 
 from .base import (
     InvoiceResponse,
+    PaymentFailedStatus,
     PaymentPendingStatus,
     PaymentResponse,
     PaymentStatus,
@@ -168,6 +169,9 @@ class LNbitsWallet(Wallet):
             if r.is_error:
                 return PaymentPendingStatus()
             data = r.json()
+
+            if data.get("failed", False) is True:
+                return PaymentFailedStatus()
 
             if "paid" not in data or not data["paid"]:
                 return PaymentPendingStatus()

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -120,7 +120,7 @@ class LNbitsWallet(Wallet):
 
             if r.is_error or "payment_hash" not in data:
                 error_message = data["detail"] if "detail" in data else r.text
-                return PaymentResponse(False, None, None, None, error_message)
+                return PaymentResponse(None, None, None, None, error_message)
 
             checking_id = data["payment_hash"]
 
@@ -133,17 +133,17 @@ class LNbitsWallet(Wallet):
             )
         except json.JSONDecodeError:
             return PaymentResponse(
-                False, None, None, None, "Server error: 'invalid json response'"
+                None, None, None, None, "Server error: 'invalid json response'"
             )
         except KeyError:
             return PaymentResponse(
-                False, None, None, None, "Server error: 'missing required fields'"
+                None, None, None, None, "Server error: 'missing required fields'"
             )
         except Exception as exc:
             logger.info(f"Failed to pay invoice {bolt11}")
             logger.warning(exc)
             return PaymentResponse(
-                False, None, None, None, f"Unable to connect to {self.endpoint}."
+                None, None, None, None, f"Unable to connect to {self.endpoint}."
             )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -167,7 +167,7 @@ class LndWallet(Wallet):
             resp = await self.routerpc.SendPaymentV2(req).read()
         except Exception as exc:
             logger.warning(exc)
-            return PaymentResponse(False, None, None, None, str(exc))
+            return PaymentResponse(None, None, None, None, str(exc))
 
         # PaymentStatus from https://github.com/lightningnetwork/lnd/blob/master/channeldb/payments.go#L178
         statuses = {

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -177,7 +177,7 @@ class LndRestWallet(Wallet):
         except Exception as exc:
             logger.warning(f"LndRestWallet pay_invoice POST error: {exc}.")
             return PaymentResponse(
-                False, None, None, None, f"Unable to connect to {self.endpoint}."
+                None, None, None, None, f"Unable to connect to {self.endpoint}."
             )
 
         try:
@@ -188,7 +188,7 @@ class LndRestWallet(Wallet):
                 logger.warning(
                     f"LndRestWallet pay_invoice payment_error: {error_message}."
                 )
-                return PaymentResponse(False, None, None, None, error_message)
+                return PaymentResponse(None, None, None, None, error_message)
 
             if (
                 "payment_hash" not in data
@@ -197,7 +197,7 @@ class LndRestWallet(Wallet):
                 or "payment_preimage" not in data
             ):
                 return PaymentResponse(
-                    False, None, None, None, "Server error: 'missing required fields'"
+                    None, None, None, None, "Server error: 'missing required fields'"
                 )
 
             checking_id = base64.b64decode(data["payment_hash"]).hex()
@@ -206,7 +206,7 @@ class LndRestWallet(Wallet):
             return PaymentResponse(True, checking_id, fee_msat, preimage, None)
         except json.JSONDecodeError:
             return PaymentResponse(
-                False, None, None, None, "Server error: 'invalid json response'"
+                None, None, None, None, "Server error: 'invalid json response'"
             )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -176,12 +176,10 @@ class LndRestWallet(Wallet):
             r.raise_for_status()
             data = r.json()
 
-            if data.get("payment_error"):
-                error_message = r.json().get("payment_error") or r.text
-                logger.warning(
-                    f"LndRestWallet pay_invoice payment_error: {error_message}."
-                )
-                return PaymentResponse(None, None, None, None, error_message)
+            payment_error = data.get("payment_error")
+            if payment_error:
+                logger.warning(f"LndRestWallet payment_error: {payment_error}.")
+                return PaymentResponse(False, None, None, None, payment_error)
 
             checking_id = base64.b64decode(data["payment_hash"]).hex()
             fee_msat = int(data["payment_route"]["total_fees_msat"])

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -189,6 +189,7 @@ class PhoenixdWallet(Wallet):
             return PaymentPendingStatus()
 
     async def get_payment_status(self, checking_id: str) -> PaymentStatus:
+        # TODO: how can we detect a failed payment?
         try:
             r = await self.client.get(f"/payments/outgoing/{checking_id}")
             if r.is_error:

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -144,11 +144,11 @@ class PhoenixdWallet(Wallet):
             data = r.json()
 
             if "routingFeeSat" not in data and "reason" in data:
-                return PaymentResponse(False, None, None, None, data["reason"])
+                return PaymentResponse(None, None, None, None, data["reason"])
 
             if r.is_error or "paymentHash" not in data:
                 error_message = data["message"] if "message" in data else r.text
-                return PaymentResponse(False, None, None, None, error_message)
+                return PaymentResponse(None, None, None, None, error_message)
 
             checking_id = data["paymentHash"]
             fee_msat = -int(data["routingFeeSat"])
@@ -158,17 +158,17 @@ class PhoenixdWallet(Wallet):
 
         except json.JSONDecodeError:
             return PaymentResponse(
-                False, None, None, None, "Server error: 'invalid json response'"
+                None, None, None, None, "Server error: 'invalid json response'"
             )
         except KeyError:
             return PaymentResponse(
-                False, None, None, None, "Server error: 'missing required fields'"
+                None, None, None, None, "Server error: 'missing required fields'"
             )
         except Exception as exc:
             logger.info(f"Failed to pay invoice {bolt11}")
             logger.warning(exc)
             return PaymentResponse(
-                False, None, None, None, f"Unable to connect to {self.endpoint}."
+                None, None, None, None, f"Unable to connect to {self.endpoint}."
             )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:

--- a/tests/regtest/test_real_invoice.py
+++ b/tests/regtest/test_real_invoice.py
@@ -226,26 +226,13 @@ async def test_pay_hold_invoice_check_pending_and_fail(
     cancel_invoice(preimage_hash)
 
     response = await task
-    assert response.status_code > 300, "Payment failed on the funding source"
+    assert response.status_code > 300  # should error
 
     await asyncio.sleep(1)
-    # get payment from LNbits
-    response = await client.get(
-        f"/api/v1/payments/{preimage_hash}",
-        headers=adminkey_headers_from,
-    )
 
-    # no time to delete the payment yet
-    # assert response.status_code == 200, "Payment found"
-    # data = response.json()
-    # assert data["details"]["failed"] is True, "Payment expected to fail"
-
-    # TODO: to be updated after the failed status is explicit
-    # await asyncio.sleep(1)
-
-    # # payment should not be in database anymore
-    # payment_db_after_settlement=await get_standalone_payment(invoice_obj.payment_hash)
-    # assert payment_db_after_settlement is None
+    # payment should not be in database anymore
+    payment_db_after_settlement = await get_standalone_payment(invoice_obj.payment_hash)
+    assert payment_db_after_settlement is None
 
 
 @pytest.mark.asyncio

--- a/tests/regtest/test_real_invoice.py
+++ b/tests/regtest/test_real_invoice.py
@@ -236,9 +236,9 @@ async def test_pay_hold_invoice_check_pending_and_fail(
     )
 
     # no time to delete the payment yet
-    assert response.status_code == 200, "Payment found"
-    data = response.json()
-    assert data["details"]["failed"] is True, "Payment expected to fail"
+    # assert response.status_code == 200, "Payment found"
+    # data = response.json()
+    # assert data["details"]["failed"] is True, "Payment expected to fail"
 
     # TODO: to be updated after the failed status is explicit
     # await asyncio.sleep(1)

--- a/tests/regtest/test_real_invoice.py
+++ b/tests/regtest/test_real_invoice.py
@@ -226,13 +226,15 @@ async def test_pay_hold_invoice_check_pending_and_fail(
     cancel_invoice(preimage_hash)
 
     response = await task
-    assert response.status_code == 201, "Payment created, but not settled"
+    assert response.status_code > 300, "Payment failed on the funding source"
 
+    # get payment from LNbits
     response = await client.get(
         f"/api/v1/payments/{preimage_hash}",
         headers=adminkey_headers_from,
     )
 
+    # no time to delete the payment yet
     assert response.status_code == 200, "Payment found"
     data = response.json()
     assert data["details"]["failed"] is True, "Payment expected to fail"

--- a/tests/regtest/test_real_invoice.py
+++ b/tests/regtest/test_real_invoice.py
@@ -228,6 +228,7 @@ async def test_pay_hold_invoice_check_pending_and_fail(
     response = await task
     assert response.status_code > 300, "Payment failed on the funding source"
 
+    await asyncio.sleep(1)
     # get payment from LNbits
     response = await client.get(
         f"/api/v1/payments/{preimage_hash}",

--- a/tests/wallets/fixtures/json/fixtures_rest.json
+++ b/tests/wallets/fixtures/json/fixtures_rest.json
@@ -1311,6 +1311,44 @@
           }
         },
         {
+          "description": "failed",
+          "call_params": {
+            "bolt11": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
+            "fee_limit_msat": 25000
+          },
+          "expect": {
+            "success": false,
+            "pending": false,
+            "failed": true,
+            "checking_id": null,
+            "fee_msat": null,
+            "preimage": null
+          },
+          "mocks": {
+            "corelightningrest": {
+              "pay_invoice_endpoint": [
+                {
+                  "request_type": "data",
+                  "request_body": {
+                    "invoice": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
+                    "maxfeepercent": "119.04761905",
+                    "exemptfee": 0
+                  },
+                  "response_type": "json",
+                  "response": {
+                    "status": "failed"
+                  }
+                }
+              ]
+            },
+            "lndrest": {},
+            "alby": {},
+            "eclair": [],
+            "lnbits": [],
+            "phoenixd": []
+          }
+        },
+        {
           "description": "pending, no fee",
           "call_params": {
             "bolt11": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",

--- a/tests/wallets/fixtures/json/fixtures_rest.json
+++ b/tests/wallets/fixtures/json/fixtures_rest.json
@@ -1519,6 +1519,7 @@
                   },
                   "response_type": "json",
                   "response": {
+                    "status": "pending",
                     "error": "Test Error"
                   }
                 }

--- a/tests/wallets/fixtures/json/fixtures_rest.json
+++ b/tests/wallets/fixtures/json/fixtures_rest.json
@@ -1462,8 +1462,8 @@
           },
           "expect": {
             "success": false,
-            "pending": false,
-            "failed": true,
+            "pending": true,
+            "failed": false,
             "checking_id": null,
             "fee_msat": null,
             "preimage": null,
@@ -1591,8 +1591,8 @@
           "expect": {
             "error_message": "Server error: 'missing required fields'",
             "success": false,
-            "pending": false,
-            "failed": true,
+            "pending": true,
+            "failed": false,
             "checking_id": null,
             "fee_msat": null,
             "preimage": null
@@ -1688,8 +1688,8 @@
           "expect": {
             "error_message": "Server error: 'invalid json response'",
             "success": false,
-            "pending": false,
-            "failed": true,
+            "pending": true,
+            "failed": false,
             "checking_id": null,
             "fee_msat": null,
             "preimage": null
@@ -1806,8 +1806,8 @@
           "expect": {
             "error_message": "Unable to connect to http://127.0.0.1:8555.",
             "success": false,
-            "pending": false,
-            "failed": true,
+            "pending": true,
+            "failed": false,
             "checking_id": null,
             "fee_msat": null,
             "preimage": null
@@ -1936,8 +1936,8 @@
           "expect": {
             "error_message": "Unable to connect to http://127.0.0.1:8555.",
             "success": false,
-            "pending": false,
-            "failed": true,
+            "pending": true,
+            "failed": false,
             "checking_id": null,
             "fee_msat": null,
             "preimage": null

--- a/tests/wallets/fixtures/json/fixtures_rest.json
+++ b/tests/wallets/fixtures/json/fixtures_rest.json
@@ -1571,31 +1571,7 @@
               ]
             },
             "lnbits": {
-              "pay_invoice_endpoint": [
-                {
-                  "request_type": "json",
-                  "request_body": {
-                    "out": true,
-                    "blt11": "lnbc5550n1pnq9jg3sp52rvwstvjcypjsaenzdh0h30jazvzsf8aaye0julprtth9kysxtuspp5e5s3z7felv4t9zrcc6wpn7ehvjl5yzewanzl5crljdl3jgeffyhqdq2f38xy6t5wvxqzjccqpjrzjq0yzeq76ney45hmjlnlpvu0nakzy2g35hqh0dujq8ujdpr2e42pf2rrs6vqpgcsqqqqqqqqqqqqqqeqqyg9qxpqysgqwftcx89k5pp28435pgxfl2vx3ksemzxccppw2j9yjn0ngr6ed7wj8ztc0d5kmt2mvzdlcgrludhz7jncd5l5l9w820hc4clpwhtqj3gq62g66n"
-                  },
-                  "response_type": "json",
-                  "response": {
-                    "detail": "Test Error"
-                  }
-                }
-              ],
-              "get_payment_status_endpoint": [
-                {
-                  "response_type": "json",
-                  "response": {
-                    "paid": true,
-                    "preimage": "0000000000000000000000000000000000000000000000000000000000000000",
-                    "details": {
-                      "fee": 50
-                    }
-                  }
-                }
-              ]
+              "pay_invoice_endpoint": []
             },
             "phoenixd": {
               "pay_invoice_endpoint": [

--- a/tests/wallets/fixtures/json/fixtures_rest.json
+++ b/tests/wallets/fixtures/json/fixtures_rest.json
@@ -2665,7 +2665,7 @@
                   "response_type": "json",
                   "response": {
                     "paid": false,
-                    "failed": true,
+                    "status": "failed",
                     "preimage": "0000000000000000000000000000000000000000000000000000000000000000",
                     "details": {}
                   }

--- a/tests/wallets/fixtures/json/fixtures_rest.json
+++ b/tests/wallets/fixtures/json/fixtures_rest.json
@@ -2643,7 +2643,17 @@
               ]
             },
             "lnbits": {
-              "get_payment_status_endpoint": []
+              "get_payment_status_endpoint": [
+                {
+                  "response_type": "json",
+                  "response": {
+                    "paid": false,
+                    "failed": true,
+                    "preimage": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "details": {}
+                  }
+                }
+              ]
             },
             "phoenixd": {
               "description": "phoenixd.py doesn't handle the 'failed' status for `get_invoice_status`",

--- a/tests/wallets/fixtures/json/fixtures_rest.json
+++ b/tests/wallets/fixtures/json/fixtures_rest.json
@@ -1341,7 +1341,21 @@
                 }
               ]
             },
-            "lndrest": {},
+            "lndrest": {
+              "pay_invoice_endpoint": [
+                {
+                  "request_type": "json",
+                  "request_body": {
+                    "payment_request": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
+                    "fee_limit": 25000
+                  },
+                  "response_type": "json",
+                  "response": {
+                    "payment_error": "Test Error"
+                  }
+                }
+              ]
+            },
             "alby": {},
             "eclair": [],
             "lnbits": [],
@@ -1526,19 +1540,7 @@
               ]
             },
             "lndrest": {
-              "pay_invoice_endpoint": [
-                {
-                  "request_type": "json",
-                  "request_body": {
-                    "payment_request": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
-                    "fee_limit": 25000
-                  },
-                  "response_type": "json",
-                  "response": {
-                    "payment_error": "Test Error"
-                  }
-                }
-              ]
+              "pay_invoice_endpoint": []
             },
             "alby": {
               "pay_invoice_endpoint": []

--- a/tests/wallets/fixtures/json/fixtures_rpc.json
+++ b/tests/wallets/fixtures/json/fixtures_rpc.json
@@ -818,7 +818,7 @@
           }
         },
         {
-          "description": "error",
+          "description": "failed",
           "call_params": {
             "bolt11": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
             "fee_limit_msat": 25000
@@ -826,54 +826,15 @@
           "expect": {
             "__eval__:error_message": "\"Payment failed: \" in \"{error_message}\"",
             "success": false,
+            "pending": false,
+            "failed": true,
             "checking_id": null,
             "fee_msat": null,
             "preimage": null
           },
           "mocks": {
-            "breez": {
-              "sdk_services": [
-                {
-                  "response_type": "data",
-                  "response": {
-                    "send_payment": {
-                      "request_type": "function",
-                      "response_type": "exception",
-                      "response": {
-                        "data": "test-error"
-                      }
-                    }
-                  }
-                }
-              ]
-            },
-            "corelightning": {
-              "ln": [
-                {
-                  "description": "test-error",
-                  "response": {
-                    "call": {
-                      "description": "indirect call to `pay` (via `call`)",
-                      "request_type": "function",
-                      "request_data": {
-                        "args": [
-                          "pay",
-                          {
-                            "bolt11": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
-                            "description": "Unit Test Invoice",
-                            "maxfee": 25000
-                          }
-                        ]
-                      },
-                      "response_type": "exception",
-                      "response": {
-                        "data": "test-error"
-                      }
-                    }
-                  }
-                }
-              ]
-            },
+            "breez": {},
+            "corelightning": {},
             "lndrpc": {
               "rpc": [
                 {
@@ -994,7 +955,77 @@
                       }
                     }
                   }
-                },
+                }
+              ]
+            }
+          }
+        },
+        {
+          "description": "error",
+          "call_params": {
+            "bolt11": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
+            "fee_limit_msat": 25000
+          },
+          "expect": {
+            "__eval__:error_message": "\"Payment failed: \" in \"{error_message}\"",
+            "success": false,
+            "pending": true,
+            "failed": false,
+            "checking_id": null,
+            "fee_msat": null,
+            "preimage": null
+          },
+          "mocks": {
+            "breez": {
+              "sdk_services": [
+                {
+                  "response_type": "data",
+                  "response": {
+                    "send_payment": {
+                      "request_type": "function",
+                      "response_type": "exception",
+                      "response": {
+                        "data": "test-error"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "corelightning": {
+              "ln": [
+                {
+                  "description": "test-error",
+                  "response": {
+                    "call": {
+                      "description": "indirect call to `pay` (via `call`)",
+                      "request_type": "function",
+                      "request_data": {
+                        "args": [
+                          "pay",
+                          {
+                            "bolt11": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
+                            "description": "Unit Test Invoice",
+                            "maxfee": 25000
+                          }
+                        ]
+                      },
+                      "response_type": "exception",
+                      "response": {
+                        "data": "test-error"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "lndrpc": {
+              "rpc": [
+                {
+                  "response": {}
+                }
+              ],
+              "routerpc": [
                 {
                   "description": "RPC error.",
                   "response": {
@@ -1024,11 +1055,13 @@
             "fee_limit_msat": 25000
           },
           "expect": {
+            "error_message": "Server error: 'missing required fields'",
             "success": false,
+            "pending": true,
+            "failed": false,
             "checking_id": null,
             "fee_msat": null,
-            "preimage": null,
-            "error_message": "Server error: 'missing required fields'"
+            "preimage": null
           },
           "mocks": {
             "breez": {
@@ -1071,11 +1104,13 @@
             "fee_limit_msat": 25000
           },
           "expect": {
+            "error_message": "RPC 'test_method' failed with 'test-error'.",
             "success": false,
+            "pending": true,
+            "failed": false,
             "checking_id": null,
             "fee_msat": null,
-            "preimage": null,
-            "error_message": "RPC 'test_method' failed with 'test-error'."
+            "preimage": null
           },
           "mocks": {
             "breez": {

--- a/tests/wallets/fixtures/json/fixtures_rpc.json
+++ b/tests/wallets/fixtures/json/fixtures_rpc.json
@@ -859,6 +859,7 @@
                           "method": "test_method",
                           "payload": "y",
                           "error": {
+                            "code": 205,
                             "attempts": [
                               {
                                 "fail_reason": "some reason"

--- a/tests/wallets/fixtures/json/fixtures_rpc.json
+++ b/tests/wallets/fixtures/json/fixtures_rpc.json
@@ -834,7 +834,44 @@
           },
           "mocks": {
             "breez": {},
-            "corelightning": {},
+            "corelightning": {
+              "ln": [
+                {
+                  "response": {
+                    "call": {
+                      "description": "indirect call to `pay` (via `call`)",
+                      "request_type": "function",
+                      "request_data": {
+                        "args": [
+                          "pay",
+                          {
+                            "bolt11": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
+                            "description": "Unit Test Invoice",
+                            "maxfee": 25000
+                          }
+                        ]
+                      },
+                      "response_type": "exception",
+                      "response": {
+                        "module": "pyln.client.lightning",
+                        "class": "RpcError",
+                        "data": {
+                          "method": "test_method",
+                          "payload": "y",
+                          "error": {
+                            "attempts": [
+                              {
+                                "fail_reason": "some reason"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
             "lndrpc": {
               "rpc": [
                 {
@@ -1118,40 +1155,6 @@
             },
             "corelightning": {
               "ln": [
-                {
-                  "response": {
-                    "call": {
-                      "description": "indirect call to `pay` (via `call`)",
-                      "request_type": "function",
-                      "request_data": {
-                        "args": [
-                          "pay",
-                          {
-                            "bolt11": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu",
-                            "description": "Unit Test Invoice",
-                            "maxfee": 25000
-                          }
-                        ]
-                      },
-                      "response_type": "exception",
-                      "response": {
-                        "module": "pyln.client.lightning",
-                        "class": "RpcError",
-                        "data": {
-                          "method": "test_method",
-                          "payload": "y",
-                          "error": {
-                            "attempts": [
-                              {
-                                "fail_reason": "RPC 'test_method' failed with 'test-error'."
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
                 {
                   "response": {
                     "call": {


### PR DESCRIPTION
### Summary

This PR addresses an issue for **failed** `outgoing payments`.

If an outgoing payment (invoice paid by the user) is marked as failed, then it will be deleted after a certain time interval.
The (current) reason for deleting the failed outgoing payment is to unlock the user funds. Because while the payment is still present the amount is considered locked.

The issue is that sometimes the `outgoing payment` can be marked as failed for technical reason, BUT the invoice is not actually canceled.

The solution in this PR is to:
 - never mark a payment as `failed` unless the funding source explicitly returns a status that says the payment is failed
 - any technical errors will keep the invoice as `pending`
 - make sure `get_payment_status` for all funding sources returns `failed` under _some_ condition
   - `alby` and `poenixd` have an issue here