### PR TITLE
fix: always create default wallet for user

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -785,6 +785,7 @@ async def create_user_account(
     email: Optional[str] = None,
     username: Optional[str] = None,
     password: Optional[str] = None,
+    wallet_name: Optional[str] = None,
     user_config: Optional[UserConfig] = None,
 ) -> User:
     if not settings.new_accounts_allowed:
@@ -805,6 +806,7 @@ async def create_user_account(
     password = pwd_context.hash(password) if password else None
 
     account = await create_account(user_id, username, email, password, user_config)
+    await create_wallet(user_id=account.id, wallet_name=wallet_name)
 
     for ext_id in settings.lnbits_user_default_extensions:
         await update_user_extension(user_id=account.id, extension=ext_id, active=True)

--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -806,7 +806,8 @@ async def create_user_account(
     password = pwd_context.hash(password) if password else None
 
     account = await create_account(user_id, username, email, password, user_config)
-    await create_wallet(user_id=account.id, wallet_name=wallet_name)
+    wallet = await create_wallet(user_id=account.id, wallet_name=wallet_name)
+    account.wallets = [wallet]
 
     for ext_id in settings.lnbits_user_default_extensions:
         await update_user_extension(user_id=account.id, extension=ext_id, active=True)

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -37,7 +37,7 @@ from lnbits.utils.exchange_rates import (
 )
 
 from ..crud import (
-    create_wallet,
+    get_wallets,
 )
 from ..services import create_user_account, perform_lnurlauth
 
@@ -69,8 +69,11 @@ async def api_create_account(data: CreateWallet) -> Wallet:
             status_code=HTTPStatus.FORBIDDEN,
             detail="Account creation is disabled.",
         )
-    account = await create_user_account()
-    return await create_wallet(user_id=account.id, wallet_name=data.name)
+    account = await create_user_account(wallet_name=data.name)
+    wallets = await get_wallets(account.id)
+    assert len(wallets) != 0, "Wallet not created for user."
+
+    return wallets[0]
 
 
 @api_router.get("/api/v1/lnurlscan/{code}")

--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -36,9 +36,6 @@ from lnbits.utils.exchange_rates import (
     satoshis_amount_as_fiat,
 )
 
-from ..crud import (
-    get_wallets,
-)
 from ..services import create_user_account, perform_lnurlauth
 
 # backwards compatibility for extension
@@ -70,10 +67,7 @@ async def api_create_account(data: CreateWallet) -> Wallet:
             detail="Account creation is disabled.",
         )
     account = await create_user_account(wallet_name=data.name)
-    wallets = await get_wallets(account.id)
-    assert len(wallets) != 0, "Wallet not created for user."
-
-    return wallets[0]
+    return account.wallets[0]
 
 
 @api_router.get("/api/v1/lnurlscan/{code}")


### PR DESCRIPTION
The default wallet was created only if the user was accessing the UI right after register.

This fix creates the default wallet also when the user is created via an API call.