### PR TITLE
refactor: make settings key-value in DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ test-migration:
 	HOST=0.0.0.0 \
 	PORT=5002 \
 	LNBITS_DATABASE_URL="postgres://lnbits:lnbits@localhost:5432/migration" \
+	LNBITS_ADMIN_UI=False \
 	timeout 5s poetry run lnbits --host 0.0.0.0 --port 5002 || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
 	LNBITS_DATA_FOLDER="./tests/data" \
 	LNBITS_DATABASE_URL="postgres://lnbits:lnbits@localhost:5432/migration" \

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-regtest:
 	poetry run pytest tests/regtest
 
 test-migration:
-	LNBITS_ADMIN_UI=True \
+	LNBITS_ADMIN_UI=False \
 	make test-api
 	HOST=0.0.0.0 \
 	PORT=5002 \

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-regtest:
 	poetry run pytest tests/regtest
 
 test-migration:
-	LNBITS_ADMIN_UI=False \
+	LNBITS_ADMIN_UI=True \
 	make test-api
 	HOST=0.0.0.0 \
 	PORT=5002 \

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -90,14 +90,14 @@ async def get_settings_field(
 async def set_settings_field(
     id_: str, value: Optional[Any], tag: Optional[str] = "core"
 ):
-    await db.execute(
-        """
-        INSERT INTO system_settings (id, value, tag)
-        VALUES (:id, :value, :tag)
-        ON CONFLICT (id, tag) DO UPDATE SET value = :value
-        """,
-        {"id": id_, "value": json.dumps(value), "tag": tag or "core"},
-    )
+    value = json.dumps(value) if value is not None else None
+    field = SettingsField(id=id_, value=value, tag=tag or "core")
+
+    field_exists = await get_settings_field(id_, tag)
+    if field_exists:
+        await db.update("system_settings", field)
+    else:
+        await db.insert("system_settings", field)
 
 
 async def get_settings_by_tag(tag: str) -> Optional[dict[str, Any]]:

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -58,7 +58,7 @@ async def update_super_user(super_user: str) -> SuperSettings:
 
 
 async def delete_admin_settings(tag: Optional[str] = "core") -> None:
-    await db.execute("DELETE FROM settings WEHERE tag = :tag", {"tag": tag})
+    await db.execute("DELETE FROM settings WHERE tag = :tag", {"tag": tag})
 
 
 async def create_admin_settings(super_user: str, new_settings: dict) -> SuperSettings:
@@ -104,16 +104,18 @@ async def update_settings_field(
 
 
 async def get_settings_by_tag(tag: str) -> Optional[dict[str, Any]]:
-    fields: list[SettingsField] = await db.fetchall(
-        "SELECT * FROM system_settings WHERE tag = :tag", {"tag": tag}, SettingsField
+    rows: list[dict] = await db.fetchall(
+        "SELECT * FROM system_settings WHERE tag = :tag", {"tag": tag}
     )
-    if len(fields) == 0:
+    if len(rows) == 0:
         return None
     data: dict[str, Any] = {}
-    for field in fields:
+    for row in rows:
         try:
-            data[field.id] = json.loads(field.value) if field.value else None
+            data[row["id"]] = json.loads(row["value"]) if row["value"] else None
         except Exception as _:
-            logger.warning(f"Failed to load settings value for '{tag}.{field.id}'.")
+            logger.warning(
+                f"""Failed to load settings value for '{tag}.{row["id"]}'."""
+            )
     data.pop("super_user")
     return data

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -1,21 +1,25 @@
 import json
-from typing import Optional
+from typing import Any, Optional
+
+from loguru import logger
 
 from lnbits.core.db import db
 from lnbits.settings import (
     AdminSettings,
     EditableSettings,
+    SettingsField,
     SuperSettings,
     settings,
 )
 
 
 async def get_super_settings() -> Optional[SuperSettings]:
-    row: dict = await db.fetchone("SELECT * FROM settings")
-    if not row:
-        return None
-    editable_settings = json.loads(row["editable_settings"])
-    return SuperSettings(**{"super_user": row["super_user"], **editable_settings})
+    data = await get_settings_by_tag("core")
+    if data:
+        super_user = await get_settings_field("super_user")
+        super_user_id = super_user.value if super_user else None
+        return SuperSettings(**{"super_user": super_user_id, **data})
+    return None
 
 
 async def get_admin_settings(is_super_user: bool = False) -> Optional[AdminSettings]:
@@ -34,38 +38,83 @@ async def get_admin_settings(is_super_user: bool = False) -> Optional[AdminSetti
     return admin_settings
 
 
-async def delete_admin_settings() -> None:
-    await db.execute("DELETE FROM settings")
-
-
-async def update_admin_settings(data: EditableSettings) -> None:
-    row: dict = await db.fetchone("SELECT editable_settings FROM settings")
-    editable_settings = json.loads(row["editable_settings"]) if row else {}
+async def update_admin_settings(
+    data: EditableSettings, tag: Optional[str] = "core"
+) -> None:
+    editable_settings = await get_settings_by_tag("core") or {}
     editable_settings.update(data.dict(exclude_unset=True))
-    await db.execute(
-        "UPDATE settings SET editable_settings = :settings",
-        {"settings": json.dumps(editable_settings)},
-    )
+    for key, value in editable_settings.items():
+        try:
+            await update_settings_field(key, value, tag)
+        except Exception as _:
+            logger.warning(f"Failed to update settings for '{tag}.{key}'.")
 
 
 async def update_super_user(super_user: str) -> SuperSettings:
-    await db.execute(
-        "UPDATE settings SET super_user = :user",
-        {"user": super_user},
-    )
+    await update_settings_field("super_user", super_user)
     settings = await get_super_settings()
     assert settings, "updated super_user settings could not be retrieved"
     return settings
 
 
+async def delete_admin_settings(tag: Optional[str] = "core") -> None:
+    await db.execute("DELETE FROM settings WEHERE tag = :tag", {"tag": tag})
+
+
 async def create_admin_settings(super_user: str, new_settings: dict):
-    await db.execute(
-        """
-        INSERT INTO settings (super_user, editable_settings)
-        VALUES (:user, :settings)
-        """,
-        {"user": super_user, "settings": json.dumps(new_settings)},
-    )
+    data = {"super_user": super_user, **new_settings}
+    for key, value in data.items():
+        await create_settings_field(key, value)
+
     settings = await get_super_settings()
     assert settings, "created admin settings could not be retrieved"
     return settings
+
+
+async def create_settings_field(
+    id_: str, value: Optional[Any], tag: Optional[str] = "core"
+):
+    value = json.dumps(value) if value else None
+    field = SettingsField(id=id_, value=value, tag=tag or "core")
+    await db.insert("system_settings", field)
+
+
+async def get_settings_field(
+    id_: str, tag: Optional[str] = "core"
+) -> Optional[SettingsField]:
+
+    row: dict = await db.fetchone(
+        """
+            SELECT * FROM system_settings
+            WHERE  id = :id AND tag = :tag
+        """,
+        {"id": id_, "tag": tag},
+    )
+    if not row:
+        return None
+    return SettingsField(id=row["id"], value=json.loads(row["value"]), tag=row["tag"])
+
+
+async def update_settings_field(
+    id_: str, value: Optional[Any], tag: Optional[str] = "core"
+) -> SettingsField:
+    field = SettingsField(id=id_, value=json.dumps(value), tag=tag or "core")
+    await db.update("system_settings", field)
+    return field
+
+
+async def get_settings_by_tag(tag: str) -> Optional[dict[str, Any]]:
+    fields: list[SettingsField] = await db.fetchall(
+        "SELECT * FROM system_settings WHERE tag = :tag", {"tag": tag}, SettingsField
+    )
+    if len(fields) == 0:
+        return None
+    data: dict[str, Any] = {}
+    for field in fields:
+        try:
+            data[field.id] = json.loads(field.value) if field.value else None
+        except Exception as _:
+            logger.warning(f"Failed to load settings value for '{tag}.{field.id}'.")
+            data[field.id] = None
+    data.pop("super_user")
+    return data

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -61,7 +61,7 @@ async def delete_admin_settings(tag: Optional[str] = "core") -> None:
     await db.execute("DELETE FROM settings WEHERE tag = :tag", {"tag": tag})
 
 
-async def create_admin_settings(super_user: str, new_settings: dict):
+async def create_admin_settings(super_user: str, new_settings: dict) -> SuperSettings:
     data = {"super_user": super_user, **new_settings}
     for key, value in data.items():
         await create_settings_field(key, value)

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -74,7 +74,7 @@ async def create_admin_settings(super_user: str, new_settings: dict):
 async def create_settings_field(
     id_: str, value: Optional[Any], tag: Optional[str] = "core"
 ):
-    value = json.dumps(value) if value else None
+    value = json.dumps(value) if value is not None else None
     field = SettingsField(id=id_, value=value, tag=tag or "core")
     await db.insert("system_settings", field)
 
@@ -115,6 +115,5 @@ async def get_settings_by_tag(tag: str) -> Optional[dict[str, Any]]:
             data[field.id] = json.loads(field.value) if field.value else None
         except Exception as _:
             logger.warning(f"Failed to load settings value for '{tag}.{field.id}'.")
-            data[field.id] = None
     data.pop("super_user")
     return data

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -654,11 +654,11 @@ async def m028_update_settings(db: Connection):
         )
 
     row: dict = await db.fetchone("SELECT * FROM settings")
+    if row:
+        await _insert_key_value("super_user", row["super_user"])
+        editable_settings = json.loads(row["editable_settings"])
 
-    await _insert_key_value("super_user", row["super_user"])
-    editable_settings = json.loads(row["editable_settings"])
-
-    for key, value in editable_settings.items():
-        await _insert_key_value(key, value)
+        for key, value in editable_settings.items():
+            await _insert_key_value(key, value)
 
     await db.execute("drop table settings")

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -639,7 +639,9 @@ async def m028_update_settings(db: Connection):
         CREATE TABLE IF NOT EXISTS system_settings (
             id TEXT PRIMARY KEY,
             value TEXT,
-            tag TEXT NOT NULL DEFAULT 'core'
+            tag TEXT NOT NULL DEFAULT 'core',
+
+            UNIQUE (id, tag)
         );
     """
     )

--- a/lnbits/core/services/settings.py
+++ b/lnbits/core/services/settings.py
@@ -29,7 +29,8 @@ async def check_webpush_settings():
             "lnbits_webpush_pubkey": pubkey,
         }
         update_cached_settings(push_settings)
-        await update_admin_settings(EditableSettings(**push_settings))
+        if settings.lnbits_admin_ui:
+            await update_admin_settings(EditableSettings(**push_settings))
 
     logger.info("Initialized webpush settings with generated VAPID key pair.")
     logger.info(f"Pubkey: {settings.lnbits_webpush_pubkey}")

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -684,6 +684,12 @@ class AdminSettings(EditableSettings):
     lnbits_allowed_funding_sources: Optional[list[str]]
 
 
+class SettingsField(BaseModel):
+    id: str
+    value: Optional[Any]
+    tag: str = "core"
+
+
 def set_cli_settings(**kwargs):
     for key, value in kwargs.items():
         setattr(settings, key, value)


### PR DESCRIPTION
### Summary
Previously the `settings` were saved as JSON in DB. This made it hard to update a particular value.

This PR introduces a new table called `system_settings` where the values are saved like so:
![image](https://github.com/user-attachments/assets/01eb1744-edd5-4382-849a-7eec701f7fcd)

- the value is serialised with `json.dumps()` and deserialised with `json.loads()` so the type is preserved (number, list, string, etc)
- the tag defaults to `core`, but it can be used in future by extensions (ex: `satspay`)