### PR TITLE
fix: check the settings for extension installed

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -225,7 +225,8 @@ async def check_installed_extensions(app: FastAPI):
     re-created. The 'data' directory (where the '.zip' files live) is expected to
     persist state. Zips that are missing will be re-downloaded.
     """
-    shutil.rmtree(os.path.join("lnbits", "upgrades"), True)
+
+    shutil.rmtree(Path(settings.lnbits_extensions_path, "upgrades"), True)
     installed_extensions = await build_all_installed_extensions_list(False)
 
     for ext in installed_extensions:

--- a/lnbits/core/models/extensions.py
+++ b/lnbits/core/models/extensions.py
@@ -5,7 +5,6 @@ import hashlib
 import json
 import os
 import shutil
-import sys
 import zipfile
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
@@ -170,7 +169,7 @@ class Extension(NamedTuple):
             name=ext_info.name,
             short_description=ext_info.short_description,
             tile=ext_info.icon,
-            upgrade_hash=ext_info.hash if ext_info.module_installed else "",
+            upgrade_hash=settings.extension_upgrade_hash(ext_info.id),
         )
 
 
@@ -352,10 +351,6 @@ class InstallableExtension(BaseModel):
         if settings.has_default_extension_path:
             return f"lnbits.extensions.{self.id}"
         return self.id
-
-    @property
-    def module_installed(self) -> bool:
-        return self.module_name in sys.modules
 
     @property
     def has_installed_version(self) -> bool:

--- a/lnbits/core/services/extensions.py
+++ b/lnbits/core/services/extensions.py
@@ -71,7 +71,7 @@ async def stop_extension_background_work(ext_id: str) -> bool:
     Stop background work for extension (like asyncio.Tasks, WebSockets, etc).
     Extensions SHOULD expose a `api_stop()` function.
     """
-    upgrade_hash = settings.lnbits_upgraded_extensions.get(ext_id, "")
+    upgrade_hash = settings.extension_upgrade_hash(ext_id)
     ext = Extension(ext_id, True, upgrade_hash=upgrade_hash)
 
     try:

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -165,6 +165,9 @@ class InstalledExtensionsSettings(LNbitsSettings):
         self.lnbits_deactivated_extensions.add(ext_id)
         self._remove_extension_redirects(ext_id)
 
+    def extension_upgrade_hash(self, ext_id: str) -> str:
+        return settings.lnbits_upgraded_extensions.get(ext_id, "")
+
     def _activate_extension_redirects(self, ext_id: str, ext_redirects: list[dict]):
         ext_redirect_paths = [
             RedirectPath(**{"ext_id": ext_id, **er}) for er in ext_redirects


### PR DESCRIPTION
In order to check if an extension was previously installed check if there is an `upgrade_hash` instead of checking `self.module_name in sys.modules`