### PR TITLE
refactor: remove `get_key_type` decorator

### DIFF
--- a/lnbits/core/views/wallet_api.py
+++ b/lnbits/core/views/wallet_api.py
@@ -13,8 +13,8 @@ from lnbits.core.models import (
 )
 from lnbits.decorators import (
     WalletTypeInfo,
-    get_key_type,
     require_admin_key,
+    require_invoice_key,
 )
 
 from ..crud import (
@@ -27,15 +27,12 @@ wallet_router = APIRouter(prefix="/api/v1/wallet", tags=["Wallet"])
 
 
 @wallet_router.get("")
-async def api_wallet(wallet: WalletTypeInfo = Depends(get_key_type)):
-    if wallet.key_type == KeyType.admin:
-        return {
-            "id": wallet.wallet.id,
-            "name": wallet.wallet.name,
-            "balance": wallet.wallet.balance_msat,
-        }
-    else:
-        return {"name": wallet.wallet.name, "balance": wallet.wallet.balance_msat}
+async def api_wallet(wallet: WalletTypeInfo = Depends(require_invoice_key)):
+    return {
+        "id": wallet.wallet.id if wallet.key_type == KeyType.admin else None,
+        "name": wallet.wallet.name,
+        "balance": wallet.wallet.balance_msat,
+    }
 
 
 @wallet_router.put("/{new_name}")

--- a/lnbits/core/views/wallet_api.py
+++ b/lnbits/core/views/wallet_api.py
@@ -28,11 +28,13 @@ wallet_router = APIRouter(prefix="/api/v1/wallet", tags=["Wallet"])
 
 @wallet_router.get("")
 async def api_wallet(wallet: WalletTypeInfo = Depends(require_invoice_key)):
-    return {
-        "id": wallet.wallet.id if wallet.key_type == KeyType.admin else None,
+    res = {
         "name": wallet.wallet.name,
         "balance": wallet.wallet.balance_msat,
     }
+    if wallet.key_type == KeyType.admin:
+        res["id"] = wallet.wallet.id
+    return res
 
 
 @wallet_router.put("/{new_name}")

--- a/lnbits/decorators.py
+++ b/lnbits/decorators.py
@@ -95,15 +95,6 @@ class KeyChecker(SecurityBase):
         return WalletTypeInfo(key_type, wallet)
 
 
-async def get_key_type(
-    request: Request,
-    api_key_header: str = Security(api_key_header),
-    api_key_query: str = Security(api_key_query),
-) -> WalletTypeInfo:
-    check: KeyChecker = KeyChecker(api_key=api_key_header or api_key_query)
-    return await check(request)
-
-
 async def require_admin_key(
     request: Request,
     api_key_header: str = Security(api_key_header),


### PR DESCRIPTION
its always better to explicitly choose `require_invoice_key` or `require_admin_key` makes the code more readable and you always know upfront which key you need.

breaking change for 1.0.0