### PR TITLE
fix: show proper total balances fix cleanups

### DIFF
--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -206,7 +206,7 @@ async def database_delete_wallet(wallet: str):
 @click.option("-c", "--checking-id", required=True, help="Payment checking Id.")
 @coro
 async def database_delete_wallet_payment(wallet: str, checking_id: str):
-    """Mark wallet as deleted"""
+    """Delete wallet payment"""
     async with core_db.connect() as conn:
         await delete_wallet_payment(
             wallet_id=wallet, checking_id=checking_id, conn=conn

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -207,14 +207,21 @@ async def delete_accounts_no_wallets(
     time_delta: int,
     conn: Optional[Connection] = None,
 ) -> None:
+    delta = int(time()) - time_delta
     await (conn or db).execute(
         f"""
         DELETE FROM accounts
         WHERE NOT EXISTS (
             SELECT wallets.id FROM wallets WHERE wallets.user = accounts.id
-        ) AND updated_at < {db.timestamp_placeholder}
+        ) AND (
+            (updated_at is null AND created_at < {db.timestamp_placeholder})
+            OR updated_at < {db.timestamp_placeholder}
+        )
         """,
-        (int(time()) - time_delta,),
+        (
+            delta,
+            delta,
+        ),
     )
 
 
@@ -588,14 +595,21 @@ async def delete_unused_wallets(
     time_delta: int,
     conn: Optional[Connection] = None,
 ) -> None:
+    delta = int(time()) - time_delta
     await (conn or db).execute(
         f"""
         DELETE FROM wallets
         WHERE (
             SELECT COUNT(*) FROM apipayments WHERE wallet = wallets.id
-        ) = 0 AND updated_at < {db.timestamp_placeholder}
+        ) = 0 AND (
+            (updated_at is null AND created_at < {db.timestamp_placeholder})
+            OR updated_at < {db.timestamp_placeholder}
+        )
         """,
-        (int(time()) - time_delta,),
+        (
+            delta,
+            delta,
+        ),
     )
 
 


### PR DESCRIPTION
payments are not deleted if we delete a wallet, so to get a accurate total representation of the lnbits balance we need to create the balances view based on the wallets table, not payments, else deleted balances will still show up.

2nd, `delete_unused_wallets` and `delete_accounts was` never working because they never got an `updated_at` time, so i just check if its null else i check to timedelta on created_at