### PR TITLE
fix: add proper validation for the unit field when creating an invoice

### DIFF
--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -12,12 +12,13 @@ from typing import Callable, Optional
 
 from ecdsa import SECP256k1, SigningKey
 from fastapi import Query
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from lnbits.db import FilterModel, FromRowModel
 from lnbits.helpers import url_for
 from lnbits.lnurl import encode as lnurl_encode
 from lnbits.settings import settings
+from lnbits.utils.exchange_rates import allowed_currencies
 from lnbits.wallets import get_funding_source
 from lnbits.wallets.base import (
     PaymentPendingStatus,
@@ -381,6 +382,14 @@ class CreateInvoice(BaseModel):
     webhook: Optional[str] = None
     bolt11: Optional[str] = None
     lnurl_callback: Optional[str] = None
+
+    @validator("unit")
+    @classmethod
+    def unit_is_from_allowed_currencies(cls, v):
+        if v != "sat" and v not in allowed_currencies():
+            raise ValueError("The provided unit is not supported")
+
+        return v
 
 
 class CreateTopup(BaseModel):

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -150,6 +150,21 @@ async def test_create_invoice_fiat_amount(client, inkey_headers_to):
     assert extra["fiat_rate"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("currency", ("msat", "RRR"))
+async def test_create_invoice_validates_used_currency(
+    currency, client, inkey_headers_to
+):
+    data = await get_random_invoice_data()
+    data["unit"] = currency
+    response = await client.post(
+        "/api/v1/payments", json=data, headers=inkey_headers_to
+    )
+    assert response.status_code == 400
+    res_data = response.json()
+    assert "The provided unit is not supported" in res_data["detail"]
+
+
 # check POST /api/v1/payments: invoice creation for internal payments only
 @pytest.mark.asyncio
 async def test_create_internal_invoice(client, inkey_headers_to):


### PR DESCRIPTION
Addresses:  #2642 

The issue states that when an invoice is created using `msat` as a unit, the `sat` value is not calculated properly. Which is, in fact, true. 

Looking deeper at the code, we can see [`api_payments_create_invoice`](https://github.com/lnbits/lnbits/blob/65ecca2507fb474398504d1c792eb08a04666a6f/lnbits/core/views/payment_api.py#L125) relies on [`create_invoice`](https://github.com/lnbits/lnbits/blob/65ecca2507fb474398504d1c792eb08a04666a6f/lnbits/core/services.py#L123) to create the actual invoice, and that the latter uses [`calculate_fiat_amounts`](https://github.com/lnbits/lnbits/blob/65ecca2507fb474398504d1c792eb08a04666a6f/lnbits/core/services.py#L85) to get the amount in `sats` regardless of the selected unit/currency. 

`calculate_fiat_amounts` only supports the currency parameter value to be `sats` or any of the existing fiat currencies.

This PR, adds proper validation to the endpoint in order to:

1. Make the user aware that the supplied currency is not supported
2. Avoid creating invoices with wrong amounts when the user provides a nonexistent currency. Leading to other kinds of problems.