### PR TITLE
Set a maximium sleep time when retrying to connect to the funding source

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -206,7 +206,7 @@ async def check_funding_source() -> None:
             break
 
         retry_counter += 1
-        sleep_time = 0.25 * (2**retry_counter)
+        sleep_time = min(0.25 * (2 ** retry_counter), 60)
         logger.warning(
             f"Retrying connection to backend in {sleep_time} seconds... "
             f"({retry_counter}/{max_retries})"

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -206,7 +206,7 @@ async def check_funding_source() -> None:
             break
 
         retry_counter += 1
-        sleep_time = min(0.25 * (2 ** retry_counter), 60)
+        sleep_time = min(0.25 * (2**retry_counter), 60)
         logger.warning(
             f"Retrying connection to backend in {sleep_time} seconds... "
             f"({retry_counter}/{max_retries})"


### PR DESCRIPTION
Set a max wait time of 60 seconds. After 7 retries, all future retries will have a 60 second max wait.