### PR TITLE
feat: explicitly export for extensions from `__init__.py`

### DIFF
--- a/lnbits/__init__.py
+++ b/lnbits/__init__.py
@@ -1,0 +1,24 @@
+from .core.exceptions import InvoiceError, PaymentError
+from .core.services import create_invoice, pay_invoice
+from .decorators import (
+    check_admin,
+    check_super_user,
+    check_user_exists,
+    require_admin_key,
+    require_user_key,
+)
+
+__all__ = [
+    # decorators
+    "require_admin_key",
+    "require_user_key",
+    "check_admin",
+    "check_super_user",
+    "check_user_exists",
+    # services
+    "pay_invoice",
+    "create_invoice",
+    # exceptions
+    "PaymentError",
+    "InvoiceError",
+]

--- a/lnbits/__init__.py
+++ b/lnbits/__init__.py
@@ -1,17 +1,17 @@
-from .core.exceptions import InvoiceError, PaymentError
 from .core.services import create_invoice, pay_invoice
 from .decorators import (
     check_admin,
     check_super_user,
     check_user_exists,
     require_admin_key,
-    require_user_key,
+    require_invoice_key,
 )
+from .exceptions import InvoiceError, PaymentError
 
 __all__ = [
     # decorators
     "require_admin_key",
-    "require_user_key",
+    "require_invoice_key",
     "check_admin",
     "check_super_user",
     "check_user_exists",


### PR DESCRIPTION
makes it clear what extensions are expected to use and also makes future changes to the structure of core safer because extension can just depend on ```from lnbits import require_admin_key``` for example.

TODO: still couple of exports from `crud.py` are missing, still thinking about making proper services.py fn's instead of extension import from core crud