### PR TITLE
feat: filter response fields for `/api/v1/payments/decode`

### DIFF
--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -356,6 +356,7 @@ class Callback(BaseModel):
 
 class DecodePayment(BaseModel):
     data: str
+    filter_fields: Optional[list[str]] = []
 
 
 class CreateLnurl(BaseModel):

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -40,7 +40,7 @@ from lnbits.decorators import (
     require_admin_key,
     require_invoice_key,
 )
-from lnbits.helpers import generate_filter_params_openapi
+from lnbits.helpers import filter_dict_keys, generate_filter_params_openapi
 from lnbits.lnurl import decode as lnurl_decode
 from lnbits.settings import settings
 from lnbits.utils.exchange_rates import fiat_amount_as_satoshis
@@ -433,7 +433,8 @@ async def api_payments_decode(data: DecodePayment) -> JSONResponse:
             return JSONResponse({"domain": url})
         else:
             invoice = bolt11.decode(payment_str)
-            return JSONResponse(invoice.data)
+            filtered_data = filter_dict_keys(invoice.data, data.filter_fields)
+            return JSONResponse(filtered_data)
     except Exception as exc:
         return JSONResponse(
             {"message": f"Failed to decode: {exc!s}"},

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -226,7 +226,7 @@ def decrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
 
 
 def filter_dict_keys(data: dict, filter_fields: Optional[list[str]]) -> dict:
-    if not filter_fields or len(filter_fields) == 0:
+    if not filter_fields:
         # return shallow clone of the dict even if there are no filters
         return {**data}
     _data = {}

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -229,10 +229,4 @@ def filter_dict_keys(data: dict, filter_fields: Optional[list[str]]) -> dict:
     if not filter_fields:
         # return shallow clone of the dict even if there are no filters
         return {**data}
-    _data = {}
-    for key in filter_fields:
-        if key not in data:
-            continue
-        _data[key] = data[key]
-
-    return _data
+    return {key: data[key] for key in filter_keys if key in data}

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -225,8 +225,8 @@ def decrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
     return AESCipher(key=settings.auth_secret_key).decrypt(m)
 
 
-def filter_dict_keys(data: dict, filter_fields: Optional[list[str]]) -> dict:
-    if not filter_fields:
+def filter_dict_keys(data: dict, filter_keys: Optional[list[str]]) -> dict:
+    if not filter_keys:
         # return shallow clone of the dict even if there are no filters
         return {**data}
     return {key: data[key] for key in filter_keys if key in data}

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -225,14 +225,13 @@ def decrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
     return AESCipher(key=settings.auth_secret_key).decrypt(m)
 
 
-def filter_dict_keys(data: dict, filter: Optional[list[str]] = []) -> dict:
-    if not filter or len(filter) == 0:
+def filter_dict_keys(data: dict, filter_fields: Optional[list[str]]) -> dict:
+    if not filter_fields or len(filter_fields) == 0:
         return {**data}
     _data = {}
-    for key in filter:
+    for key in filter_fields:
         if key not in data:
             continue
         _data[key] = data[key]
 
     return _data
-

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -227,6 +227,7 @@ def decrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
 
 def filter_dict_keys(data: dict, filter_fields: Optional[list[str]]) -> dict:
     if not filter_fields or len(filter_fields) == 0:
+        # return shallow clone of the dict even if there are no filters
         return {**data}
     _data = {}
     for key in filter_fields:

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -223,3 +223,16 @@ def decrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
     if not m:
         return None
     return AESCipher(key=settings.auth_secret_key).decrypt(m)
+
+
+def filter_dict_keys(data: dict, filter: Optional[list[str]] = []) -> dict:
+    if not filter or len(filter) == 0:
+        return {**data}
+    _data = {}
+    for key in filter:
+        if key not in data:
+            continue
+        _data[key] = data[key]
+
+    return _data
+


### PR DESCRIPTION
Some devices cannot handle a large response payload.
This PR adds the `filter_fields` optional field that only includes the filtered fields. If `filter_fields` is missing or an empty list then all fields are returned.
It only filters top-level fields.

**Request**:
```curl
curl --location 'http://localhost:5000/api/v1/payments/decode' \
--header 'Content-Type: application/json' \
--data '{
    "data": "lnbc230n1pn20zexsp5yh56523hvkysgak3jyv3c4tj8jaljjwchpdr4sxfj0lf87lnshyqpp5u5enyfn0wyxmrcpdhrmc2sa3r385qdq9a2f9ntscnhvqezg334kqdq8xye8xcgcqpjrzjqvnwdyky2hw42nrsnwa5wzcv5lstkpq49amh69z9l59lxuy69qe6xrrpfyqqtlcqqgqqqqqqqqqqqzgq0q9qxpqysgqfqvvxnnd4j2s3yqn6j0xcdjf80ar76dvlrutwsalc6aevhaf6avhtlumuu3pctk3mstr0pk6e72jz5w7th5vtx5gn536z9feqsz5yuspqnahvd",
    "filter_fields": ["amount_msat", "payment_hash"]
}'
```

**Response**:
```json
{
    "amount_msat": 23000,
    "payment_hash": "e53332266f710db1e02db8f78543b11c4f403405ea9259ae189dd80c89118d6c"
}
```

![image](https://github.com/user-attachments/assets/b05d9c2d-798f-478d-9d82-d3fe82fce137)
