### PR TITLE
Fix overlapping redirect paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,8 @@ fly.toml
 lnbits-backup.zip
 
 # Ignore extensions (post installable extension PR)
-extensions
-upgrades/
+/extensions
+/upgrades/
 
 # builded python package
 dist

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -383,13 +383,7 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
 
     if hasattr(ext_module, f"{ext.code}_redirect_paths"):
         ext_redirects = getattr(ext_module, f"{ext.code}_redirect_paths")
-        print("### ext_redirects", ext.code, ext_redirects)
-        print("### lnbits_extensions_redirects 0", settings.lnbits_extensions_redirects)
-
-        print("### lnbits_extensions_redirects 1", settings.lnbits_extensions_redirects)
         activate_extension_settings(ext.code, ext_redirects)
-
-        print("### lnbits_extensions_redirects 2", settings.lnbits_extensions_redirects)
 
     logger.trace(f"adding route for extension {ext_module}")
 

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -17,6 +17,7 @@ from slowapi.util import get_remote_address
 from starlette.middleware.sessions import SessionMiddleware
 
 from lnbits.core.crud import (
+    add_installed_extension,
     get_dbversions,
     get_installed_extensions,
     update_installed_extension_state,
@@ -48,7 +49,6 @@ from .core import init_core_routers
 from .core.db import core_app_extra
 from .core.extensions.models import Extension, InstallableExtension
 from .core.services import check_admin_settings, check_webpush_settings
-from .core.views.extension_api import add_installed_extension
 from .middleware import (
     CustomGZipMiddleware,
     ExtensionsRedirectMiddleware,

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -49,7 +49,6 @@ from .core.views.extension_api import add_installed_extension
 from .extension_manager import (
     Extension,
     InstallableExtension,
-    activate_extension_paths,
     get_valid_extensions,
     version_parse,
 )
@@ -383,7 +382,7 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
 
     if hasattr(ext_module, f"{ext.code}_redirect_paths"):
         ext_redirects = getattr(ext_module, f"{ext.code}_redirect_paths")
-        activate_extension_paths(ext.code, ext_redirects)
+        settings.activate_extension_paths(ext.code, ext_redirects)
 
     logger.trace(f"adding route for extension {ext_module}")
 

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -21,6 +21,8 @@ from lnbits.core.crud import (
     get_installed_extensions,
     update_installed_extension_state,
 )
+from lnbits.core.extensions.extension_manager import get_valid_extensions
+from lnbits.core.extensions.helpers import version_parse
 from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.tasks import (  # watchdog_task
     killswitch_task,
@@ -44,14 +46,9 @@ from lnbits.wallets import get_funding_source, set_funding_source
 from .commands import migrate_databases
 from .core import init_core_routers
 from .core.db import core_app_extra
+from .core.extensions.models import Extension, InstallableExtension
 from .core.services import check_admin_settings, check_webpush_settings
 from .core.views.extension_api import add_installed_extension
-from .extension_manager import (
-    Extension,
-    InstallableExtension,
-    get_valid_extensions,
-    version_parse,
-)
 from .middleware import (
     CustomGZipMiddleware,
     ExtensionsRedirectMiddleware,

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -49,6 +49,7 @@ from .core.views.extension_api import add_installed_extension
 from .extension_manager import (
     Extension,
     InstallableExtension,
+    activate_extension_settings,
     get_valid_extensions,
     version_parse,
 )
@@ -382,12 +383,13 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
 
     if hasattr(ext_module, f"{ext.code}_redirect_paths"):
         ext_redirects = getattr(ext_module, f"{ext.code}_redirect_paths")
-        settings.lnbits_extensions_redirects = [
-            r for r in settings.lnbits_extensions_redirects if r["ext_id"] != ext.code
-        ]
-        for r in ext_redirects:
-            r["ext_id"] = ext.code
-            settings.lnbits_extensions_redirects.append(r)
+        print("### ext_redirects", ext.code, ext_redirects)
+        print("### lnbits_extensions_redirects 0", settings.lnbits_extensions_redirects)
+
+        print("### lnbits_extensions_redirects 1", settings.lnbits_extensions_redirects)
+        activate_extension_settings(ext.code, ext_redirects)
+
+        print("### lnbits_extensions_redirects 2", settings.lnbits_extensions_redirects)
 
     logger.trace(f"adding route for extension {ext_module}")
 

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -21,7 +21,6 @@ from lnbits.core.crud import (
     get_installed_extensions,
     update_installed_extension_state,
 )
-from lnbits.core.extensions.extension_manager import get_valid_extensions
 from lnbits.core.extensions.helpers import version_parse
 from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.tasks import (  # watchdog_task
@@ -389,7 +388,7 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
 
 async def check_and_register_extensions(app: FastAPI):
     await check_installed_extensions(app)
-    for ext in get_valid_extensions(False):
+    for ext in Extension.get_valid_extensions(False):
         try:
             register_ext_routes(app, ext)
         except Exception as exc:

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -21,6 +21,7 @@ from lnbits.core.crud import (
     get_installed_extensions,
     update_installed_extension_state,
 )
+from lnbits.core.extensions.extension_manager import deactivate_extension
 from lnbits.core.extensions.helpers import version_parse
 from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.tasks import (  # watchdog_task
@@ -239,6 +240,7 @@ async def check_installed_extensions(app: FastAPI):
                 )
         except Exception as e:
             logger.warning(e)
+            await deactivate_extension(ext)
             logger.warning(
                 f"Failed to re-install extension: {ext.id} ({ext.installed_version})"
             )

--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -49,7 +49,7 @@ from .core.views.extension_api import add_installed_extension
 from .extension_manager import (
     Extension,
     InstallableExtension,
-    activate_extension_settings,
+    activate_extension_paths,
     get_valid_extensions,
     version_parse,
 )
@@ -383,7 +383,7 @@ def register_ext_routes(app: FastAPI, ext: Extension) -> None:
 
     if hasattr(ext_module, f"{ext.code}_redirect_paths"):
         ext_redirects = getattr(ext_module, f"{ext.code}_redirect_paths")
-        activate_extension_settings(ext.code, ext_redirects)
+        activate_extension_paths(ext.code, ext_redirects)
 
     logger.trace(f"adding route for extension {ext_module}")
 

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -26,7 +26,7 @@ from lnbits.core.crud import (
     update_payment_status,
 )
 from lnbits.core.helpers import migrate_databases
-from lnbits.core.models import Payment, PaymentState, User
+from lnbits.core.models import Payment, PaymentState
 from lnbits.core.services import check_admin_settings
 from lnbits.core.views.extension_api import (
     api_install_extension,
@@ -611,7 +611,7 @@ async def _call_install_extension(
             )
             resp.raise_for_status()
     else:
-        await api_install_extension(data, User(id="mock_id"))
+        await api_install_extension(data)
 
 
 async def _call_uninstall_extension(
@@ -625,7 +625,7 @@ async def _call_uninstall_extension(
             )
             resp.raise_for_status()
     else:
-        await api_uninstall_extension(extension, User(id="mock_id"))
+        await api_uninstall_extension(extension)
 
 
 async def _can_run_operation(url) -> bool:

--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -25,17 +25,17 @@ from lnbits.core.crud import (
     remove_deleted_wallets,
     update_payment_status,
 )
+from lnbits.core.extensions.models import (
+    CreateExtension,
+    ExtensionRelease,
+    InstallableExtension,
+)
 from lnbits.core.helpers import migrate_databases
 from lnbits.core.models import Payment, PaymentState
 from lnbits.core.services import check_admin_settings
 from lnbits.core.views.extension_api import (
     api_install_extension,
     api_uninstall_extension,
-)
-from lnbits.extension_manager import (
-    CreateExtension,
-    ExtensionRelease,
-    InstallableExtension,
 )
 from lnbits.settings import settings
 from lnbits.wallets.base import Wallet

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -8,14 +8,14 @@ import shortuuid
 from passlib.context import CryptContext
 
 from lnbits.core.db import db
-from lnbits.core.models import PaymentState
-from lnbits.db import DB_TYPE, SQLITE, Connection, Database, Filters, Page
-from lnbits.extension_manager import (
+from lnbits.core.extensions.models import (
     InstallableExtension,
     PayToEnableInfo,
     UserExtension,
     UserExtensionInfo,
 )
+from lnbits.core.models import PaymentState
+from lnbits.db import DB_TYPE, SQLITE, Connection, Database, Filters, Page
 from lnbits.settings import (
     AdminSettings,
     EditableSettings,

--- a/lnbits/core/crud.py
+++ b/lnbits/core/crud.py
@@ -430,7 +430,7 @@ async def get_installed_extension(
 async def get_installed_extensions(
     active: Optional[bool] = None,
     conn: Optional[Connection] = None,
-) -> List["InstallableExtension"]:
+) -> List[InstallableExtension]:
     rows = await (conn or db).fetchall(
         "SELECT * FROM installed_extensions",
         (),

--- a/lnbits/core/extensions/extension_manager.py
+++ b/lnbits/core/extensions/extension_manager.py
@@ -7,17 +7,26 @@ from lnbits.core.crud import (
     get_installed_extension,
     update_installed_extension_state,
 )
+from lnbits.core.db import core_app_extra
 from lnbits.settings import settings
 
 from .models import Extension
 
 
-async def activate_extension(ext_id: str):
-    settings.activate_extension_paths(ext_id)
-    await update_installed_extension_state(ext_id=ext_id, active=True)
+async def try_activate_extension(ext: Extension):
+    try:
+        await activate_extension(ext)
+    except Exception as exc:
+        logger.warning(exc)
+        await deactivate_extension(ext.code)
 
 
-async def deactivate_extension(ext_id):
+async def activate_extension(ext: Extension):
+    core_app_extra.register_new_ext_routes(ext)
+    await update_installed_extension_state(ext_id=ext.code, active=True)
+
+
+async def deactivate_extension(ext_id: str):
     settings.deactivate_extension_paths(ext_id)
     await update_installed_extension_state(ext_id=ext_id, active=False)
 

--- a/lnbits/core/extensions/extension_manager.py
+++ b/lnbits/core/extensions/extension_manager.py
@@ -40,7 +40,7 @@ async def stop_extension_background_work(ext_id) -> bool:
     Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
     Extensions SHOULD expose a `api_stop()` function.
     """
-    upgrade_hash = settings.extension_upgrade_hash(ext_id) or ""
+    upgrade_hash = settings.lnbits_upgraded_extensions.get(ext_id, "")
     ext = Extension(ext_id, True, False, upgrade_hash=upgrade_hash)
 
     try:

--- a/lnbits/core/extensions/extension_manager.py
+++ b/lnbits/core/extensions/extension_manager.py
@@ -11,21 +11,7 @@ from lnbits.core.crud import (
 )
 from lnbits.settings import settings
 
-from .helpers import github_api_get
-from .models import Extension, ExtensionConfig
-
-# All subdirectories in the current directory, not recursive.
-
-
-async def fetch_github_release_config(
-    org: str, repo: str, tag_name: str
-) -> Optional[ExtensionConfig]:
-    config_url = (
-        f"https://raw.githubusercontent.com/{org}/{repo}/{tag_name}/config.json"
-    )
-    error_msg = "Cannot fetch GitHub extension config"
-    config = await github_api_get(config_url, error_msg)
-    return ExtensionConfig.parse_obj(config)
+from .models import Extension
 
 
 async def fetch_release_details(details_link: str) -> Optional[dict]:

--- a/lnbits/core/extensions/extension_manager.py
+++ b/lnbits/core/extensions/extension_manager.py
@@ -1,0 +1,145 @@
+import importlib
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import httpx
+from loguru import logger
+
+from lnbits.core.crud import delete_installed_extension, get_installed_extension
+from lnbits.settings import settings
+
+from .helpers import github_api_get
+from .models import Extension, ExtensionConfig
+
+# All subdirectories in the current directory, not recursive.
+
+
+class ExtensionManager:
+    def __init__(self) -> None:
+        p = Path(settings.lnbits_extensions_path, "extensions")
+        Path(p).mkdir(parents=True, exist_ok=True)
+        self._extension_folders: List[Path] = [f for f in p.iterdir() if f.is_dir()]
+
+    @property
+    def extensions(self) -> List[Extension]:
+        # todo: remove this property somehow, it is too expensive
+        output: List[Extension] = []
+
+        for extension_folder in self._extension_folders:
+            extension_code = extension_folder.parts[-1]
+            try:
+                with open(extension_folder / "config.json") as json_file:
+                    config = json.load(json_file)
+                is_valid = True
+                is_admin_only = extension_code in settings.lnbits_admin_extensions
+            except Exception:
+                config = {}
+                is_valid = False
+                is_admin_only = False
+
+            output.append(
+                Extension(
+                    extension_code,
+                    is_valid,
+                    is_admin_only,
+                    config.get("name"),
+                    config.get("short_description"),
+                    config.get("tile"),
+                    config.get("contributors"),
+                    config.get("hidden") or False,
+                    config.get("migration_module"),
+                    config.get("db_name"),
+                )
+            )
+
+        return output
+
+
+async def fetch_github_release_config(
+    org: str, repo: str, tag_name: str
+) -> Optional[ExtensionConfig]:
+    config_url = (
+        f"https://raw.githubusercontent.com/{org}/{repo}/{tag_name}/config.json"
+    )
+    error_msg = "Cannot fetch GitHub extension config"
+    config = await github_api_get(config_url, error_msg)
+    return ExtensionConfig.parse_obj(config)
+
+
+async def fetch_release_details(details_link: str) -> Optional[dict]:
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(details_link)
+            resp.raise_for_status()
+            data = resp.json()
+            if "description_md" in data:
+                resp = await client.get(data["description_md"])
+                if not resp.is_error:
+                    data["description_md"] = resp.text
+
+            return data
+    except Exception as e:
+        logger.warning(e)
+        return None
+
+
+async def uninstall_extension(ext_id):
+    await stop_extension_background_work(ext_id)
+
+    settings.lnbits_deactivated_extensions.add(ext_id)
+
+    extension = await get_installed_extension(ext_id)
+    if extension:
+        extension.clean_extension_files()
+    await delete_installed_extension(ext_id=ext_id)
+
+
+async def stop_extension_background_work(ext_id) -> bool:
+    """
+    Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
+    Extensions SHOULD expose a `api_stop()` function.
+    """
+    upgrade_hash = settings.extension_upgrade_hash(ext_id) or ""
+    ext = Extension(ext_id, True, False, upgrade_hash=upgrade_hash)
+
+    try:
+        logger.info(f"Stopping background work for extension '{ext.module_name}'.")
+        old_module = importlib.import_module(ext.module_name)
+
+        # Extensions must expose an `{ext_id}_stop()` function at the module level
+        # The `api_stop()` function is for backwards compatibility (will be deprecated)
+        stop_fns = [f"{ext_id}_stop", "api_stop"]
+        stop_fn_name = next((fn for fn in stop_fns if hasattr(old_module, fn)), None)
+        assert stop_fn_name, "No stop function found for '{ext.module_name}'"
+
+        stop_fn = getattr(old_module, stop_fn_name)
+        if stop_fn:
+            await stop_fn()
+
+        logger.info(f"Stopped background work for extension '{ext.module_name}'.")
+    except Exception as ex:
+        logger.warning(f"Failed to stop background work for '{ext.module_name}'.")
+        logger.warning(ex)
+        return False
+
+    return True
+
+
+def get_valid_extensions(include_deactivated: Optional[bool] = True) -> List[Extension]:
+    valid_extensions = [
+        extension for extension in ExtensionManager().extensions if extension.is_valid
+    ]
+
+    if include_deactivated:
+        return valid_extensions
+
+    if settings.lnbits_extensions_deactivate_all:
+        return []
+
+    return [
+        e
+        for e in valid_extensions
+        if e.code not in settings.lnbits_deactivated_extensions
+    ]

--- a/lnbits/core/extensions/extension_manager.py
+++ b/lnbits/core/extensions/extension_manager.py
@@ -1,7 +1,5 @@
 import importlib
-from typing import Optional
 
-import httpx
 from loguru import logger
 
 from lnbits.core.crud import (
@@ -12,24 +10,6 @@ from lnbits.core.crud import (
 from lnbits.settings import settings
 
 from .models import Extension
-
-
-async def fetch_release_details(details_link: str) -> Optional[dict]:
-
-    try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(details_link)
-            resp.raise_for_status()
-            data = resp.json()
-            if "description_md" in data:
-                resp = await client.get(data["description_md"])
-                if not resp.is_error:
-                    data["description_md"] = resp.text
-
-            return data
-    except Exception as e:
-        logger.warning(e)
-        return None
 
 
 async def activate_extension(ext_id: str):

--- a/lnbits/core/extensions/extension_manager.py
+++ b/lnbits/core/extensions/extension_manager.py
@@ -4,7 +4,11 @@ from typing import Optional
 import httpx
 from loguru import logger
 
-from lnbits.core.crud import delete_installed_extension, get_installed_extension
+from lnbits.core.crud import (
+    delete_installed_extension,
+    get_installed_extension,
+    update_installed_extension_state,
+)
 from lnbits.settings import settings
 
 from .helpers import github_api_get
@@ -40,6 +44,16 @@ async def fetch_release_details(details_link: str) -> Optional[dict]:
     except Exception as e:
         logger.warning(e)
         return None
+
+
+async def activate_extension(ext_id: str):
+    settings.activate_extension_paths(ext_id)
+    await update_installed_extension_state(ext_id=ext_id, active=True)
+
+
+async def deactivate_extension(ext_id):
+    settings.deactivate_extension_paths(ext_id)
+    await update_installed_extension_state(ext_id=ext_id, active=False)
 
 
 async def uninstall_extension(ext_id):

--- a/lnbits/core/extensions/helpers.py
+++ b/lnbits/core/extensions/helpers.py
@@ -1,0 +1,56 @@
+import hashlib
+from typing import Any, Optional
+from urllib import request
+
+import httpx
+from loguru import logger
+from packaging import version
+
+from lnbits.settings import settings
+
+
+def version_parse(v: str):
+    """
+    Wrapper for version.parse() that does not throw if the version is invalid.
+    Instead it return the lowest possible version ("0.0.0")
+    """
+    try:
+        return version.parse(v)
+    except Exception:
+        return version.parse("0.0.0")
+
+
+async def github_api_get(url: str, error_msg: Optional[str]) -> Any:
+    headers = {"User-Agent": settings.user_agent}
+    if settings.lnbits_ext_github_token:
+        headers["Authorization"] = f"Bearer {settings.lnbits_ext_github_token}"
+    async with httpx.AsyncClient(headers=headers) as client:
+        resp = await client.get(url)
+        if resp.status_code != 200:
+            logger.warning(f"{error_msg} ({url}): {resp.text}")
+        resp.raise_for_status()
+        return resp.json()
+
+
+def download_url(url, save_path):
+    with request.urlopen(url, timeout=60) as dl_file:
+        with open(save_path, "wb") as out_file:
+            out_file.write(dl_file.read())
+
+
+def file_hash(filename):
+    h = hashlib.sha256()
+    b = bytearray(128 * 1024)
+    mv = memoryview(b)
+    with open(filename, "rb", buffering=0) as f:
+        while n := f.readinto(mv):
+            h.update(mv[:n])
+    return h.hexdigest()
+
+
+def icon_to_github_url(source_repo: str, path: Optional[str]) -> str:
+    if not path:
+        return ""
+    _, _, *rest = path.split("/")
+    tail = "/".join(rest)
+    return f"https://github.com/{source_repo}/raw/main/{tail}"

--- a/lnbits/core/extensions/models.py
+++ b/lnbits/core/extensions/models.py
@@ -346,6 +346,24 @@ class ExtensionRelease(BaseModel):
         releases = await github_api_get(releases_url, error_msg)
         return [GitHubRepoRelease.parse_obj(r) for r in releases]
 
+    @classmethod
+    async def fetch_release_details(cls, details_link: str) -> Optional[dict]:
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(details_link)
+                resp.raise_for_status()
+                data = resp.json()
+                if "description_md" in data:
+                    resp = await client.get(data["description_md"])
+                    if not resp.is_error:
+                        data["description_md"] = resp.text
+
+                return data
+        except Exception as e:
+            logger.warning(e)
+            return None
+
 
 class InstallableExtension(BaseModel):
     id: str

--- a/lnbits/core/extensions/models.py
+++ b/lnbits/core/extensions/models.py
@@ -1,6 +1,5 @@
 import asyncio
 import hashlib
-import importlib
 import json
 import os
 import shutil
@@ -8,15 +7,20 @@ import sys
 import zipfile
 from pathlib import Path
 from typing import Any, List, NamedTuple, Optional, Tuple
-from urllib import request
 
 import httpx
 from loguru import logger
-from packaging import version
 from pydantic import BaseModel
 
-from lnbits.core.crud import delete_installed_extension, get_installed_extension
 from lnbits.settings import settings
+
+from .helpers import (
+    download_url,
+    file_hash,
+    github_api_get,
+    icon_to_github_url,
+    version_parse,
+)
 
 
 class ExplicitRelease(BaseModel):
@@ -124,124 +128,6 @@ class UserExtension(BaseModel):
         return ext
 
 
-def download_url(url, save_path):
-    with request.urlopen(url, timeout=60) as dl_file:
-        with open(save_path, "wb") as out_file:
-            out_file.write(dl_file.read())
-
-
-def file_hash(filename):
-    h = hashlib.sha256()
-    b = bytearray(128 * 1024)
-    mv = memoryview(b)
-    with open(filename, "rb", buffering=0) as f:
-        while n := f.readinto(mv):
-            h.update(mv[:n])
-    return h.hexdigest()
-
-
-async def fetch_github_repo_info(
-    org: str, repository: str
-) -> Tuple[GitHubRepo, GitHubRepoRelease, ExtensionConfig]:
-    repo_url = f"https://api.github.com/repos/{org}/{repository}"
-    error_msg = "Cannot fetch extension repo"
-    repo = await github_api_get(repo_url, error_msg)
-    github_repo = GitHubRepo.parse_obj(repo)
-
-    lates_release_url = (
-        f"https://api.github.com/repos/{org}/{repository}/releases/latest"
-    )
-    error_msg = "Cannot fetch extension releases"
-    latest_release: Any = await github_api_get(lates_release_url, error_msg)
-
-    config_url = f"https://raw.githubusercontent.com/{org}/{repository}/{github_repo.default_branch}/config.json"
-    error_msg = "Cannot fetch config for extension"
-    config = await github_api_get(config_url, error_msg)
-
-    return (
-        github_repo,
-        GitHubRepoRelease.parse_obj(latest_release),
-        ExtensionConfig.parse_obj(config),
-    )
-
-
-async def fetch_manifest(url) -> Manifest:
-    error_msg = "Cannot fetch extensions manifest"
-    manifest = await github_api_get(url, error_msg)
-    return Manifest.parse_obj(manifest)
-
-
-async def fetch_github_releases(org: str, repo: str) -> List[GitHubRepoRelease]:
-    releases_url = f"https://api.github.com/repos/{org}/{repo}/releases"
-    error_msg = "Cannot fetch extension releases"
-    releases = await github_api_get(releases_url, error_msg)
-    return [GitHubRepoRelease.parse_obj(r) for r in releases]
-
-
-async def fetch_github_release_config(
-    org: str, repo: str, tag_name: str
-) -> Optional[ExtensionConfig]:
-    config_url = (
-        f"https://raw.githubusercontent.com/{org}/{repo}/{tag_name}/config.json"
-    )
-    error_msg = "Cannot fetch GitHub extension config"
-    config = await github_api_get(config_url, error_msg)
-    return ExtensionConfig.parse_obj(config)
-
-
-async def github_api_get(url: str, error_msg: Optional[str]) -> Any:
-    headers = {"User-Agent": settings.user_agent}
-    if settings.lnbits_ext_github_token:
-        headers["Authorization"] = f"Bearer {settings.lnbits_ext_github_token}"
-    async with httpx.AsyncClient(headers=headers) as client:
-        resp = await client.get(url)
-        if resp.status_code != 200:
-            logger.warning(f"{error_msg} ({url}): {resp.text}")
-        resp.raise_for_status()
-        return resp.json()
-
-
-async def fetch_release_payment_info(
-    url: str, amount: Optional[int] = None
-) -> Optional[ReleasePaymentInfo]:
-    if amount:
-        url = f"{url}?amount={amount}"
-    try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(url)
-            resp.raise_for_status()
-            return ReleasePaymentInfo(**resp.json())
-    except Exception as e:
-        logger.warning(e)
-        return None
-
-
-async def fetch_release_details(details_link: str) -> Optional[dict]:
-
-    try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(details_link)
-            resp.raise_for_status()
-            data = resp.json()
-            if "description_md" in data:
-                resp = await client.get(data["description_md"])
-                if not resp.is_error:
-                    data["description_md"] = resp.text
-
-            return data
-    except Exception as e:
-        logger.warning(e)
-        return None
-
-
-def icon_to_github_url(source_repo: str, path: Optional[str]) -> str:
-    if not path:
-        return ""
-    _, _, *rest = path.split("/")
-    tail = "/".join(rest)
-    return f"https://github.com/{source_repo}/raw/main/{tail}"
-
-
 class Extension(NamedTuple):
     code: str
     is_valid: bool
@@ -281,50 +167,6 @@ class Extension(NamedTuple):
         )
 
 
-# All subdirectories in the current directory, not recursive.
-
-
-class ExtensionManager:
-    def __init__(self) -> None:
-        p = Path(settings.lnbits_extensions_path, "extensions")
-        Path(p).mkdir(parents=True, exist_ok=True)
-        self._extension_folders: List[Path] = [f for f in p.iterdir() if f.is_dir()]
-
-    @property
-    def extensions(self) -> List[Extension]:
-        # todo: remove this property somehow, it is too expensive
-        output: List[Extension] = []
-
-        for extension_folder in self._extension_folders:
-            extension_code = extension_folder.parts[-1]
-            try:
-                with open(extension_folder / "config.json") as json_file:
-                    config = json.load(json_file)
-                is_valid = True
-                is_admin_only = extension_code in settings.lnbits_admin_extensions
-            except Exception:
-                config = {}
-                is_valid = False
-                is_admin_only = False
-
-            output.append(
-                Extension(
-                    extension_code,
-                    is_valid,
-                    is_admin_only,
-                    config.get("name"),
-                    config.get("short_description"),
-                    config.get("tile"),
-                    config.get("contributors"),
-                    config.get("hidden") or False,
-                    config.get("migration_module"),
-                    config.get("db_name"),
-                )
-            )
-
-        return output
-
-
 class ExtensionRelease(BaseModel):
     name: str
     version: str
@@ -358,8 +200,22 @@ class ExtensionRelease(BaseModel):
         if not self.pay_link:
             return
 
-        payment_info = await fetch_release_payment_info(self.pay_link)
+        payment_info = await self.fetch_release_payment_info()
         self.cost_sats = payment_info.amount if payment_info else None
+
+    async def fetch_release_payment_info(
+        self, amount: Optional[int] = None
+    ) -> Optional[ReleasePaymentInfo]:
+        url = f"{self.pay_link}?amount={amount}" if amount else self.pay_link
+        assert url, "Missing URL for payment info."
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+                return ReleasePaymentInfo(**resp.json())
+        except Exception as e:
+            logger.warning(e)
+            return None
 
     @classmethod
     def from_github_release(
@@ -401,7 +257,7 @@ class ExtensionRelease(BaseModel):
     @classmethod
     async def get_github_releases(cls, org: str, repo: str) -> List["ExtensionRelease"]:
         try:
-            github_releases = await fetch_github_releases(org, repo)
+            github_releases = await cls.fetch_github_releases(org, repo)
             return [
                 ExtensionRelease.from_github_release(f"{org}/{repo}", r)
                 for r in github_releases
@@ -409,6 +265,15 @@ class ExtensionRelease(BaseModel):
         except Exception as e:
             logger.warning(e)
             return []
+
+    @classmethod
+    async def fetch_github_releases(
+        cls, org: str, repo: str
+    ) -> List[GitHubRepoRelease]:
+        releases_url = f"https://api.github.com/repos/{org}/{repo}/releases"
+        error_msg = "Cannot fetch extension releases"
+        releases = await github_api_get(releases_url, error_msg)
+        return [GitHubRepoRelease.parse_obj(r) for r in releases]
 
 
 class InstallableExtension(BaseModel):
@@ -638,7 +503,7 @@ class InstallableExtension(BaseModel):
         cls, github_release: GitHubRelease
     ) -> Optional["InstallableExtension"]:
         try:
-            repo, latest_release, config = await fetch_github_repo_info(
+            repo, latest_release, config = await cls.fetch_github_repo_info(
                 github_release.organisation, github_release.repository
             )
             source_repo = f"{github_release.organisation}/{github_release.repository}"
@@ -679,7 +544,7 @@ class InstallableExtension(BaseModel):
 
         for url in settings.lnbits_extensions_manifests:
             try:
-                manifest = await fetch_manifest(url)
+                manifest = await cls.fetch_manifest(url)
 
                 for r in manifest.repos:
                     ext = await InstallableExtension.from_github_release(r)
@@ -720,7 +585,7 @@ class InstallableExtension(BaseModel):
 
         for url in settings.lnbits_extensions_manifests:
             try:
-                manifest = await fetch_manifest(url)
+                manifest = await cls.fetch_manifest(url)
                 for r in manifest.repos:
                     if r.id != ext_id:
                         continue
@@ -758,6 +623,37 @@ class InstallableExtension(BaseModel):
 
         return selected_release[0] if len(selected_release) != 0 else None
 
+    @classmethod
+    async def fetch_github_repo_info(
+        cls, org: str, repository: str
+    ) -> Tuple[GitHubRepo, GitHubRepoRelease, ExtensionConfig]:
+        repo_url = f"https://api.github.com/repos/{org}/{repository}"
+        error_msg = "Cannot fetch extension repo"
+        repo = await github_api_get(repo_url, error_msg)
+        github_repo = GitHubRepo.parse_obj(repo)
+
+        lates_release_url = (
+            f"https://api.github.com/repos/{org}/{repository}/releases/latest"
+        )
+        error_msg = "Cannot fetch extension releases"
+        latest_release: Any = await github_api_get(lates_release_url, error_msg)
+
+        config_url = f"https://raw.githubusercontent.com/{org}/{repository}/{github_repo.default_branch}/config.json"
+        error_msg = "Cannot fetch config for extension"
+        config = await github_api_get(config_url, error_msg)
+
+        return (
+            github_repo,
+            GitHubRepoRelease.parse_obj(latest_release),
+            ExtensionConfig.parse_obj(config),
+        )
+
+    @classmethod
+    async def fetch_manifest(cls, url) -> Manifest:
+        error_msg = "Cannot fetch extensions manifest"
+        manifest = await github_api_get(url, error_msg)
+        return Manifest.parse_obj(manifest)
+
 
 class CreateExtension(BaseModel):
     ext_id: str
@@ -772,74 +668,3 @@ class ExtensionDetailsRequest(BaseModel):
     ext_id: str
     source_repo: str
     version: str
-
-
-async def uninstall_extension(ext_id):
-    await stop_extension_background_work(ext_id)
-
-    settings.lnbits_deactivated_extensions.add(ext_id)
-
-    extension = await get_installed_extension(ext_id)
-    if extension:
-        extension.clean_extension_files()
-    await delete_installed_extension(ext_id=ext_id)
-
-
-async def stop_extension_background_work(ext_id) -> bool:
-    """
-    Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
-    Extensions SHOULD expose a `api_stop()` function.
-    """
-    upgrade_hash = settings.extension_upgrade_hash(ext_id) or ""
-    ext = Extension(ext_id, True, False, upgrade_hash=upgrade_hash)
-
-    try:
-        logger.info(f"Stopping background work for extension '{ext.module_name}'.")
-        old_module = importlib.import_module(ext.module_name)
-
-        # Extensions must expose an `{ext_id}_stop()` function at the module level
-        # The `api_stop()` function is for backwards compatibility (will be deprecated)
-        stop_fns = [f"{ext_id}_stop", "api_stop"]
-        stop_fn_name = next((fn for fn in stop_fns if hasattr(old_module, fn)), None)
-        assert stop_fn_name, "No stop function found for '{ext.module_name}'"
-
-        stop_fn = getattr(old_module, stop_fn_name)
-        if stop_fn:
-            await stop_fn()
-
-        logger.info(f"Stopped background work for extension '{ext.module_name}'.")
-    except Exception as ex:
-        logger.warning(f"Failed to stop background work for '{ext.module_name}'.")
-        logger.warning(ex)
-        return False
-
-    return True
-
-
-def get_valid_extensions(include_deactivated: Optional[bool] = True) -> List[Extension]:
-    valid_extensions = [
-        extension for extension in ExtensionManager().extensions if extension.is_valid
-    ]
-
-    if include_deactivated:
-        return valid_extensions
-
-    if settings.lnbits_extensions_deactivate_all:
-        return []
-
-    return [
-        e
-        for e in valid_extensions
-        if e.code not in settings.lnbits_deactivated_extensions
-    ]
-
-
-def version_parse(v: str):
-    """
-    Wrapper for version.parse() that does not throw if the version is invalid.
-    Instead it return the lowest possible version ("0.0.0")
-    """
-    try:
-        return version.parse(v)
-    except Exception:
-        return version.parse("0.0.0")

--- a/lnbits/core/extensions/models.py
+++ b/lnbits/core/extensions/models.py
@@ -89,6 +89,17 @@ class ExtensionConfig(BaseModel):
             return True
         return version_parse(self.min_lnbits_version) <= version_parse(settings.version)
 
+    @classmethod
+    async def fetch_github_release_config(
+        cls, org: str, repo: str, tag_name: str
+    ) -> Optional[ExtensionConfig]:
+        config_url = (
+            f"https://raw.githubusercontent.com/{org}/{repo}/{tag_name}/config.json"
+        )
+        error_msg = "Cannot fetch GitHub extension config"
+        config = await github_api_get(config_url, error_msg)
+        return ExtensionConfig.parse_obj(config)
+
 
 class ReleasePaymentInfo(BaseModel):
     amount: Optional[int] = None

--- a/lnbits/core/extensions/models.py
+++ b/lnbits/core/extensions/models.py
@@ -200,6 +200,13 @@ class Extension(NamedTuple):
         ]
 
     @classmethod
+    def get_valid_extension(
+        cls, ext_id: str, include_deactivated: Optional[bool] = True
+    ) -> Optional[Extension]:
+        all_extensions = cls.get_valid_extensions(include_deactivated)
+        return next((e for e in all_extensions if e.code == ext_id), None)
+
+    @classmethod
     def _extensions(cls) -> list[Extension]:
         p = Path(settings.lnbits_extensions_path, "extensions")
         Path(p).mkdir(parents=True, exist_ok=True)
@@ -501,17 +508,6 @@ class InstallableExtension(BaseModel):
         shutil.rmtree(self.ext_dir, True)
         shutil.copytree(Path(self.ext_upgrade_dir), Path(self.ext_dir))
         logger.success(f"Extension {self.name} ({self.installed_version}) installed.")
-
-    def notify_upgrade(self, upgrade_hash: Optional[str]) -> None:
-        """
-        Update the list of upgraded extensions. The middleware will perform
-        redirects based on this
-        """
-        if upgrade_hash:
-            # bug
-            settings.lnbits_upgraded_extensions.add(f"{self.hash}/{self.id}")
-
-        settings.lnbits_all_extensions_ids.add(self.id)
 
     def clean_extension_files(self):
         # remove downloaded archive

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -12,9 +12,6 @@ from lnbits.core.crud import (
     update_migration_version,
 )
 from lnbits.core.db import db as core_db
-from lnbits.core.extensions.extension_manager import (
-    get_valid_extensions,
-)
 from lnbits.core.extensions.models import (
     Extension,
 )
@@ -100,7 +97,7 @@ async def migrate_databases():
     await load_disabled_extension_list()
 
     # todo: revisit, use installed extensions
-    for ext in get_valid_extensions(False):
+    for ext in Extension.get_valid_extensions(False):
         current_version = current_versions.get(ext.code, 0)
         try:
             await migrate_extension_database(ext, current_version)

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -1,9 +1,8 @@
 import importlib
 import re
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
-import httpx
 from loguru import logger
 
 from lnbits.core import migrations as core_migrations
@@ -53,68 +52,6 @@ async def run_migration(
                 else:
                     async with core_db.connect() as conn:
                         await update_migration_version(conn, db_name, version)
-
-
-async def stop_extension_background_work(
-    ext_id: str, user: str, access_token: Optional[str] = None
-):
-    """
-    Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
-    Extensions SHOULD expose a `api_stop()` function and/or a DELETE enpoint
-    at the root level of their API.
-    """
-    stopped = await _stop_extension_background_work(ext_id)
-
-    if not stopped:
-        # fallback to REST API call
-        await _stop_extension_background_work_via_api(ext_id, user, access_token)
-
-
-async def _stop_extension_background_work(ext_id) -> bool:
-    upgrade_hash = settings.extension_upgrade_hash(ext_id) or ""
-    ext = Extension(ext_id, True, False, upgrade_hash=upgrade_hash)
-
-    try:
-        logger.info(f"Stopping background work for extension '{ext.module_name}'.")
-        old_module = importlib.import_module(ext.module_name)
-
-        # Extensions must expose an `{ext_id}_stop()` function at the module level
-        # The `api_stop()` function is for backwards compatibility (will be deprecated)
-        stop_fns = [f"{ext_id}_stop", "api_stop"]
-        stop_fn_name = next((fn for fn in stop_fns if hasattr(old_module, fn)), None)
-        assert stop_fn_name, "No stop function found for '{ext.module_name}'"
-
-        stop_fn = getattr(old_module, stop_fn_name)
-        if stop_fn:
-            await stop_fn()
-
-        logger.info(f"Stopped background work for extension '{ext.module_name}'.")
-    except Exception as ex:
-        logger.warning(f"Failed to stop background work for '{ext.module_name}'.")
-        logger.warning(ex)
-        return False
-
-    return True
-
-
-async def _stop_extension_background_work_via_api(ext_id, user, access_token):
-    logger.info(
-        f"Stopping background work for extension '{ext_id}' using the REST API."
-    )
-    async with httpx.AsyncClient() as client:
-        try:
-            url = f"http://{settings.host}:{settings.port}/{ext_id}/api/v1?usr={user}"
-            headers = (
-                {"Authorization": "Bearer " + access_token} if access_token else None
-            )
-            resp = await client.delete(url=url, headers=headers)
-            resp.raise_for_status()
-            logger.info(f"Stopped background work for extension '{ext_id}'.")
-        except Exception as ex:
-            logger.warning(
-                f"Failed to stop background work for '{ext_id}' using the REST API."
-            )
-            logger.warning(ex)
 
 
 def to_valid_user_id(user_id: str) -> UUID:

--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -12,11 +12,13 @@ from lnbits.core.crud import (
     update_migration_version,
 )
 from lnbits.core.db import db as core_db
-from lnbits.db import COCKROACH, POSTGRES, SQLITE, Connection
-from lnbits.extension_manager import (
-    Extension,
+from lnbits.core.extensions.extension_manager import (
     get_valid_extensions,
 )
+from lnbits.core.extensions.models import (
+    Extension,
+)
+from lnbits.db import COCKROACH, POSTGRES, SQLITE, Connection
 from lnbits.settings import settings
 
 

--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -36,8 +36,6 @@ from lnbits.extension_manager import (
     PayToEnableInfo,
     ReleasePaymentInfo,
     UserExtensionInfo,
-    activate_extension_paths,
-    deactivate_extension_paths,
     fetch_github_release_config,
     fetch_release_details,
     fetch_release_payment_info,
@@ -280,7 +278,7 @@ async def api_activate_extension(ext_id: str) -> SimpleStatus:
             # run extension start-up routine
             core_app_extra.register_new_ext_routes(ext)
 
-        activate_extension_paths(ext_id, [])
+        settings.activate_extension_paths(ext_id)
 
         await update_installed_extension_state(ext_id=ext_id, active=True)
         return SimpleStatus(success=True, message=f"Extension '{ext_id}' activated.")
@@ -301,7 +299,7 @@ async def api_deactivate_extension(ext_id: str) -> SimpleStatus:
         ext = next((e for e in all_extensions if e.code == ext_id), None)
         assert ext, f"Extension '{ext_id}' doesn't exist."
 
-        deactivate_extension_paths(ext_id)
+        settings.deactivate_extension_paths(ext_id)
 
         await update_installed_extension_state(ext_id=ext_id, active=False)
         return SimpleStatus(success=True, message=f"Extension '{ext_id}' deactivated.")

--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -36,8 +36,8 @@ from lnbits.extension_manager import (
     PayToEnableInfo,
     ReleasePaymentInfo,
     UserExtensionInfo,
-    activate_extension_settings,
-    deactivate_extension_settings,
+    activate_extension_paths,
+    deactivate_extension_paths,
     fetch_github_release_config,
     fetch_release_details,
     fetch_release_payment_info,
@@ -280,7 +280,7 @@ async def api_activate_extension(ext_id: str) -> SimpleStatus:
             # run extension start-up routine
             core_app_extra.register_new_ext_routes(ext)
 
-        activate_extension_settings(ext_id, [])
+        activate_extension_paths(ext_id, [])
 
         await update_installed_extension_state(ext_id=ext_id, active=True)
         return SimpleStatus(success=True, message=f"Extension '{ext_id}' activated.")
@@ -301,7 +301,7 @@ async def api_deactivate_extension(ext_id: str) -> SimpleStatus:
         ext = next((e for e in all_extensions if e.code == ext_id), None)
         assert ext, f"Extension '{ext_id}' doesn't exist."
 
-        deactivate_extension_settings(ext_id)
+        deactivate_extension_paths(ext_id)
 
         await update_installed_extension_state(ext_id=ext_id, active=False)
         return SimpleStatus(success=True, message=f"Extension '{ext_id}' deactivated.")

--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -16,7 +16,6 @@ from lnbits.core.db import core_app_extra
 from lnbits.core.extensions.extension_manager import (
     fetch_github_release_config,
     fetch_release_details,
-    get_valid_extensions,
     stop_extension_background_work,
     uninstall_extension,
 )
@@ -179,7 +178,7 @@ async def api_update_pay_to_enable(
 async def api_enable_extension(
     ext_id: str, user: User = Depends(check_user_exists)
 ) -> SimpleStatus:
-    if ext_id not in [e.code for e in get_valid_extensions()]:
+    if ext_id not in [e.code for e in Extension.get_valid_extensions()]:
         raise HTTPException(
             HTTPStatus.NOT_FOUND, f"Extension '{ext_id}' doesn't exist."
         )
@@ -242,7 +241,7 @@ async def api_enable_extension(
 async def api_disable_extension(
     ext_id: str, user: User = Depends(check_user_exists)
 ) -> SimpleStatus:
-    if ext_id not in [e.code for e in get_valid_extensions()]:
+    if ext_id not in [e.code for e in Extension.get_valid_extensions()]:
         raise HTTPException(
             HTTPStatus.BAD_REQUEST, f"Extension '{ext_id}' doesn't exist."
         )
@@ -263,7 +262,7 @@ async def api_activate_extension(ext_id: str) -> SimpleStatus:
     try:
         logger.info(f"Activating extension: '{ext_id}'.")
 
-        all_extensions = get_valid_extensions()
+        all_extensions = Extension.get_valid_extensions()
         ext = next((e for e in all_extensions if e.code == ext_id), None)
         assert ext, f"Extension '{ext_id}' doesn't exist."
         # if extension never loaded (was deactivated on server startup)
@@ -288,7 +287,7 @@ async def api_deactivate_extension(ext_id: str) -> SimpleStatus:
     try:
         logger.info(f"Deactivating extension: '{ext_id}'.")
 
-        all_extensions = get_valid_extensions()
+        all_extensions = Extension.get_valid_extensions()
         ext = next((e for e in all_extensions if e.code == ext_id), None)
         assert ext, f"Extension '{ext_id}' doesn't exist."
 
@@ -316,7 +315,7 @@ async def api_uninstall_extension(ext_id: str) -> SimpleStatus:
 
     installed_extensions = await get_installed_extensions()
     # check that other extensions do not depend on this one
-    for valid_ext_id in [ext.code for ext in get_valid_extensions()]:
+    for valid_ext_id in [ext.code for ext in Extension.get_valid_extensions()]:
         installed_ext = next(
             (ext for ext in installed_extensions if ext.id == valid_ext_id), None
         )

--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -14,10 +14,7 @@ from fastapi import (
 from loguru import logger
 
 from lnbits.core.db import core_app_extra
-from lnbits.core.helpers import (
-    migrate_extension_database,
-    stop_extension_background_work,
-)
+from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.models import (
     SimpleStatus,
     User,
@@ -40,6 +37,7 @@ from lnbits.extension_manager import (
     fetch_release_details,
     fetch_release_payment_info,
     get_valid_extensions,
+    stop_extension_background_work,
 )
 from lnbits.settings import settings
 

--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -89,7 +89,6 @@ async def api_install_extension(data: CreateExtension):
         db_version = (await get_dbversions()).get(data.ext_id, 0)
         await migrate_extension_database(extension, db_version)
 
-        # ext_info.active = True
         await add_installed_extension(ext_info)
 
         if extension.is_upgrade_extension:

--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -16,7 +16,6 @@ from lnbits.core.db import core_app_extra
 from lnbits.core.extensions.extension_manager import (
     activate_extension,
     deactivate_extension,
-    fetch_github_release_config,
     fetch_release_details,
     stop_extension_background_work,
     uninstall_extension,
@@ -24,6 +23,7 @@ from lnbits.core.extensions.extension_manager import (
 from lnbits.core.extensions.models import (
     CreateExtension,
     Extension,
+    ExtensionConfig,
     ExtensionRelease,
     InstallableExtension,
     PayToEnableInfo,
@@ -454,7 +454,7 @@ async def get_pay_to_enable_invoice(
 )
 async def get_extension_release(org: str, repo: str, tag_name: str):
     try:
-        config = await fetch_github_release_config(org, repo, tag_name)
+        config = await ExtensionConfig.fetch_github_release_config(org, repo, tag_name)
         if not config:
             return {}
 

--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -36,6 +36,8 @@ from lnbits.extension_manager import (
     PayToEnableInfo,
     ReleasePaymentInfo,
     UserExtensionInfo,
+    activate_extension_settings,
+    deactivate_extension_settings,
     fetch_github_release_config,
     fetch_release_details,
     fetch_release_payment_info,
@@ -278,7 +280,7 @@ async def api_activate_extension(ext_id: str) -> SimpleStatus:
             # run extension start-up routine
             core_app_extra.register_new_ext_routes(ext)
 
-        settings.lnbits_deactivated_extensions.discard(ext_id)
+        activate_extension_settings(ext_id, [])
 
         await update_installed_extension_state(ext_id=ext_id, active=True)
         return SimpleStatus(success=True, message=f"Extension '{ext_id}' activated.")
@@ -299,7 +301,7 @@ async def api_deactivate_extension(ext_id: str) -> SimpleStatus:
         ext = next((e for e in all_extensions if e.code == ext_id), None)
         assert ext, f"Extension '{ext_id}' doesn't exist."
 
-        settings.lnbits_deactivated_extensions.add(ext_id)
+        deactivate_extension_settings(ext_id)
 
         await update_installed_extension_state(ext_id=ext_id, active=False)
         return SimpleStatus(success=True, message=f"Extension '{ext_id}' deactivated.")

--- a/lnbits/core/views/extension_api.py
+++ b/lnbits/core/views/extension_api.py
@@ -16,7 +16,6 @@ from lnbits.core.db import core_app_extra
 from lnbits.core.extensions.extension_manager import (
     activate_extension,
     deactivate_extension,
-    fetch_release_details,
     stop_extension_background_work,
     uninstall_extension,
 )
@@ -138,7 +137,7 @@ async def api_extension_details(
         )
         assert release, "Details not found for release"
 
-        release_details = await fetch_release_details(details_link)
+        release_details = await ExtensionRelease.fetch_release_details(details_link)
         assert release_details, "Cannot fetch details for release"
         release_details["icon"] = release.icon
         release_details["repo"] = release.repo

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -12,7 +12,7 @@ from lnurl import decode as lnurl_decode
 from loguru import logger
 from pydantic.types import UUID4
 
-from lnbits.core.extensions.models import InstallableExtension
+from lnbits.core.extensions.models import Extension, InstallableExtension
 from lnbits.core.helpers import to_valid_user_id
 from lnbits.core.models import User
 from lnbits.core.services import create_invoice
@@ -29,7 +29,6 @@ from ..crud import (
     get_installed_extensions,
     get_user,
 )
-from ..extensions.extension_manager import get_valid_extensions
 
 generic_router = APIRouter(
     tags=["Core NON-API Website Routes"], include_in_schema=False
@@ -105,7 +104,7 @@ async def extensions(request: Request, user: User = Depends(check_user_exists)):
         installed_exts_ids = []
 
     try:
-        all_ext_ids = [ext.code for ext in get_valid_extensions()]
+        all_ext_ids = [ext.code for ext in Extension.get_valid_extensions()]
         inactive_extensions = [
             e.id for e in await get_installed_extensions(active=False)
         ]

--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -12,6 +12,7 @@ from lnurl import decode as lnurl_decode
 from loguru import logger
 from pydantic.types import UUID4
 
+from lnbits.core.extensions.models import InstallableExtension
 from lnbits.core.helpers import to_valid_user_id
 from lnbits.core.models import User
 from lnbits.core.services import create_invoice
@@ -20,7 +21,6 @@ from lnbits.helpers import template_renderer
 from lnbits.settings import settings
 from lnbits.wallets import get_funding_source
 
-from ...extension_manager import InstallableExtension, get_valid_extensions
 from ...utils.exchange_rates import allowed_currencies, currencies
 from ..crud import (
     create_account,
@@ -29,6 +29,7 @@ from ..crud import (
     get_installed_extensions,
     get_user,
 )
+from ..extensions.extension_manager import get_valid_extensions
 
 generic_router = APIRouter(
     tags=["Core NON-API Website Routes"], include_in_schema=False

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import importlib
 import json
 import os
 import shutil
@@ -770,6 +771,68 @@ class ExtensionDetailsRequest(BaseModel):
     ext_id: str
     source_repo: str
     version: str
+
+
+async def stop_extension_background_work(
+    ext_id: str, user: str, access_token: Optional[str] = None
+):
+    """
+    Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
+    Extensions SHOULD expose a `api_stop()` function and/or a DELETE enpoint
+    at the root level of their API.
+    """
+    stopped = await _stop_extension_background_work(ext_id)
+
+    if not stopped:
+        # fallback to REST API call
+        await _stop_extension_background_work_via_api(ext_id, user, access_token)
+
+
+async def _stop_extension_background_work(ext_id) -> bool:
+    upgrade_hash = settings.extension_upgrade_hash(ext_id) or ""
+    ext = Extension(ext_id, True, False, upgrade_hash=upgrade_hash)
+
+    try:
+        logger.info(f"Stopping background work for extension '{ext.module_name}'.")
+        old_module = importlib.import_module(ext.module_name)
+
+        # Extensions must expose an `{ext_id}_stop()` function at the module level
+        # The `api_stop()` function is for backwards compatibility (will be deprecated)
+        stop_fns = [f"{ext_id}_stop", "api_stop"]
+        stop_fn_name = next((fn for fn in stop_fns if hasattr(old_module, fn)), None)
+        assert stop_fn_name, "No stop function found for '{ext.module_name}'"
+
+        stop_fn = getattr(old_module, stop_fn_name)
+        if stop_fn:
+            await stop_fn()
+
+        logger.info(f"Stopped background work for extension '{ext.module_name}'.")
+    except Exception as ex:
+        logger.warning(f"Failed to stop background work for '{ext.module_name}'.")
+        logger.warning(ex)
+        return False
+
+    return True
+
+
+async def _stop_extension_background_work_via_api(ext_id, user, access_token):
+    logger.info(
+        f"Stopping background work for extension '{ext_id}' using the REST API."
+    )
+    async with httpx.AsyncClient() as client:
+        try:
+            url = f"http://{settings.host}:{settings.port}/{ext_id}/api/v1?usr={user}"
+            headers = (
+                {"Authorization": "Bearer " + access_token} if access_token else None
+            )
+            resp = await client.delete(url=url, headers=headers)
+            resp.raise_for_status()
+            logger.info(f"Stopped background work for extension '{ext_id}'.")
+        except Exception as ex:
+            logger.warning(
+                f"Failed to stop background work for '{ext_id}' using the REST API."
+            )
+            logger.warning(ex)
 
 
 def get_valid_extensions(include_deactivated: Optional[bool] = True) -> List[Extension]:

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -774,7 +774,7 @@ class ExtensionDetailsRequest(BaseModel):
 
 
 async def stop_extension_background_work(
-    ext_id: str, user: str, access_token: Optional[str] = None
+    ext_id: str, user_id: Optional[str] = None, access_token: Optional[str] = None
 ):
     """
     Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
@@ -785,7 +785,7 @@ async def stop_extension_background_work(
 
     if not stopped:
         # fallback to REST API call
-        await _stop_extension_background_work_via_api(ext_id, user, access_token)
+        await _stop_extension_background_work_via_api(ext_id, user_id, access_token)
 
 
 async def _stop_extension_background_work(ext_id) -> bool:
@@ -815,13 +815,18 @@ async def _stop_extension_background_work(ext_id) -> bool:
     return True
 
 
-async def _stop_extension_background_work_via_api(ext_id, user, access_token):
+async def _stop_extension_background_work_via_api(
+    ext_id, user_id: Optional[str] = None, access_token: Optional[str] = None
+):
     logger.info(
         f"Stopping background work for extension '{ext_id}' using the REST API."
     )
     async with httpx.AsyncClient() as client:
         try:
-            url = f"http://{settings.host}:{settings.port}/{ext_id}/api/v1?usr={user}"
+            query_params = f"?usr={user_id}" if user_id else ""
+            url = (
+                f"http://{settings.host}:{settings.port}/{ext_id}/api/v1{query_params}"
+            )
             headers = (
                 {"Authorization": "Bearer " + access_token} if access_token else None
             )

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -552,7 +552,7 @@ class InstallableExtension(BaseModel):
         redirects based on this
         """
         if upgrade_hash:
-            #bug
+            # bug
             settings.lnbits_upgraded_extensions.add(f"{self.hash}/{self.id}")
 
         settings.lnbits_all_extensions_ids.add(self.id)
@@ -772,7 +772,7 @@ class ExtensionDetailsRequest(BaseModel):
     version: str
 
 
-def activate_extension_settings(ext_id: str, ext_redirects: List[dict]):
+def activate_extension_paths(ext_id: str, ext_redirects: List[dict]):
     from_path_redirects = [r["from_path"] for r in ext_redirects]
     existing_redirects = [
         r["ext_id"]
@@ -790,7 +790,7 @@ def activate_extension_settings(ext_id: str, ext_redirects: List[dict]):
         settings.lnbits_extensions_redirects.append(r)
 
 
-def deactivate_extension_settings(ext_id: str):
+def deactivate_extension_paths(ext_id: str):
     settings.lnbits_deactivated_extensions.add(ext_id)
     settings.lnbits_extensions_redirects = [
         r for r in settings.lnbits_extensions_redirects if r["ext_id"] != ext_id

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -552,6 +552,7 @@ class InstallableExtension(BaseModel):
         redirects based on this
         """
         if upgrade_hash:
+            #bug
             settings.lnbits_upgraded_extensions.add(f"{self.hash}/{self.id}")
 
         settings.lnbits_all_extensions_ids.add(self.id)
@@ -769,6 +770,31 @@ class ExtensionDetailsRequest(BaseModel):
     ext_id: str
     source_repo: str
     version: str
+
+
+def activate_extension_settings(ext_id: str, ext_redirects: List[dict]):
+    from_path_redirects = [r["from_path"] for r in ext_redirects]
+    existing_redirects = [
+        r["ext_id"]
+        for r in settings.lnbits_extensions_redirects
+        if r["from_path"] in from_path_redirects
+    ]
+
+    assert len(existing_redirects) == 0, (
+        f" Cannot redirect for extension '{ext_id}'."
+        f" Already mapped by {existing_redirects}"
+    )
+    settings.lnbits_deactivated_extensions.discard(ext_id)
+    for r in ext_redirects:
+        r["ext_id"] = ext_id
+        settings.lnbits_extensions_redirects.append(r)
+
+
+def deactivate_extension_settings(ext_id: str):
+    settings.lnbits_deactivated_extensions.add(ext_id)
+    settings.lnbits_extensions_redirects = [
+        r for r in settings.lnbits_extensions_redirects if r["ext_id"] != ext_id
+    ]
 
 
 def get_valid_extensions(include_deactivated: Optional[bool] = True) -> List[Extension]:

--- a/lnbits/extension_manager.py
+++ b/lnbits/extension_manager.py
@@ -772,31 +772,6 @@ class ExtensionDetailsRequest(BaseModel):
     version: str
 
 
-def activate_extension_paths(ext_id: str, ext_redirects: List[dict]):
-    from_path_redirects = [r["from_path"] for r in ext_redirects]
-    existing_redirects = [
-        r["ext_id"]
-        for r in settings.lnbits_extensions_redirects
-        if r["from_path"] in from_path_redirects
-    ]
-
-    assert len(existing_redirects) == 0, (
-        f" Cannot redirect for extension '{ext_id}'."
-        f" Already mapped by {existing_redirects}"
-    )
-    settings.lnbits_deactivated_extensions.discard(ext_id)
-    for r in ext_redirects:
-        r["ext_id"] = ext_id
-        settings.lnbits_extensions_redirects.append(r)
-
-
-def deactivate_extension_paths(ext_id: str):
-    settings.lnbits_deactivated_extensions.add(ext_id)
-    settings.lnbits_extensions_redirects = [
-        r for r in settings.lnbits_extensions_redirects if r["ext_id"] != ext_id
-    ]
-
-
 def get_valid_extensions(include_deactivated: Optional[bool] = True) -> List[Extension]:
     valid_extensions = [
         extension for extension in ExtensionManager().extensions if extension.is_valid

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -17,8 +17,8 @@ from lnbits.requestvars import g
 from lnbits.settings import settings
 from lnbits.utils.crypto import AESCipher
 
+from .core.extensions.extension_manager import get_valid_extensions
 from .db import FilterModel
-from .extension_manager import get_valid_extensions
 
 
 def get_db_vendor_name():

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -10,6 +10,7 @@ import shortuuid
 from pydantic import BaseModel
 from pydantic.schema import field_schema
 
+from lnbits.core.extensions.models import Extension
 from lnbits.db import get_placeholder
 from lnbits.jinja2_templating import Jinja2Templates
 from lnbits.nodes import get_node_class
@@ -17,7 +18,6 @@ from lnbits.requestvars import g
 from lnbits.settings import settings
 from lnbits.utils.crypto import AESCipher
 
-from .core.extensions.extension_manager import get_valid_extensions
 from .db import FilterModel
 
 
@@ -93,7 +93,7 @@ def template_renderer(additional_folders: Optional[List] = None) -> Jinja2Templa
         settings.lnbits_node_ui and get_node_class() is not None
     )
     t.env.globals["LNBITS_NODE_UI_AVAILABLE"] = get_node_class() is not None
-    t.env.globals["EXTENSIONS"] = get_valid_extensions(False)
+    t.env.globals["EXTENSIONS"] = Extension.get_valid_extensions(False)
     if settings.lnbits_custom_logo:
         t.env.globals["USE_CUSTOM_LOGO"] = settings.lnbits_custom_logo
 

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Union
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -118,71 +118,11 @@ class ExtensionsRedirectMiddleware:
             return
 
         req_headers = scope["headers"] if "headers" in scope else []
-        redirect = self._find_redirect(scope["path"], req_headers)
+        redirect = settings.find_extension_redirect(scope["path"], req_headers)
         if redirect:
-            scope["path"] = self._new_path(redirect, scope["path"])
+            scope["path"] = redirect.new_path_from(scope["path"])
 
         await self.app(scope, receive, send)
-
-    def _find_redirect(self, path: str, req_headers: List[Tuple[bytes, bytes]]):
-        return next(
-            (
-                r
-                for r in settings.lnbits_extensions_redirects
-                if self._redirect_matches(r, path, req_headers)
-            ),
-            None,
-        )
-
-    def _redirect_matches(
-        self, redirect: dict, path: str, req_headers: List[Tuple[bytes, bytes]]
-    ) -> bool:
-        if "from_path" not in redirect:
-            return False
-        header_filters = (
-            redirect["header_filters"] if "header_filters" in redirect else {}
-        )
-        return self._has_common_path(redirect["from_path"], path) and self._has_headers(
-            header_filters, req_headers
-        )
-
-    def _has_headers(
-        self, filter_headers: dict, req_headers: List[Tuple[bytes, bytes]]
-    ) -> bool:
-        for h in filter_headers:
-            if not self._has_header(req_headers, (str(h), str(filter_headers[h]))):
-                return False
-        return True
-
-    def _has_header(
-        self, req_headers: List[Tuple[bytes, bytes]], header: Tuple[str, str]
-    ) -> bool:
-        for h in req_headers:
-            if (
-                h[0].decode().lower() == header[0].lower()
-                and h[1].decode() == header[1]
-            ):
-                return True
-        return False
-
-    def _has_common_path(self, redirect_path: str, req_path: str) -> bool:
-        redirect_path_elements = redirect_path.split("/")
-        req_path_elements = req_path.split("/")
-        if len(redirect_path) > len(req_path):
-            return False
-        sub_path = req_path_elements[: len(redirect_path_elements)]
-        return redirect_path == "/".join(sub_path)
-
-    def _new_path(self, redirect: dict, req_path: str) -> str:
-        from_path = redirect["from_path"].split("/")
-        redirect_to = redirect["redirect_to_path"].split("/")
-        req_tail_path = req_path.split("/")[len(from_path) :]
-
-        elements = [
-            e for e in ([redirect["ext_id"], *redirect_to, *req_tail_path]) if e != ""
-        ]
-
-        return "/" + "/".join(elements)
 
 
 def add_ratelimit_middleware(app: FastAPI):

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -45,16 +45,11 @@ class InstalledExtensionMiddleware:
             await self.app(scope, receive, send)
             return
 
-        upgrade_path = next(
-            (
-                e
-                for e in settings.lnbits_upgraded_extensions
-                if e.endswith(f"/{top_path}")
-            ),
-            None,
-        )
         # re-route all trafic if the extension has been upgraded
-        if upgrade_path:
+        if top_path in settings.lnbits_upgraded_extensions:
+            upgrade_path = (
+                f"""{settings.lnbits_upgraded_extensions[top_path]}/{top_path}"""
+            )
             tail = "/".join(rest)
             scope["path"] = f"/upgrades/{upgrade_path}/{tail}"
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -143,12 +143,25 @@ class InstalledExtensionsSettings(LNbitsSettings):
         )
 
     def activate_extension_paths(
-        self, ext_id: str, ext_redirects: Optional[list[dict]] = None
+        self,
+        ext_id: str,
+        upgrade_hash: Optional[str] = None,
+        ext_redirects: Optional[list[dict]] = None,
     ):
-        settings.lnbits_deactivated_extensions.discard(ext_id)
+        self.lnbits_deactivated_extensions.discard(ext_id)
+
+        """
+        Update the list of upgraded extensions. The middleware will perform
+        redirects based on this
+        """
+        if upgrade_hash:
+            # bug
+            self.lnbits_upgraded_extensions.add(f"{upgrade_hash}/{ext_id}")
 
         if ext_redirects:
             self._activate_extension_redirects(ext_id, ext_redirects)
+
+        self.lnbits_all_extensions_ids.add(ext_id)
 
     def deactivate_extension_paths(self, ext_id: str):
         self.lnbits_deactivated_extensions.add(ext_id)

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -68,10 +68,35 @@ class InstalledExtensionsSettings(LNbitsSettings):
     # upgraded extensions that require API redirects
     lnbits_upgraded_extensions: set[str] = Field(default=[])
     # list of redirects that extensions want to perform
-    lnbits_extensions_redirects: list[Any] = Field(default=[])
+    lnbits_extensions_redirects: list[RedirectPath] = Field(default=[])
 
     # list of all extension ids
     lnbits_all_extensions_ids: set[Any] = Field(default=[])
+
+    def find_extension_redirect(
+        self, path: str, req_headers: list[tuple[bytes, bytes]]
+    ) -> Optional[RedirectPath]:
+        headers = [(k.decode(), v.decode()) for k, v in req_headers]
+        return next(
+            (
+                r
+                for r in settings.lnbits_extensions_redirects
+                if r.redirect_matches(path, headers)
+            ),
+            None,
+        )
+
+    def activate_extension_paths(
+        self, ext_id: str, ext_redirects: Optional[list[dict]] = None
+    ):
+        settings.lnbits_deactivated_extensions.discard(ext_id)
+
+        if ext_redirects:
+            self._activate_extension_redirects(ext_id, ext_redirects)
+
+    def deactivate_extension_paths(self, ext_id: str):
+        self.lnbits_deactivated_extensions.add(ext_id)
+        self._remove_extension_redirects(ext_id)
 
     def extension_upgrade_path(self, ext_id: str) -> Optional[str]:
         return next(
@@ -82,6 +107,29 @@ class InstalledExtensionsSettings(LNbitsSettings):
     def extension_upgrade_hash(self, ext_id: str) -> Optional[str]:
         path = settings.extension_upgrade_path(ext_id)
         return path.split("/")[0] if path else None
+
+    def _activate_extension_redirects(self, ext_id: str, ext_redirects: list[dict]):
+        ext_redirect_paths = [
+            RedirectPath(**{"ext_id": ext_id, **er}) for er in ext_redirects
+        ]
+        existing_redirects = [
+            r.ext_id
+            for r in self.lnbits_extensions_redirects
+            if r.find_in_conflict(ext_redirect_paths)
+        ]
+
+        assert len(existing_redirects) == 0, (
+            f" Cannot redirect for extension '{ext_id}'."
+            f" Already mapped by {existing_redirects}."
+        )
+
+        self._remove_extension_redirects(ext_id)
+        self.lnbits_extensions_redirects += ext_redirect_paths
+
+    def _remove_extension_redirects(self, ext_id: str):
+        self.lnbits_extensions_redirects = [
+            er for er in self.lnbits_extensions_redirects if er.ext_id == ext_id
+        ]
 
 
 class ThemesSettings(LNbitsSettings):
@@ -543,6 +591,62 @@ class SuperSettings(EditableSettings):
 class AdminSettings(EditableSettings):
     is_super_user: bool
     lnbits_allowed_funding_sources: Optional[list[str]]
+
+
+class RedirectPath(BaseModel):
+    ext_id: str
+    from_path: str
+    redirect_to_path: str
+    header_filters: dict = {}
+
+    def in_conflict(self, other: RedirectPath) -> bool:
+        if self.ext_id == other.ext_id:
+            return False
+        return self.redirect_matches(
+            other.from_path, list(other.header_filters.items())
+        )
+
+    def find_in_conflict(self, others: list[RedirectPath]) -> Optional[RedirectPath]:
+        for other in others:
+            if self.in_conflict(other):
+                return other
+        return None
+
+    def new_path_from(self, req_path: str) -> str:
+        from_path = self.from_path.split("/")
+        redirect_to = self.redirect_to_path.split("/")
+        req_tail_path = req_path.split("/")[len(from_path) :]
+
+        elements = [e for e in ([self.ext_id, *redirect_to, *req_tail_path]) if e != ""]
+
+        return "/" + "/".join(elements)
+
+    def redirect_matches(self, path: str, req_headers: list[tuple[str, str]]) -> bool:
+        return self.has_common_path(path) and self.has_headers(req_headers)
+
+    def has_common_path(self, req_path: str) -> bool:
+        if len(self.from_path) > len(req_path):
+            return False
+
+        redirect_path_elements = self.from_path.split("/")
+        req_path_elements = req_path.split("/")
+
+        sub_path = req_path_elements[: len(redirect_path_elements)]
+        return self.from_path == "/".join(sub_path)
+
+    def has_headers(self, req_headers: list[tuple[str, str]]) -> bool:
+        for h in self.header_filters:
+            if not self.has_header(req_headers, (str(h), str(self.header_filters[h]))):
+                return False
+        return True
+
+    def has_header(
+        self, req_headers: list[tuple[str, str]], header: tuple[str, str]
+    ) -> bool:
+        for h in req_headers:
+            if h[0].lower() == header[0].lower() and h[1].lower() == header[1].lower():
+                return True
+        return False
 
 
 def set_cli_settings(**kwargs):

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -197,7 +197,7 @@ class InstalledExtensionsSettings(LNbitsSettings):
 
     def _remove_extension_redirects(self, ext_id: str):
         self.lnbits_extensions_redirects = [
-            er for er in self.lnbits_extensions_redirects if er.ext_id == ext_id
+            er for er in self.lnbits_extensions_redirects if er.ext_id != ext_id
         ]
 
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -91,9 +91,9 @@ class RedirectPath(BaseModel):
         return "/" + "/".join(elements)
 
     def redirect_matches(self, path: str, req_headers: list[tuple[str, str]]) -> bool:
-        return self.has_common_path(path) and self.has_headers(req_headers)
+        return self._has_common_path(path) and self._has_headers(req_headers)
 
-    def has_common_path(self, req_path: str) -> bool:
+    def _has_common_path(self, req_path: str) -> bool:
         if len(self.from_path) > len(req_path):
             return False
 
@@ -103,13 +103,13 @@ class RedirectPath(BaseModel):
         sub_path = req_path_elements[: len(redirect_path_elements)]
         return self.from_path == "/".join(sub_path)
 
-    def has_headers(self, req_headers: list[tuple[str, str]]) -> bool:
+    def _has_headers(self, req_headers: list[tuple[str, str]]) -> bool:
         for h in self.header_filters:
-            if not self.has_header(req_headers, (str(h), str(self.header_filters[h]))):
+            if not self._has_header(req_headers, (str(h), str(self.header_filters[h]))):
                 return False
         return True
 
-    def has_header(
+    def _has_header(
         self, req_headers: list[tuple[str, str]], header: tuple[str, str]
     ) -> bool:
         for h in req_headers:

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -73,7 +73,7 @@ class RedirectPath(BaseModel):
             return False
         return self.redirect_matches(
             other.from_path, list(other.header_filters.items())
-        )
+        ) or other.redirect_matches(self.from_path, list(self.header_filters.items()))
 
     def find_in_conflict(self, others: list[RedirectPath]) -> Optional[RedirectPath]:
         for other in others:

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -168,14 +168,14 @@ class InstalledExtensionsSettings(LNbitsSettings):
         ext_redirect_paths = [
             RedirectPath(**{"ext_id": ext_id, **er}) for er in ext_redirects
         ]
-        existing_redirects = [
+        existing_redirects = {
             r.ext_id
             for r in self.lnbits_extensions_redirects
             if r.find_in_conflict(ext_redirect_paths)
-        ]
+        }
 
         assert len(existing_redirects) == 0, (
-            f" Cannot redirect for extension '{ext_id}'."
+            f"Cannot redirect for extension '{ext_id}'."
             f" Already mapped by {existing_redirects}."
         )
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -122,7 +122,7 @@ class InstalledExtensionsSettings(LNbitsSettings):
     # installed extensions that have been deactivated
     lnbits_deactivated_extensions: set[str] = Field(default=[])
     # upgraded extensions that require API redirects
-    lnbits_upgraded_extensions: set[str] = Field(default=[])
+    lnbits_upgraded_extensions: dict[str, str] = Field(default={})
     # list of redirects that extensions want to perform
     lnbits_extensions_redirects: list[RedirectPath] = Field(default=[])
 
@@ -156,7 +156,7 @@ class InstalledExtensionsSettings(LNbitsSettings):
         """
         if upgrade_hash:
             # bug
-            self.lnbits_upgraded_extensions.add(f"{upgrade_hash}/{ext_id}")
+            self.lnbits_upgraded_extensions[ext_id] = upgrade_hash
 
         if ext_redirects:
             self._activate_extension_redirects(ext_id, ext_redirects)
@@ -166,16 +166,6 @@ class InstalledExtensionsSettings(LNbitsSettings):
     def deactivate_extension_paths(self, ext_id: str):
         self.lnbits_deactivated_extensions.add(ext_id)
         self._remove_extension_redirects(ext_id)
-
-    def extension_upgrade_path(self, ext_id: str) -> Optional[str]:
-        return next(
-            (e for e in self.lnbits_upgraded_extensions if e.endswith(f"/{ext_id}")),
-            None,
-        )
-
-    def extension_upgrade_hash(self, ext_id: str) -> Optional[str]:
-        path = settings.extension_upgrade_path(ext_id)
-        return path.split("/")[0] if path else None
 
     def _activate_extension_redirects(self, ext_id: str, ext_redirects: list[dict]):
         ext_redirect_paths = [

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -155,7 +155,6 @@ class InstalledExtensionsSettings(LNbitsSettings):
         redirects based on this
         """
         if upgrade_hash:
-            # bug
             self.lnbits_upgraded_extensions[ext_id] = upgrade_hash
 
         if ext_redirects:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -105,10 +105,51 @@ def test_redirect_path_in_conflict_with_headers(
 def test_redirect_path_matches_with_headers(
     lnurlp: RedirectPath, lnurlp_with_headers: RedirectPath
 ):
+    headers_list = list(lnurlp_with_headers.header_filters.items())
     assert lnurlp.redirect_matches(
-        path=lnurlp_redirect_path_with_headers["from_path"],
-        req_headers=lnurlp_redirect_path_with_headers["header_filters"],
+        path=lnurlp_with_headers.from_path,
+        req_headers=headers_list,
     )
     assert not lnurlp_with_headers.redirect_matches(
         path=lnurlp_redirect_path["from_path"], req_headers=[]
+    )
+    assert not lnurlp_with_headers.redirect_matches(path="/random/path", req_headers=[])
+    assert not lnurlp_with_headers.redirect_matches(path="/random_path", req_headers=[])
+    assert not lnurlp_with_headers.redirect_matches(
+        path="/.well-known/lnurlp", req_headers=[]
+    )
+    assert lnurlp.redirect_matches(path="/.well-known/lnurlp", req_headers=[])
+    assert lnurlp.redirect_matches(
+        path="/.well-known/lnurlp/some/other/path", req_headers=[]
+    )
+    assert lnurlp.redirect_matches(
+        path="/.well-known/lnurlp/some/other/path",
+        req_headers=headers_list,
+    )
+    assert not lnurlp_with_headers.redirect_matches(
+        path="/.well-known/lnurlp", req_headers=[]
+    )
+    assert not lnurlp_with_headers.redirect_matches(
+        path="/.well-known/lnurlp/some/other/path", req_headers=[]
+    )
+    assert lnurlp_with_headers.redirect_matches(
+        path="/.well-known/lnurlp/some/other/path",
+        req_headers=headers_list,
+    )
+
+
+def test_redirect_path_new_path_from(lnurlp: RedirectPath):
+    assert lnurlp.new_path_from("") == "/lnurlp/api/v1/well-known"
+    assert lnurlp.new_path_from("/") == "/lnurlp/api/v1/well-known"
+    assert lnurlp.new_path_from("/path") == "/lnurlp/api/v1/well-known"
+    assert lnurlp.new_path_from("/path/more") == "/lnurlp/api/v1/well-known"
+
+    assert lnurlp.new_path_from("/.well-known/lnurlp") == "/lnurlp/api/v1/well-known"
+    assert (
+        lnurlp.new_path_from("/.well-known/lnurlp/path")
+        == "/lnurlp/api/v1/well-known/path"
+    )
+    assert (
+        lnurlp.new_path_from("/.well-known/lnurlp/path/more")
+        == "/lnurlp/api/v1/well-known/path/more"
     )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -110,8 +110,21 @@ def test_redirect_path_matches_with_headers(
         path=lnurlp_with_headers.from_path,
         req_headers=headers_list,
     )
+    assert lnurlp_with_headers.redirect_matches(
+        path=lnurlp_redirect_path["from_path"],
+        req_headers=[("ACCEPT", "APPlication/nostr+json")],
+    )
+    assert lnurlp_with_headers.redirect_matches(
+        path=lnurlp_redirect_path["from_path"],
+        req_headers=[("accept", "application/nostr+json"), ("my_header", "my_value")],
+    )
+
     assert not lnurlp_with_headers.redirect_matches(
         path=lnurlp_redirect_path["from_path"], req_headers=[]
+    )
+    assert not lnurlp_with_headers.redirect_matches(
+        path=lnurlp_redirect_path["from_path"],
+        req_headers=[("accept", "application/json")],
     )
     assert not lnurlp_with_headers.redirect_matches(path="/random/path", req_headers=[])
     assert not lnurlp_with_headers.redirect_matches(path="/random_path", req_headers=[])

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -6,6 +6,11 @@ lnurlp_redirect_path = {
     "from_path": "/.well-known/lnurlp",
     "redirect_to_path": "/api/v1/well-known",
 }
+lnurlp_redirect_path_with_headers = {
+    "from_path": "/.well-known/lnurlp",
+    "redirect_to_path": "/api/v1/well-known",
+    "header_filters": {"accept": "application/nostr+json"},
+}
 
 lnaddress_redirect_path = {
     "from_path": "/.well-known/lnurlp",
@@ -25,6 +30,13 @@ def lnurlp():
 
 
 @pytest.fixture()
+def lnurlp_with_headers():
+    return RedirectPath(
+        ext_id="lnurlp_with_headers", **lnurlp_redirect_path_with_headers
+    )
+
+
+@pytest.fixture()
 def lnaddress():
     return RedirectPath(ext_id="lnaddress", **lnaddress_redirect_path)
 
@@ -34,8 +46,7 @@ def nostrrelay():
     return RedirectPath(ext_id="nostrrelay", **nostrrelay_redirect_path)
 
 
-@pytest.mark.asyncio
-async def test_redirect_path_self_not_in_conflict(
+def test_redirect_path_self_not_in_conflict(
     lnurlp: RedirectPath, lnaddress: RedirectPath, nostrrelay: RedirectPath
 ):
     assert not lnurlp.in_conflict(lnurlp), "Path is not in conflict with itself."
@@ -44,47 +55,60 @@ async def test_redirect_path_self_not_in_conflict(
         nostrrelay
     ), "Path is not in conflict with itself."
 
-    assert not lnurlp.in_conflict(nostrrelay), "Paths are not in conflict."
+    assert not lnurlp.in_conflict(nostrrelay)
 
-    assert not nostrrelay.in_conflict(lnurlp), "Paths are not in conflict."
+    assert not nostrrelay.in_conflict(lnurlp)
 
 
-@pytest.mark.asyncio
-async def test_redirect_path_not_in_conflict(
+def test_redirect_path_not_in_conflict(
     lnurlp: RedirectPath, lnaddress: RedirectPath, nostrrelay: RedirectPath
 ):
 
-    assert not lnurlp.in_conflict(nostrrelay), "Paths are not in conflict."
+    assert not lnurlp.in_conflict(nostrrelay)
 
-    assert not nostrrelay.in_conflict(lnurlp), "Paths are not in conflict."
+    assert not nostrrelay.in_conflict(lnurlp)
 
-    assert not lnaddress.in_conflict(nostrrelay), "Paths are not in conflict."
+    assert not lnaddress.in_conflict(nostrrelay)
 
-    assert not nostrrelay.in_conflict(lnaddress), "Paths are not in conflict."
-
-
-@pytest.mark.asyncio
-async def test_redirect_path_in_conflict(lnurlp: RedirectPath, lnaddress: RedirectPath):
-    assert lnurlp.in_conflict(lnaddress), "Paths are in conflict."
-    assert lnaddress.in_conflict(lnurlp), "Paths are in conflict."
+    assert not nostrrelay.in_conflict(lnaddress)
 
 
-@pytest.mark.asyncio
-async def test_redirect_path_find_conflict(
+def test_redirect_path_in_conflict(lnurlp: RedirectPath, lnaddress: RedirectPath):
+    assert lnurlp.in_conflict(lnaddress)
+    assert lnaddress.in_conflict(lnurlp)
+
+
+def test_redirect_path_find_conflict(
     lnurlp: RedirectPath, lnaddress: RedirectPath, nostrrelay: RedirectPath
 ):
-    assert lnurlp.find_in_conflict([nostrrelay, lnaddress]), "Paths are in conflict."
-    assert lnurlp.find_in_conflict([lnaddress, nostrrelay]), "Paths are in conflict."
-    assert lnaddress.find_in_conflict([nostrrelay, lnurlp]), "Paths are in conflict."
-    assert lnaddress.find_in_conflict([lnurlp, nostrrelay]), "Paths are in conflict."
+    assert lnurlp.find_in_conflict([nostrrelay, lnaddress])
+    assert lnurlp.find_in_conflict([lnaddress, nostrrelay])
+    assert lnaddress.find_in_conflict([nostrrelay, lnurlp])
+    assert lnaddress.find_in_conflict([lnurlp, nostrrelay])
 
 
-@pytest.mark.asyncio
-async def test_redirect_path_find_no_conflict(
+def test_redirect_path_find_no_conflict(
     lnurlp: RedirectPath, lnaddress: RedirectPath, nostrrelay: RedirectPath
 ):
-    assert not nostrrelay.find_in_conflict(
-        [lnurlp, lnaddress]
-    ), "Paths are not in conflict."
-    assert not lnurlp.find_in_conflict([nostrrelay]), "Paths are not in conflict."
-    assert not lnaddress.find_in_conflict([nostrrelay]), "Paths are not in conflict."
+    assert not nostrrelay.find_in_conflict([lnurlp, lnaddress])
+    assert not lnurlp.find_in_conflict([nostrrelay])
+    assert not lnaddress.find_in_conflict([nostrrelay])
+
+
+def test_redirect_path_in_conflict_with_headers(
+    lnurlp: RedirectPath, lnurlp_with_headers: RedirectPath
+):
+    assert lnurlp.in_conflict(lnurlp_with_headers)
+    assert lnurlp_with_headers.in_conflict(lnurlp)
+
+
+def test_redirect_path_matches_with_headers(
+    lnurlp: RedirectPath, lnurlp_with_headers: RedirectPath
+):
+    assert lnurlp.redirect_matches(
+        path=lnurlp_redirect_path_with_headers["from_path"],
+        req_headers=lnurlp_redirect_path_with_headers["header_filters"],
+    )
+    assert not lnurlp_with_headers.redirect_matches(
+        path=lnurlp_redirect_path["from_path"], req_headers=[]
+    )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,55 @@
+import pytest
+
+from lnbits.settings import RedirectPath
+
+lnurlp_redirect_path = {
+    "from_path": "/.well-known/lnurlp",
+    "redirect_to_path": "/api/v1/well-known",
+}
+
+lnaddress_redirect_path = {
+    "from_path": "/.well-known/lnurlp",
+    "redirect_to_path": "/api/v1/well-known",
+}
+
+nostrrelay_redirect_path = {
+    "from_path": "/",
+    "redirect_to_path": "/api/v1/relay-info",
+    "header_filters": {"accept": "application/nostr+json"},
+}
+
+
+@pytest.mark.asyncio
+async def test_redirect_path_in_conflict():
+
+    redirect_path_lnurl = RedirectPath(ext_id="lnurlp", **lnurlp_redirect_path)
+    redirect_path_lnaddress = RedirectPath(
+        ext_id="lnaddress", **lnaddress_redirect_path
+    )
+    nostrrelay_path_lnurl = RedirectPath(ext_id="lnurlp", **nostrrelay_redirect_path)
+
+    assert not redirect_path_lnurl.in_conflict(
+        redirect_path_lnurl
+    ), "Path is not in conflict with itself."
+    assert not redirect_path_lnaddress.in_conflict(
+        redirect_path_lnaddress
+    ), "Path is not in conflict with itself."
+    assert not nostrrelay_path_lnurl.in_conflict(
+        nostrrelay_path_lnurl
+    ), "Path is not in conflict with itself."
+
+    assert redirect_path_lnurl.in_conflict(
+        redirect_path_lnaddress
+    ), "Paths are in conflict."
+
+    assert redirect_path_lnaddress.in_conflict(
+        redirect_path_lnurl
+    ), "Paths are in conflict (commutative)."
+
+    assert not redirect_path_lnurl.in_conflict(
+        nostrrelay_path_lnurl
+    ), "Paths are not in conflict."
+
+    assert not nostrrelay_path_lnurl.in_conflict(
+        redirect_path_lnurl
+    ), "Paths are not in conflict (commutative)."

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -19,37 +19,72 @@ nostrrelay_redirect_path = {
 }
 
 
+@pytest.fixture()
+def lnurlp():
+    return RedirectPath(ext_id="lnurlp", **lnurlp_redirect_path)
+
+
+@pytest.fixture()
+def lnaddress():
+    return RedirectPath(ext_id="lnaddress", **lnaddress_redirect_path)
+
+
+@pytest.fixture()
+def nostrrelay():
+    return RedirectPath(ext_id="nostrrelay", **nostrrelay_redirect_path)
+
+
 @pytest.mark.asyncio
-async def test_redirect_path_in_conflict():
-
-    redirect_path_lnurl = RedirectPath(ext_id="lnurlp", **lnurlp_redirect_path)
-    redirect_path_lnaddress = RedirectPath(
-        ext_id="lnaddress", **lnaddress_redirect_path
-    )
-    nostrrelay_path_lnurl = RedirectPath(ext_id="lnurlp", **nostrrelay_redirect_path)
-
-    assert not redirect_path_lnurl.in_conflict(
-        redirect_path_lnurl
-    ), "Path is not in conflict with itself."
-    assert not redirect_path_lnaddress.in_conflict(
-        redirect_path_lnaddress
-    ), "Path is not in conflict with itself."
-    assert not nostrrelay_path_lnurl.in_conflict(
-        nostrrelay_path_lnurl
+async def test_redirect_path_self_not_in_conflict(
+    lnurlp: RedirectPath, lnaddress: RedirectPath, nostrrelay: RedirectPath
+):
+    assert not lnurlp.in_conflict(lnurlp), "Path is not in conflict with itself."
+    assert not lnaddress.in_conflict(lnaddress), "Path is not in conflict with itself."
+    assert not nostrrelay.in_conflict(
+        nostrrelay
     ), "Path is not in conflict with itself."
 
-    assert redirect_path_lnurl.in_conflict(
-        redirect_path_lnaddress
-    ), "Paths are in conflict."
+    assert not lnurlp.in_conflict(nostrrelay), "Paths are not in conflict."
 
-    assert redirect_path_lnaddress.in_conflict(
-        redirect_path_lnurl
-    ), "Paths are in conflict (commutative)."
+    assert not nostrrelay.in_conflict(lnurlp), "Paths are not in conflict."
 
-    assert not redirect_path_lnurl.in_conflict(
-        nostrrelay_path_lnurl
+
+@pytest.mark.asyncio
+async def test_redirect_path_not_in_conflict(
+    lnurlp: RedirectPath, lnaddress: RedirectPath, nostrrelay: RedirectPath
+):
+
+    assert not lnurlp.in_conflict(nostrrelay), "Paths are not in conflict."
+
+    assert not nostrrelay.in_conflict(lnurlp), "Paths are not in conflict."
+
+    assert not lnaddress.in_conflict(nostrrelay), "Paths are not in conflict."
+
+    assert not nostrrelay.in_conflict(lnaddress), "Paths are not in conflict."
+
+
+@pytest.mark.asyncio
+async def test_redirect_path_in_conflict(lnurlp: RedirectPath, lnaddress: RedirectPath):
+    assert lnurlp.in_conflict(lnaddress), "Paths are in conflict."
+    assert lnaddress.in_conflict(lnurlp), "Paths are in conflict."
+
+
+@pytest.mark.asyncio
+async def test_redirect_path_find_conflict(
+    lnurlp: RedirectPath, lnaddress: RedirectPath, nostrrelay: RedirectPath
+):
+    assert lnurlp.find_in_conflict([nostrrelay, lnaddress]), "Paths are in conflict."
+    assert lnurlp.find_in_conflict([lnaddress, nostrrelay]), "Paths are in conflict."
+    assert lnaddress.find_in_conflict([nostrrelay, lnurlp]), "Paths are in conflict."
+    assert lnaddress.find_in_conflict([lnurlp, nostrrelay]), "Paths are in conflict."
+
+
+@pytest.mark.asyncio
+async def test_redirect_path_find_no_conflict(
+    lnurlp: RedirectPath, lnaddress: RedirectPath, nostrrelay: RedirectPath
+):
+    assert not nostrrelay.find_in_conflict(
+        [lnurlp, lnaddress]
     ), "Paths are not in conflict."
-
-    assert not nostrrelay_path_lnurl.in_conflict(
-        redirect_path_lnurl
-    ), "Paths are not in conflict (commutative)."
+    assert not lnurlp.find_in_conflict([nostrrelay]), "Paths are not in conflict."
+    assert not lnaddress.find_in_conflict([nostrrelay]), "Paths are not in conflict."


### PR DESCRIPTION
### Summary
Derived from: https://github.com/lnbits/lnbits/issues/2540
If two extensions (`ext_a` and `ext_b`) have overlapping redirect paths then the second one (`ext_b`) will be installed but deactivated.
If `ext_a` is deactivated, then `ext_b` can be activated.
See test scenario here:
![image](https://github.com/user-attachments/assets/7433f23b-d5e2-4114-a4a0-125c7bd40790)

The PR with JMeter tests: https://github.com/lnbits/lnbits-extensions/pull/415


This PR extended a bit outside the scope defined in the title. Some of the concepts in extension manager got clearer and I've decide to also refactor the extension manager and add tests to guard for future bugs.


### Changes
Short explanation of the relevant changes per file:
- `app.py` (refactor)
  - extract redirect logic from this file to `settings.activate_extension_paths`

- `commands.py` (refactor)
  - update function calls and imports
- `crud.py` (code quality only)
- `extension_manager.py`
    - moved to the `core/extensions` directory
    - all the classes have been moved to `extensions/models.py`
    - utilities have been moved to `extensions/helpers.py`
    - it contains only the logic for install/uninstall, activate/deactivate and stop_background_work
      - `stop_extension_background_work` changes:
        - do not call via API anymore (all extensions have `_start` & `_stop` now)
        - fix `stop_fn()` in case it is not an `async` function
 - `extensions/helpers.py`
   -  helpers extracted from the `extension_manager.py` (no new logic)
 - `extensions/models.py`
   - classes extracted from  `extension_manager.py` (no new logic, some standalone functions are now `@classmethods`)
- `extensions_api.py` (extract some methods and update imports) 
- `middleware.py` (simplify, extract path logic to its own `RedirectPath` class)
- `settings.py`
  - encapsulate the path redirect logic here instead of having it in multiple places in the app
  - fix bug for update extension
- `test_settings.py` (add tests for the `RedirectPath` class)