### PR TITLE
[feat] add `default_user_extensions` setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,8 @@ LNBITS_ADMIN_USERS=""
 
 # Extensions only admin can access
 LNBITS_ADMIN_EXTENSIONS="ngrok, admin"
+# Extensions enabled by default when a user is created
+LNBITS_USER_DEFAULT_EXTENSIONS="lnurlp"
 
 # Start LNbits core only. The extensions are not loaded.
 # LNBITS_EXTENSIONS_DEACTIVATE_ALL=true

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -64,6 +64,7 @@ from .crud import (
     update_payment_details,
     update_payment_status,
     update_super_user,
+    update_user_extension,
 )
 from .helpers import to_valid_user_id
 from .models import BalanceDelta, Payment, User, UserConfig, Wallet
@@ -803,7 +804,12 @@ async def create_user_account(
     pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
     password = pwd_context.hash(password) if password else None
 
-    return await create_account(user_id, username, email, password, user_config)
+    account = await create_account(user_id, username, email, password, user_config)
+
+    for ext_id in settings.lnbits_user_default_extensions:
+        await update_user_extension(user_id=account.id, extension=ext_id, active=True)
+
+    return account
 
 
 class WebsocketConnectionManager:

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -6,12 +6,14 @@ from io import BytesIO
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, TypedDict
 from urllib.parse import parse_qs, urlparse
+from uuid import UUID, uuid4
 
 import httpx
 from bolt11 import decode as bolt11_decode
 from cryptography.hazmat.primitives import serialization
 from fastapi import Depends, WebSocket
 from loguru import logger
+from passlib.context import CryptContext
 from py_vapid import Vapid
 from py_vapid.utils import b64urlencode
 
@@ -50,6 +52,8 @@ from .crud import (
     create_wallet,
     delete_wallet_payment,
     get_account,
+    get_account_by_email,
+    get_account_by_username,
     get_payments,
     get_standalone_payment,
     get_super_settings,
@@ -62,7 +66,7 @@ from .crud import (
     update_super_user,
 )
 from .helpers import to_valid_user_id
-from .models import BalanceDelta, Payment, UserConfig, Wallet
+from .models import BalanceDelta, Payment, User, UserConfig, Wallet
 
 
 class PaymentError(Exception):
@@ -773,6 +777,33 @@ async def init_admin_settings(super_user: Optional[str] = None) -> SuperSettings
     editable_settings = EditableSettings.from_dict(settings.dict())
 
     return await create_admin_settings(account.id, editable_settings.dict())
+
+
+async def create_user_account(
+    user_id: Optional[str] = None,
+    email: Optional[str] = None,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    user_config: Optional[UserConfig] = None,
+) -> User:
+    if not settings.new_accounts_allowed:
+        raise ValueError("Account creation is disabled.")
+    if username and await get_account_by_username(username):
+        raise ValueError("Username already exists.")
+
+    if email and await get_account_by_email(email):
+        raise ValueError("Email already exists.")
+
+    if user_id:
+        user_uuid4 = UUID(hex=user_id, version=4)
+        assert user_uuid4.hex == user_id, "User ID is not valid UUID4 hex string"
+    else:
+        user_id = uuid4().hex
+
+    pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    password = pwd_context.hash(password) if password else None
+
+    return await create_account(user_id, username, email, password, user_config)
 
 
 class WebsocketConnectionManager:

--- a/lnbits/core/templates/admin/_tab_server.html
+++ b/lnbits/core/templates/admin/_tab_server.html
@@ -45,56 +45,7 @@
           <br />
         </div>
       </div>
-      <div class="row q-col-gutter-md">
-        <div class="col-12 col-md-6">
-          <p>Admin Extensions</p>
-          <q-select
-            filled
-            v-model="formData.lnbits_admin_extensions"
-            multiple
-            hint="Extensions only user with admin privileges can use"
-            label="Admin extensions"
-            :options="g.extensions.map(e => e.code)"
-          ></q-select>
-          <br />
-        </div>
-        <div class="col-12 col-md-6">
-          <p>Miscellaneous</p>
-          <q-item tag="label" v-ripple>
-            <q-item-section>
-              <q-item-label>Disable Extensions</q-item-label>
-              <q-item-label caption>Disables all extensions</q-item-label>
-            </q-item-section>
-            <q-item-section avatar>
-              <q-toggle
-                size="md"
-                v-model="formData.lnbits_extensions_deactivate_all"
-                checked-icon="check"
-                color="green"
-                unchecked-icon="clear"
-              />
-            </q-item-section>
-          </q-item>
-          <q-item tag="label" v-ripple>
-            <q-item-section>
-              <q-item-label>Hide API</q-item-label>
-              <q-item-label caption
-                >Hides wallet api, extensions can choose to honor</q-item-label
-              >
-            </q-item-section>
-            <q-item-section avatar>
-              <q-toggle
-                size="md"
-                v-model="formData.lnbits_hide_api"
-                checked-icon="check"
-                color="green"
-                unchecked-icon="clear"
-              />
-            </q-item-section>
-          </q-item>
-          <br />
-        </div>
-      </div>
+
       <br />
       <h6 class="q-my-none">Service Fee</h6>
       <div class="row q-col-gutter-md">
@@ -154,32 +105,94 @@
           <br />
         </div>
       </div>
-
+      <q-separator></q-separator>
       <h6 class="q-my-none">Extensions</h6>
-      <div>
-        <p>Extension Sources</p>
-        <q-input
-          filled
-          v-model="formAddExtensionsManifest"
-          @keydown.enter="addExtensionsManifest"
-          type="text"
-          label="Source URL (only use the official LNbits extension source, and sources you can trust)"
-          hint="Repositories from where the extensions can be downloaded"
-        >
-          <q-btn @click="addExtensionsManifest" dense flat icon="add"></q-btn>
-        </q-input>
-        <div>
-          <q-chip
-            v-for="manifestUrl in formData.lnbits_extensions_manifests"
-            :key="manifestUrl"
-            removable
-            @remove="removeExtensionsManifest(manifestUrl)"
-            color="primary"
-            text-color="white"
-            ><span v-text="manifestUrl"></span
-          ></q-chip>
+      <div class="row q-col-gutter-md">
+        <div class="col-12">
+          <p>Extension Sources</p>
+          <q-input
+            filled
+            v-model="formAddExtensionsManifest"
+            @keydown.enter="addExtensionsManifest"
+            type="text"
+            label="Source URL (only use the official LNbits extension source, and sources you can trust)"
+            hint="Repositories from where the extensions can be downloaded"
+          >
+            <q-btn @click="addExtensionsManifest" dense flat icon="add"></q-btn>
+          </q-input>
+          <div>
+            <q-chip
+              v-for="manifestUrl in formData.lnbits_extensions_manifests"
+              :key="manifestUrl"
+              removable
+              @remove="removeExtensionsManifest(manifestUrl)"
+              color="primary"
+              text-color="white"
+              ><span v-text="manifestUrl"></span
+            ></q-chip>
+          </div>
         </div>
-        <br />
+      </div>
+      <div class="row q-col-gutter-md">
+        <div class="col-12 col-md-6">
+          <p>Admin Extensions</p>
+          <q-select
+            filled
+            v-model="formData.lnbits_admin_extensions"
+            multiple
+            hint="Extensions only user with admin privileges can use"
+            label="Admin extensions"
+            :options="g.extensions.map(e => e.code)"
+          ></q-select>
+        </div>
+
+        <div class="col-12 col-md-6">
+          <p>User Default Extensions</p>
+          <q-select
+            filled
+            v-model="formData.lnbits_user_default_extensions"
+            multiple
+            hint="Extensions that will be enabled by default for the users."
+            label="User extensions"
+            :options="g.extensions.map(e => e.code)"
+          ></q-select>
+        </div>
+        <div class="col-12 col-md-6">
+          <p>Miscellaneous</p>
+          <q-item tag="label" v-ripple>
+            <q-item-section>
+              <q-item-label>Disable Extensions</q-item-label>
+              <q-item-label caption>Disables all extensions</q-item-label>
+            </q-item-section>
+            <q-item-section avatar>
+              <q-toggle
+                size="md"
+                v-model="formData.lnbits_extensions_deactivate_all"
+                checked-icon="check"
+                color="green"
+                unchecked-icon="clear"
+              />
+            </q-item-section>
+          </q-item>
+          <q-item tag="label" v-ripple>
+            <q-item-section>
+              <q-item-label>Hide API</q-item-label>
+              <q-item-label caption
+                >Hides wallet api, extensions can choose to honor</q-item-label
+              >
+            </q-item-section>
+            <q-item-section avatar>
+              <q-toggle
+                size="md"
+                v-model="formData.lnbits_hide_api"
+                checked-icon="check"
+                color="green"
+                unchecked-icon="clear"
+              />
+            </q-item-section>
+          </q-item>
+          <br />
+        </div>
       </div>
     </div>
   </q-card-section>

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -37,10 +37,9 @@ from lnbits.utils.exchange_rates import (
 )
 
 from ..crud import (
-    create_account,
     create_wallet,
 )
-from ..services import perform_lnurlauth
+from ..services import create_user_account, perform_lnurlauth
 
 # backwards compatibility for extension
 # TODO: remove api_payment and pay_invoice imports from extensions
@@ -70,7 +69,7 @@ async def api_create_account(data: CreateWallet) -> Wallet:
             status_code=HTTPStatus.FORBIDDEN,
             detail="Account creation is disabled.",
         )
-    account = await create_account()
+    account = await create_user_account()
     return await create_wallet(user_id=account.id, wallet_name=data.name)
 
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -47,6 +47,7 @@ class UsersSettings(LNbitsSettings):
 
 class ExtensionsSettings(LNbitsSettings):
     lnbits_admin_extensions: list[str] = Field(default=[])
+    lnbits_user_default_extensions: list[str] = Field(default=[])
     lnbits_extensions_deactivate_all: bool = Field(default=False)
     lnbits_extensions_manifests: list[str] = Field(
         default=[


### PR DESCRIPTION
### Summary 
Have a list of extensions which are pre-enabled for the regular users.

**Steps:**
 - login as admin
 - go to: Server > Server (tab)
 - add the extensions that you want to pre-enable
 - save

![image](https://github.com/lnbits/lnbits/assets/2951406/2b6e2474-4371-46c0-bcb4-26421d30b7f7)

 - create a new user
 - the selected extensions should be enabled

![image](https://github.com/lnbits/lnbits/assets/2951406/03993464-980a-49ef-8739-a05258b35552)


Note: existing users will not get these extensions enabled by default.