### PR TITLE
[feat] add `authenticated_user_id` decorator

### DIFF
--- a/lnbits/decorators.py
+++ b/lnbits/decorators.py
@@ -168,7 +168,6 @@ async def authenticated_user_id(
         account = await _get_account_from_token(access_token)
         return account.id if account else None
 
-
     return None
 
 

--- a/lnbits/decorators.py
+++ b/lnbits/decorators.py
@@ -158,6 +158,19 @@ async def check_user_exists(
     return user
 
 
+async def fetch_user_id(
+    access_token: Annotated[Optional[str], Depends(check_access_token)],
+    usr: Optional[UUID4] = None,
+) -> Optional[str]:
+    if access_token:
+        account = await _get_account_from_token(access_token)
+        return account.id if account else None
+    if usr:
+        return usr.hex
+
+    return None
+
+
 async def check_admin(user: Annotated[User, Depends(check_user_exists)]) -> User:
     if user.id != settings.super_user and user.id not in settings.lnbits_admin_users:
         raise HTTPException(

--- a/lnbits/decorators.py
+++ b/lnbits/decorators.py
@@ -158,7 +158,7 @@ async def check_user_exists(
     return user
 
 
-async def authenticated_user_id(
+async def optional_user_id(
     access_token: Annotated[Optional[str], Depends(check_access_token)],
     usr: Optional[UUID4] = None,
 ) -> Optional[str]:

--- a/lnbits/decorators.py
+++ b/lnbits/decorators.py
@@ -158,15 +158,16 @@ async def check_user_exists(
     return user
 
 
-async def fetch_user_id(
+async def authenticated_user_id(
     access_token: Annotated[Optional[str], Depends(check_access_token)],
     usr: Optional[UUID4] = None,
 ) -> Optional[str]:
+    if usr and settings.is_auth_method_allowed(AuthMethods.user_id_only):
+        return usr.hex
     if access_token:
         account = await _get_account_from_token(access_token)
         return account.id if account else None
-    if usr:
-        return usr.hex
+
 
     return None
 


### PR DESCRIPTION
Light decorator used to check if there is an authenticated user or not.
Does not enforce authentication.
Required when querying for user specific resources.