### PR TITLE
feat: add baseurl to admin ui settings

### DIFF
--- a/lnbits/core/templates/admin/_tab_server.html
+++ b/lnbits/core/templates/admin/_tab_server.html
@@ -9,8 +9,7 @@
           <q-input
             filled
             v-model.number="formData.lnbits_baseurl"
-            label="Base URL"
-            hint="WARNING: new feature not used everywhere yet"
+            label="Static/Base url for the server"
           ></q-input>
           <br />
         </div>

--- a/lnbits/core/templates/admin/_tab_server.html
+++ b/lnbits/core/templates/admin/_tab_server.html
@@ -4,6 +4,16 @@
     <br />
     <div>
       <div class="row">
+        <div class="col-md-6">
+          <p>Base URL</p>
+          <q-input
+            filled
+            v-model.number="formData.lnbits_baseurl"
+            label="Base URL"
+            hint="WARNING: new feature not used everywhere yet"
+          ></q-input>
+          <br />
+        </div>
         <div class="col">
           <p>Server Info</p>
           <ul>

--- a/lnbits/core/templates/admin/_tab_server.html
+++ b/lnbits/core/templates/admin/_tab_server.html
@@ -1,7 +1,6 @@
 <q-tab-panel name="server">
   <q-card-section class="q-pa-none">
     <h6 class="q-my-none">Server Management</h6>
-    <br />
     <div>
       <div class="row">
         <div class="col-md-6">
@@ -13,21 +12,8 @@
           ></q-input>
           <br />
         </div>
-        <div class="col">
-          <p>Server Info</p>
-          <ul>
-            <li
-              v-if="settings.lnbits_data_folder"
-              v-text="'SQlite: ' + settings.lnbits_data_folder"
-            ></li>
-            <li
-              v-if="settings.lnbits_database_url"
-              v-text="'Postgres: ' + settings.lnbits_database_url"
-            ></li>
-          </ul>
-          <br />
-        </div>
       </div>
+      <h6 class="q-my-none">Currency Settings</h6>
       <div class="row q-col-gutter-md">
         <div class="col-12 col-md-6">
           <p>Allowed currencies</p>


### PR DESCRIPTION
server tab with a hint that it is currently not used.

i ran into an issue developing an extension where i needed to know the url inside a task, where i cannot pass the `Request` object. so i depend on `settings.lnbits_baseurl` there