### PR TITLE
add bitpay and yadio fiat rate providers + increase precision of blockchain.info fiat rate provider

### DIFF
--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -249,6 +249,20 @@ exchange_rate_providers = {
         lambda data, replacements: data["result"]["XXBTZ" + replacements["TO"]]["c"][0],
         ["czk"],
     ),
+    "bitpay": Provider(
+        "BitPay",
+        "bitpay.com",
+        "https://bitpay.com/rates",
+        lambda data, replacements: next(
+            i["rate"] for i in data["data"] if i["code"] == replacements["TO"]
+        ),
+    ),
+    "yadio": Provider(
+        "yadio",
+        "yadio.io",
+        "https://api.yadio.io/exrates/{FROM}",
+        lambda data, replacements: data[replacements["FROM"]][replacements["TO"]],
+    ),
 }
 
 

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -206,8 +206,8 @@ exchange_rate_providers = {
     "blockchain": Provider(
         "Blockchain",
         "blockchain.com",
-        "https://blockchain.info/tobtc?currency={TO}&value=1",
-        lambda data, replacements: 1 / data,
+        "https://blockchain.info/tobtc?currency={TO}&value=1000000",
+        lambda data, replacements: 1000000 / data,
     ),
     "exir": Provider(
         "Exir",


### PR DESCRIPTION
old code for CZK:

```
https://blockchain.info/tobtc?currency=CZK&value=1 -> 0.00000064
1 / 0.00000064 = 1562500.0
```

new code for CZK:

```
https://blockchain.info/tobtc?currency=CZK&value=1000000 -> 0.63594724
1000000 / 0.63594724 = 1572457.4887690367
```

---

old code for USD:

```
https://blockchain.info/tobtc?currency=USD&value=1 -> 0.00001487
1 / 0.00001487 = 67249.49562878278
```

new code for USD:

```
https://blockchain.info/tobtc?currency=USD&value=1000000 -> 14.87099547
1000000 / 14.87099547 = 67244.99392238737
```
