### PR TITLE
[feat] Check payment tag

### DIFF
--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -453,3 +453,8 @@ class BalanceDelta(BaseModel):
     @property
     def delta_msats(self):
         return self.node_balance_msats - self.lnbits_balance_msats
+
+
+class SimpleStatus(BaseModel):
+    success: bool
+    message: str

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -17,7 +17,11 @@ from py_vapid.utils import b64urlencode
 
 from lnbits.core.db import db
 from lnbits.db import Connection
-from lnbits.decorators import WalletTypeInfo, require_admin_key
+from lnbits.decorators import (
+    WalletTypeInfo,
+    check_user_extension_access,
+    require_admin_key,
+)
 from lnbits.helpers import url_for
 from lnbits.lnurl import LnurlErrorResponse
 from lnbits.lnurl import decode as decode_lnurl
@@ -312,6 +316,12 @@ async def pay_invoice(
                     status="failed",
                 )
             raise PaymentError("Insufficient balance.", status="failed")
+
+    if extra and "tag" in extra:
+        # check if the payment is made for an extension that the user disabled
+        status = await check_user_extension_access(wallet.user, extra["tag"])
+        if not status.success:
+            raise PaymentError(status.message)
 
     if internal_checking_id:
         service_fee_msat = service_fee(invoice.amount_msat, internal=True)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -304,18 +304,7 @@ async def pay_invoice(
         # do the balance check
         wallet = await get_wallet(wallet_id, conn=conn)
         assert wallet, "Wallet for balancecheck could not be fetched"
-        if wallet.balance_msat < 0:
-            logger.debug("balance is too low, deleting temporary payment")
-            if (
-                not internal_checking_id
-                and wallet.balance_msat > -fee_reserve_total_msat
-            ):
-                raise PaymentError(
-                    f"You must reserve at least ({round(fee_reserve_total_msat/1000)}"
-                    "  sat) to cover potential routing fees.",
-                    status="failed",
-                )
-            raise PaymentError("Insufficient balance.", status="failed")
+        _check_wallet_balance(wallet, fee_reserve_total_msat, internal_checking_id)
 
     if extra and "tag" in extra:
         # check if the payment is made for an extension that the user disabled
@@ -410,6 +399,22 @@ async def pay_invoice(
             pending=False,
         )
     return invoice.payment_hash
+
+
+def _check_wallet_balance(
+    wallet: Wallet,
+    fee_reserve_total_msat: int,
+    internal_checking_id: Optional[str] = None,
+):
+    if wallet.balance_msat < 0:
+        logger.debug("balance is too low, deleting temporary payment")
+        if not internal_checking_id and wallet.balance_msat > -fee_reserve_total_msat:
+            raise PaymentError(
+                f"You must reserve at least ({round(fee_reserve_total_msat/1000)}"
+                "  sat) to cover potential routing fees.",
+                status="failed",
+            )
+        raise PaymentError("Insufficient balance.", status="failed")
 
 
 async def check_wallet_limits(wallet_id, conn, amount_msat):


### PR DESCRIPTION
### Summary
Do not allow payments from extensions that are disabled by the user.

**Steps**:
 - user enables `withdraw` extension
 - user create  `withdraw link` and shares it
 - user disables  `withdraw` extension

**Actual Result**:
 - `withdraw link` still working

**Expected Result**:
 - `withdraw link` does not work until the `withdraw` extension is enabled again

**Note**:
 - this functionality relies on the fact that extensions use the `"tag"` field in the "'extra'" options
   -  this is not enforced in the code in any way at the moment

 - the function `_check_wallet_balance` is a simple refactor (no business logic changes) it was required by the code check tools (parent function was getting too large)

![image](https://github.com/lnbits/lnbits/assets/2951406/1e95f1ec-595e-4f2d-92b9-fc5421e91cf7)
