### PR TITLE
fix: add cln unspecified error code bolt11 error to errorcodes

### DIFF
--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -47,13 +47,15 @@ class CoreLightningWallet(Wallet):
         self.supports_description_hash = "deschashonly" in command
 
         # https://docs.corelightning.org/reference/lightning-pay
+        # -32602: Invalid bolt11: Prefix bc is not for regtest
+        # -1: Catchall nonspecific error.
         # 201: Already paid
         # 203: Permanent failure at destination.
         # 205: Unable to find a route.
         # 206: Route too expensive.
         # 207: Invoice expired.
         # 210: Payment timed out without a payment in progress.
-        self.pay_failure_error_codes = [201, 203, 205, 206, 207, 210]
+        self.pay_failure_error_codes = [-32602, 201, 203, 205, 206, 207, 210]
 
         # check last payindex so we can listen from that point on
         self.last_pay_index = 0
@@ -164,8 +166,8 @@ class CoreLightningWallet(Wallet):
         except RpcError as exc:
             logger.warning(exc)
             try:
-                error_code = exc.error.get("code")
-                if error_code in self.pay_failure_error_codes:  # type: ignore
+                error_code = exc.error.get("code")  # type: ignore
+                if error_code in self.pay_failure_error_codes:
                     error_message = exc.error.get("message", error_code)  # type: ignore
                     return PaymentResponse(
                         False, None, None, None, f"Payment failed: {error_message}"


### PR DESCRIPTION
```
2024-05-14 17:32:14.44 | WARNING |
lnbits.wallets.corelightning:pay_invoice:165 | RPC call failed: method:
pay, payload: {'bolt11': 'lnbc210n1pnru86xsp523xtewax3k7zam0ne8f36
4paz7dulmxf3g7f99xtynt4v5lzvgxqpp5l29euul4m0re896msdp6gawtlrrdctc97ftvh3udf4jrduuhk4tqhp5yd577hw58ty73gn9c2ekjytu39ysf33m2rfzetz37rqll86lsnhscqpjrzjqttftvqu0f5sneckep3lkwdut
7mmhhpcyjmlmnjn4hze8ed7pq88xrq4jsqqc8gqqyqqqqlgqqqqqqgq2q9qxpqysgqqzee8yulqs8s8yyllsjjmln6vetu6gq502cykcnzyqxs5mrd0hq899nauhjmklllvz7y2n2nvtg3c2z3ymvvc7pcc4f2jh4xufun7acqew4
htt', 'maxfee': 2000}, error: {'code': -32602, 'message': 'Invalid
bolt11: Prefix bc is not for regtest'}```