### PR TITLE
Add NFC Payment Support and Display Receive Amount in Receive Dialog

### DIFF
--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -484,3 +484,7 @@ class SimpleStatus(BaseModel):
 class DbVersion(BaseModel):
     db: str
     version: int
+
+
+class PayLnurlWData(BaseModel):
+    lnurl: str

--- a/lnbits/core/models.py
+++ b/lnbits/core/models.py
@@ -487,4 +487,4 @@ class DbVersion(BaseModel):
 
 
 class PayLnurlWData(BaseModel):
-    lnurl: str
+    lnurl_w: str

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -372,6 +372,12 @@
             </a>
           </div>
           <div class="text-center">
+            <h3 class="q-my-md">
+              <span v-text="formattedAmount"></span>
+            </h3>
+            <h5 v-if="receive.unit != 'sat'" class="q-mt-none q-mb-sm">
+              <span v-text="formattedSatAmount"></span>
+            </h5>
             <q-chip v-if="nfcTagReading" square>
               <q-avatar
                 icon="nfc"

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -382,10 +382,6 @@
             </q-chip>
             <span v-else class="text-caption text-grey">NFC not supported</span>
           </div>
-          <div v-if="decodedLnurl" class="q-mt-md">
-            <h4>Decoded LNURL:</h4>
-            <p v-text="decodedLnurl"></p>
-          </div>
           <div class="row q-mt-lg">
             <q-btn
               outline

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -382,7 +382,7 @@
             <h5 v-if="receive.unit != 'sat'" class="q-mt-none q-mb-sm">
               <span v-text="formattedSatAmount"></span>
             </h5>
-            <q-chip v-if="hasNfc" square>
+            <q-chip v-if="hasNfc" outline square color="positive">
               <q-avatar
                 icon="nfc"
                 color="positive"

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -281,7 +281,11 @@
         </div>
       </div>
 
-      <q-dialog v-model="receive.show" position="top">
+      <q-dialog
+        v-model="receive.show"
+        position="top"
+        @hide="onReceiveDialogHide"
+      >
         <q-card
           v-if="!receive.paymentReq"
           class="q-pa-lg q-pt-xl lnbits__dialog-card"

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -371,6 +371,21 @@
               ></lnbits-qrcode>
             </a>
           </div>
+          <div class="text-center">
+            <q-chip v-if="nfcTagReading" square>
+              <q-avatar
+                icon="nfc"
+                color="positive"
+                text-color="white"
+              ></q-avatar>
+              NFC supported
+            </q-chip>
+            <span v-else class="text-caption text-grey">NFC not supported</span>
+          </div>
+          <div v-if="decodedLnurl" class="q-mt-md">
+            <h4>Decoded LNURL:</h4>
+            <p v-text="decodedLnurl"></p>
+          </div>
           <div class="row q-mt-lg">
             <q-btn
               outline

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -378,7 +378,7 @@
             <h5 v-if="receive.unit != 'sat'" class="q-mt-none q-mb-sm">
               <span v-text="formattedSatAmount"></span>
             </h5>
-            <q-chip v-if="nfcTagReading" square>
+            <q-chip v-if="hasNfc" square>
               <q-avatar
                 icon="nfc"
                 color="positive"

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -413,8 +413,7 @@ async def api_payments_decode(data: DecodePayment) -> JSONResponse:
 async def api_payment_pay_with_nfc(
     payment_request: str,
     lnurl_data: PayLnurlWData,
-    wallet: WalletTypeInfo = Depends(require_admin_key),
-):
+) -> JSONResponse:
 
     lnurl = (
         lnurl_data.lnurl.replace("lnurlw://", "")

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -415,13 +415,10 @@ async def api_payment_pay_with_nfc(
     lnurl_data: PayLnurlWData,
 ) -> JSONResponse:
 
-    lnurl = lnurl_data.lnurl.lower()
+    lnurl = lnurl_data.lnurl_w.lower()
 
     # Follow LUD-17 -> https://github.com/lnurl/luds/blob/luds/17.md
-    if ".onion" in lnurl:
-        url = lnurl.replace("lnurlw://", "http://")
-    else:
-        url = lnurl.replace("lnurlw://", "https://")
+    url = lnurl.replace("lnurlw://", "https://")
 
     headers = {"User-Agent": settings.user_agent}
     async with httpx.AsyncClient(headers=headers, follow_redirects=True) as client:

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -440,6 +440,9 @@ async def api_payment_pay_with_nfc(
 
             lnurl_res = lnurl_req.json()
 
+            if lnurl_res["status"] == "ERROR":
+                return JSONResponse({"success": False, "detail": lnurl_res["reason"]})
+
             if lnurl_res["tag"] != "withdrawRequest":
                 return JSONResponse(
                     {"success": False, "detail": "Invalid LNURL-withdraw"}

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -440,10 +440,10 @@ async def api_payment_pay_with_nfc(
 
             lnurl_res = lnurl_req.json()
 
-            if lnurl_res["status"] == "ERROR":
+            if lnurl_res.get("status") == "ERROR":
                 return JSONResponse({"success": False, "detail": lnurl_res["reason"]})
 
-            if lnurl_res["tag"] != "withdrawRequest":
+            if lnurl_res.get("tag") != "withdrawRequest":
                 return JSONResponse(
                     {"success": False, "detail": "Invalid LNURL-withdraw"}
                 )
@@ -463,7 +463,7 @@ async def api_payment_pay_with_nfc(
 
             callback_res = callback_req.json()
 
-            if callback_res["status"] == "ERROR":
+            if callback_res.get("status") == "ERROR":
                 return JSONResponse(
                     {"success": False, "detail": callback_res["reason"]}
                 )
@@ -471,6 +471,4 @@ async def api_payment_pay_with_nfc(
                 return JSONResponse({"success": True, "detail": callback_res})
 
         except Exception as e:
-            return JSONResponse(
-                {"success": False, "detail": f"Unexpected error: {e!s}"}
-            )
+            return JSONResponse({"success": False, "detail": f"Unexpected error: {e}"})

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -169,7 +169,6 @@ window.app = Vue.createApp({
           this.receive.paymentReq = response.data.bolt11
           this.receive.amountMsat = response.data.amount * 1000
           this.receive.paymentHash = response.data.payment_hash
-          console.log(this.receive)
 
           this.readNfcTag()
 

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -607,7 +607,7 @@ window.app = Vue.createApp({
 
               const record = message.records.find(el => {
                 const payload = textDecoder.decode(el.data)
-                return payload.toUpperCase().indexOf('LNURL') !== -1
+                return payload.toUpperCase().indexOf('LNURLW') !== -1
               })
 
               if (record) {

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -647,7 +647,7 @@ window.app = Vue.createApp({
           'POST',
           `/api/v1/payments/${this.receive.paymentReq}/pay-with-nfc`,
           this.g.wallet.adminkey,
-          {lnurl: lnurl}
+          {lnurl_w: lnurl}
         )
         .then(response => {
           dismissPaymentMsg()

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -14,6 +14,7 @@ window.app = Vue.createApp({
         status: 'pending',
         paymentReq: null,
         paymentHash: null,
+        amountMsat: null,
         minMax: [0, 2100000000000000],
         lnurl: null,
         units: ['sat'],
@@ -79,6 +80,19 @@ window.app = Vue.createApp({
     canPay: function () {
       if (!this.parse.invoice) return false
       return this.parse.invoice.sat <= this.balance
+    },
+    formattedAmount: function () {
+      if (this.receive.unit != 'sat') {
+        return LNbits.utils.formatCurrency(
+          Number(this.receive.data.amount).toFixed(2),
+          this.receive.unit
+        )
+      } else {
+        return LNbits.utils.formatMsat(this.receive.amountMsat) + ' sat'
+      }
+    },
+    formattedSatAmount: function () {
+      return LNbits.utils.formatMsat(this.receive.amountMsat) + ' sat'
     }
   },
   methods: {
@@ -147,7 +161,10 @@ window.app = Vue.createApp({
         .then(response => {
           this.receive.status = 'success'
           this.receive.paymentReq = response.data.bolt11
+          this.receive.amountMsat = response.data.amount * 1000
           this.receive.paymentHash = response.data.payment_hash
+          console.log(this.receive)
+
           this.readNfcTag()
 
           // TODO: lnurl_callback and lnurl_response

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -588,7 +588,7 @@ window.app = Vue.createApp({
         }
 
         this.hasNfc = true
-        Quasar.Notify.create({
+        let dismissNfcTapMsg = Quasar.Notify.create({
           message: 'Tap your NFC tag to pay this invoice with LNURLw.'
         })
 
@@ -612,6 +612,7 @@ window.app = Vue.createApp({
               })
 
               if (record) {
+                dismissNfcTapMsg()
                 Quasar.Notify.create({
                   type: 'positive',
                   message: 'NFC tag read successfully.'

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -167,7 +167,7 @@ window.app = Vue.createApp({
         .then(response => {
           this.receive.status = 'success'
           this.receive.paymentReq = response.data.bolt11
-          this.receive.amountMsat = response.data.amount * 1000
+          this.receive.amountMsat = response.data.amount
           this.receive.paymentHash = response.data.payment_hash
 
           this.readNfcTag()

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -650,8 +650,6 @@ window.app = Vue.createApp({
               type: 'positive',
               message: 'Payment successful'
             })
-            this.updatePayments = !this.updatePayments // this may be innecessary
-            this.receive.show = false // this may be innecessary
           } else {
             Quasar.Notify.create({
               type: 'negative',

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -523,47 +523,150 @@ async def test_fiat_tracking(client, adminkey_headers_from, settings: Settings):
 
 
 @pytest.mark.asyncio
-async def test_api_payment_pay_with_nfc(client, mocker: MockerFixture):
-    # Prepare test data
+@pytest.mark.parametrize(
+    "lnurl_response_data, callback_response_data, expected_response",
+    [
+        # Happy path
+        (
+            {
+                "tag": "withdrawRequest",
+                "callback": "https://example.com/callback",
+                "k1": "randomk1value",
+            },
+            {
+                "status": "OK",
+            },
+            {
+                "success": True,
+                "detail": {"status": "OK"},
+            },
+        ),
+        # Error loading LNURL request
+        (
+            "error_loading_lnurl",
+            None,
+            {
+                "success": False,
+                "detail": "Error loading LNURL request",
+            },
+        ),
+        # LNURL response with error status
+        (
+            {
+                "status": "ERROR",
+                "reason": "LNURL request failed",
+            },
+            None,
+            {
+                "success": False,
+                "detail": "LNURL request failed",
+            },
+        ),
+        # Invalid LNURL-withdraw
+        (
+            {
+                "tag": "payRequest",
+                "callback": "https://example.com/callback",
+                "k1": "randomk1value",
+            },
+            None,
+            {
+                "success": False,
+                "detail": "Invalid LNURL-withdraw",
+            },
+        ),
+        # Error loading callback request
+        (
+            {
+                "tag": "withdrawRequest",
+                "callback": "https://example.com/callback",
+                "k1": "randomk1value",
+            },
+            "error_loading_callback",
+            {
+                "success": False,
+                "detail": "Error loading callback request",
+            },
+        ),
+        # Callback response with error status
+        (
+            {
+                "tag": "withdrawRequest",
+                "callback": "https://example.com/callback",
+                "k1": "randomk1value",
+            },
+            {
+                "status": "ERROR",
+                "reason": "Callback failed",
+            },
+            {
+                "success": False,
+                "detail": "Callback failed",
+            },
+        ),
+        # Unexpected exception during LNURL response JSON parsing
+        (
+            "exception_in_lnurl_response_json",
+            None,
+            {
+                "success": False,
+                "detail": "Unexpected error: Simulated exception",
+            },
+        ),
+    ],
+)
+async def test_api_payment_pay_with_nfc(
+    client,
+    mocker: MockerFixture,
+    lnurl_response_data,
+    callback_response_data,
+    expected_response,
+):
     payment_request = "lnbc1..."
     lnurl = "lnurlw://example.com/lnurl"
-    lnurl_data = {"lnurl": lnurl}
-
-    # Mock lnurl_decode to return the expected URL
-    mocker.patch(
-        "lnbits.core.views.payment_api.lnurl_decode",
-        return_value="https://example.com/lnurl",
-    )
-
-    # Prepare mock responses
-    lnurl_response_data = {
-        "tag": "withdrawRequest",
-        "callback": "https://example.com/callback",
-        "k1": "randomk1value",
-    }
-
-    callback_response_data = {
-        "status": "OK",
-    }
+    lnurl_data = {"lnurl_w": lnurl}
 
     # Create a mock for httpx.AsyncClient
     mock_async_client = AsyncMock()
-
-    # Mock the __aenter__ method to return the mock_async_client
     mock_async_client.__aenter__.return_value = mock_async_client
 
     # Mock the get method
     async def mock_get(url, *args, **kwargs):
         if url == "https://example.com/lnurl":
-            response = Mock()
-            response.is_error = False
-            response.json.return_value = lnurl_response_data
-            return response
+            if lnurl_response_data == "error_loading_lnurl":
+                response = Mock()
+                response.is_error = True
+                return response
+            elif lnurl_response_data == "exception_in_lnurl_response_json":
+                response = Mock()
+                response.is_error = False
+                response.json.side_effect = Exception("Simulated exception")
+                return response
+            elif isinstance(lnurl_response_data, dict):
+                response = Mock()
+                response.is_error = False
+                response.json.return_value = lnurl_response_data
+                return response
+            else:
+                # Handle unexpected data
+                response = Mock()
+                response.is_error = True
+                return response
         elif url == "https://example.com/callback":
-            response = Mock()
-            response.is_error = False
-            response.json.return_value = callback_response_data
-            return response
+            if callback_response_data == "error_loading_callback":
+                response = Mock()
+                response.is_error = True
+                return response
+            elif isinstance(callback_response_data, dict):
+                response = Mock()
+                response.is_error = False
+                response.json.return_value = callback_response_data
+                return response
+            else:
+                # Handle cases where callback is not called
+                response = Mock()
+                response.is_error = True
+                return response
         else:
             response = Mock()
             response.is_error = True
@@ -574,12 +677,10 @@ async def test_api_payment_pay_with_nfc(client, mocker: MockerFixture):
     # Mock httpx.AsyncClient to return our mock_async_client
     mocker.patch("httpx.AsyncClient", return_value=mock_async_client)
 
-    # Make the POST request to the endpoint using client
     response = await client.post(
         f"/api/v1/payments/{payment_request}/pay-with-nfc",
         json=lnurl_data,
     )
 
-    # Assert the response
     assert response.status_code == HTTPStatus.OK
-    assert response.json() == {"success": True, "detail": callback_response_data}
+    assert response.json() == expected_response


### PR DESCRIPTION
# Description:

This pull request introduces support for NFC payments when receiving Lightning payments in the wallet. It also enhances the receive dialog to display the invoice amount in both satoshis and the selected fiat currency.

# Features Added:

1. NFC Payment Support:

- Users can now receive payments via NFC-enabled LNURL-withdraw links.
- When the device supports NFC, the receive dialog prompts the user to tap an NFC tag to pay the invoice.
- The app reads the NFC tag and automatically processes the payment if it contains a valid LNURL-withdraw link.
- Notifications are provided throughout the NFC reading and payment process.

2. Receive Amount Display:

- The receive dialog now displays the invoice amount in satoshis and fiat currency.
- Provides clarity to users about the amount being requested.

3. NFC Support Detection:

- The app detects if the user's device supports NFC.
- If NFC is not supported, a message indicates the lack of NFC support.
- Users can still view the invoice amount and proceed without NFC.


# Screenshots:

## Before:

No NFC payment support.
Receive dialog did not display the invoice amount.
| ![before-min](https://github.com/user-attachments/assets/fba654af-4d27-48ab-92ba-7be900190130)| 
|------------------------|

## After (Device without NFC Support):

Receive dialog displays a message indicating NFC is not supported.
Invoice amount is shown in satoshis and fiat currency.
| ![no_nfc_1-min](https://github.com/user-attachments/assets/9770c444-e0e3-44ec-b956-5fa277c04ce5) | ![no_nfc_2-min](https://github.com/user-attachments/assets/af33ed63-f7e6-4e9a-84f3-1ec9827730db) | ![no_nfc_3-min](https://github.com/user-attachments/assets/8e600882-5d59-402f-bb80-5b5b2eae68a0) |
|------------------------|------------------------|------------------------|


## After (Device with NFC Support):

Receive dialog displays a message indicating NFC support.
Bottom notification prompts user to tap an NFC tag to pay the invoice.
Invoice amount is shown in satoshis and fiat currency.
| ![nfc_after_1-min](https://github.com/user-attachments/assets/f2e1c1ee-1154-4298-86ef-1d5832c700f4) | ![nfc_after_2-min](https://github.com/user-attachments/assets/62cae55c-1523-41d7-8994-012737376e1d) | ![nfc_after_3-min](https://github.com/user-attachments/assets/823f131a-34f2-4789-83ee-07fae006a0b9) |
|------------------------|------------------------|------------------------|

## After scanning nfc tag / Boltcard (Happy path):

Notification for "NFC tag read successfully" -> "Processing payment..." -> "Payment successful".
After hiding the receive dialog, aborts NFC reading.

| ![nfc_after_scan_1-min](https://github.com/user-attachments/assets/c61a8949-b427-41ff-af95-085736b6b9a0) | ![nfc_after_scan_2-min](https://github.com/user-attachments/assets/4152a815-7cc6-45bf-840b-23aa1c7a210f) |
|------------------------|------------------------|

## After scanning nfc tag / Boltcard (Error cases):

NFC tag does not contain any LNURLw record.
Payment failed from lack of funds.
LNURLw link already used before.
Daily limit reached. Error loading LNURLw link, Error loading Callback link, Unexpected error, etc.
| ![nfc_error_1-min](https://github.com/user-attachments/assets/60f0e396-ee40-4560-b387-f255a8bd8b7d) | ![nfc_error_2-min](https://github.com/user-attachments/assets/1a6e601a-6e5a-4749-8fb9-5e6e86b0c543) | ![nfc_error_3-min](https://github.com/user-attachments/assets/ec27b3d3-7a83-42b3-8d91-5370d8c50793) |
|------------------------|------------------------|------------------------|

# Code Changes Summary:

## Backend:

- Added api_payment_pay_with_nfc endpoint to handle payments via LNURL-withdraw links read from NFC tags.
-- Follows [Bolt Card specification](https://github.com/boltcard/boltcard/blob/main/docs/SPEC.md) specification, including [LUD-17](https://github.com/lnurl/luds/blob/luds/17.md).
-- Handles various success and error cases, returning appropriate responses.
- Updated lnbits/core/models.py: 
-- Added PayLnurlWData model for parsing LNURL-withdraw data.
- Wrote parameterized tests for api_payment_pay_with_nfc in tests/api/test_api.py:
-- Covers all scenarios, including success, error responses, and unexpected exceptions.

## Frontend:

- Modified wallet.html:
-- Added display of invoice amounts in both satoshis and fiat currency in the receive dialog.
-- Implemented NFC support detection using the NDEFReader API.
-- Display messages indicating whether NFC is supported.
-- When NFC is available, prompts users to tap their NFC tag to pay the invoice.
-- Provides notifications during the NFC reading process and payment outcome.
- Updated wallet.js:
-- Added methods to read NFC tags (readNfcTag) and process payments (payInvoiceWithNfc).
-- Handles NFC reading errors and provides user feedback.
-- Aborts NFC reading when the receive dialog is closed.

# Testing:

## Automated Tests:

- Added comprehensive tests in tests/api/test_api.py for the new API endpoint.
-- Used parameterization to cover various cases efficiently.
-- Ensured tests cover success scenarios and all possible error conditions.

## Manual Testing:

- Verified NFC payment flow on devices with NFC support.
- Confirmed that devices without NFC support display the appropriate message.
- Tested that the invoice amount is correctly displayed in both satoshis and fiat currency.

# Additional Notes:
- Compliance with Standards: 
-- Followed the LNURL standards, specifically [LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.](https://github.com/lnurl/luds/blob/luds/17.md).
-- Ensured code adheres to the project's linting and formatting guidelines.
- Backwards Compatibility:
-- The changes do not affect existing functionality for users not utilizing NFC.
-- Users can continue to receive payments without NFC support.

# Note to reviewers:
- To test the NFC functionality, a device with NFC support is required.
- Ensure that the [NDEFReader API](https://developer.mozilla.org/en-US/docs/Web/API/NDEFReader) is available in the testing environment. (Note that his feature is available only in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS) ). I suggest using [Ngrok](https://ngrok.com/) for a secure tunnel to your development environment if necessary.
- The feature has been tested on the latest browsers supporting Web NFC.
