### PR TITLE
feat: add generic lnurl error response handler

### DIFF
--- a/lnbits/core/services.py
+++ b/lnbits/core/services.py
@@ -25,6 +25,7 @@ from lnbits.decorators import (
     check_user_extension_access,
     require_admin_key,
 )
+from lnbits.exceptions import InvoiceError, PaymentError
 from lnbits.helpers import url_for
 from lnbits.lnurl import LnurlErrorResponse
 from lnbits.lnurl import decode as decode_lnurl
@@ -68,18 +69,6 @@ from .crud import (
 )
 from .helpers import to_valid_user_id
 from .models import BalanceDelta, Payment, PaymentState, User, UserConfig, Wallet
-
-
-class PaymentError(Exception):
-    def __init__(self, message: str, status: str = "pending"):
-        self.message = message
-        self.status = status
-
-
-class InvoiceError(Exception):
-    def __init__(self, message: str, status: str = "pending"):
-        self.message = message
-        self.status = status
 
 
 async def calculate_fiat_amounts(

--- a/lnbits/exceptions.py
+++ b/lnbits/exceptions.py
@@ -1,44 +1,16 @@
 import sys
 import traceback
 from http import HTTPStatus
-from typing import Callable, Optional
+from typing import Optional
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse, Response
-from fastapi.routing import APIRoute
 from loguru import logger
 
 from lnbits.core.services import InvoiceError, PaymentError
 
 from .helpers import template_renderer
-
-
-class LnurlErrorResponseHandler(APIRoute):
-    """
-    Custom APIRoute class to handle LNURL errors.
-    LNURL errors always return with status 200 and
-    a JSON responses with an `error` key.
-    now we can just catch the HTTPException and be sure
-    we return a JSON response with the error message.
-    """
-
-    def get_route_handler(self) -> Callable:
-        original_route_handler = super().get_route_handler()
-
-        async def custom_route_handler(request: Request) -> Response:
-            try:
-                response = await original_route_handler(request)
-                return response
-            except HTTPException as exc:
-                logger.debug(f"HTTPException: {exc}")
-                response = JSONResponse(
-                    status_code=200,
-                    content={"status": "ERROR", "reason": f"{exc.detail}"},
-                )
-                return response
-
-        return custom_route_handler
 
 
 def register_exception_handlers(app: FastAPI):

--- a/lnbits/exceptions.py
+++ b/lnbits/exceptions.py
@@ -8,9 +8,19 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse, Response
 from loguru import logger
 
-from lnbits.core.services import InvoiceError, PaymentError
-
 from .helpers import template_renderer
+
+
+class PaymentError(Exception):
+    def __init__(self, message: str, status: str = "pending"):
+        self.message = message
+        self.status = status
+
+
+class InvoiceError(Exception):
+    def __init__(self, message: str, status: str = "pending"):
+        self.message = message
+        self.status = status
 
 
 def register_exception_handlers(app: FastAPI):

--- a/lnbits/exceptions.py
+++ b/lnbits/exceptions.py
@@ -1,16 +1,44 @@
 import sys
 import traceback
 from http import HTTPStatus
-from typing import Optional
+from typing import Callable, Optional
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse, Response
+from fastapi.routing import APIRoute
 from loguru import logger
 
 from lnbits.core.services import InvoiceError, PaymentError
 
 from .helpers import template_renderer
+
+
+class LnurlErrorResponseHandler(APIRoute):
+    """
+    Custom APIRoute class to handle LNURL errors.
+    LNURL errors always return with status 200 and
+    a JSON responses with an `error` key.
+    now we can just catch the HTTPException and be sure
+    we return a JSON response with the error message.
+    """
+
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            try:
+                response = await original_route_handler(request)
+                return response
+            except HTTPException as exc:
+                logger.debug(f"HTTPException: {exc}")
+                response = JSONResponse(
+                    status_code=200,
+                    content={"status": "ERROR", "reason": f"{exc.detail}"},
+                )
+                return response
+
+        return custom_route_handler
 
 
 def register_exception_handlers(app: FastAPI):

--- a/lnbits/lnurl.py
+++ b/lnbits/lnurl.py
@@ -1,1 +1,42 @@
-from lnurl import LnurlErrorResponse, decode, encode, handle  # noqa: F401
+from typing import Callable
+
+from fastapi import HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
+from lnurl import LnurlErrorResponse, decode, encode, handle
+from loguru import logger
+
+
+class LnurlErrorResponseHandler(APIRoute):
+    """
+    Custom APIRoute class to handle LNURL errors.
+    LNURL errors always return with status 200 and
+    a JSON response with `status="ERROR"` and a `reason` key.
+    Helps to catch HTTPException and return a valid lnurl error response
+    """
+
+    def get_route_handler(self) -> Callable:
+        original_route_handler = super().get_route_handler()
+
+        async def custom_route_handler(request: Request) -> Response:
+            try:
+                response = await original_route_handler(request)
+                return response
+            except HTTPException as exc:
+                logger.debug(f"HTTPException: {exc}")
+                response = JSONResponse(
+                    status_code=200,
+                    content={"status": "ERROR", "reason": f"{exc.detail}"},
+                )
+                return response
+
+        return custom_route_handler
+
+
+__all__ = [
+    "decode",
+    "encode",
+    "handle",
+    "LnurlErrorResponse",
+    "LnurlErrorResponseHandler",
+]

--- a/lnbits/lnurl.py
+++ b/lnbits/lnurl.py
@@ -24,7 +24,7 @@ class LnurlErrorResponseHandler(APIRoute):
     def get_route_handler(self) -> Callable:
         original_route_handler = super().get_route_handler()
 
-        async def custom_route_handler(request: Request) -> Response:
+        async def lnurl_route_handler(request: Request) -> Response:
             try:
                 response = await original_route_handler(request)
                 return response
@@ -42,8 +42,18 @@ class LnurlErrorResponseHandler(APIRoute):
                     content={"status": "ERROR", "reason": f"{exc.detail}"},
                 )
                 return response
+            except Exception as exc:
+                logger.error("Unknown Error:", exc)
+                response = JSONResponse(
+                    status_code=200,
+                    content={
+                        "status": "ERROR",
+                        "reason": f"UNKNOWN ERROR: {exc!s}",
+                    },
+                )
+                return response
 
-        return custom_route_handler
+        return lnurl_route_handler
 
 
 __all__ = [

--- a/lnbits/lnurl.py
+++ b/lnbits/lnurl.py
@@ -13,6 +13,10 @@ class LnurlErrorResponseHandler(APIRoute):
     LNURL errors always return with status 200 and
     a JSON response with `status="ERROR"` and a `reason` key.
     Helps to catch HTTPException and return a valid lnurl error response
+
+    Example:
+    withdraw_lnurl_router = APIRouter(prefix="/api/v1/lnurl")
+    withdraw_lnurl_router.route_class = LnurlErrorResponseHandler
     """
 
     def get_route_handler(self) -> Callable:

--- a/lnbits/lnurl.py
+++ b/lnbits/lnurl.py
@@ -6,7 +6,7 @@ from fastapi.routing import APIRoute
 from lnurl import LnurlErrorResponse, decode, encode, handle
 from loguru import logger
 
-from lnbits.core.services import InvoiceError, PaymentError
+from lnbits.exceptions import InvoiceError, PaymentError
 
 
 class LnurlErrorResponseHandler(APIRoute):

--- a/lnbits/lnurl.py
+++ b/lnbits/lnurl.py
@@ -6,7 +6,7 @@ from fastapi.routing import APIRoute
 from lnurl import LnurlErrorResponse, decode, encode, handle
 from loguru import logger
 
-from lnbits.exceptions import InvoiceError, PaymentError
+from lnbits.core.services import InvoiceError, PaymentError
 
 
 class LnurlErrorResponseHandler(APIRoute):


### PR DESCRIPTION
this is used multiple times in extensions to safeguard `views_lnurl.py` endpoint to not return a wrong lnurl error response.

you use it by just setting following on your lnurl router/view

```
withdraw_ext_lnurl = APIRouter(prefix="/api/v1/lnurl")
withdraw_ext_lnurl.route_class = LNURLErrorResponseHandler
```