### PR TITLE
chore: use the v1 branch for JMeter tests

### DIFF
--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -36,7 +36,7 @@ jobs:
       - name: clone lnbits-extensions, install jmeter and run tests
         run: |
           git clone https://github.com/lnbits/lnbits-extensions
-          git fetch
+          git fetch origin v1_updates:v1_updates
           git checkout v1_updates
           cd lnbits-extensions
           mkdir logs

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -35,10 +35,7 @@ jobs:
 
       - name: clone lnbits-extensions, install jmeter and run tests
         run: |
-          git clone https://github.com/lnbits/lnbits-extensions
-          git remote update
-          git fetch
-          git checkout --track origin/v1_updates
+          git clone https://github.com/lnbits/lnbits-extensions -b v1_updates --single-branch
           cd lnbits-extensions
           mkdir logs
           mkdir reports

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -51,4 +51,4 @@ jobs:
           name: jmeter-extension-test-results
           path: |
             lnbits-extensions/reports/
-            lnbits-extensions/logs/
+            data/logs/

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -36,6 +36,7 @@ jobs:
       - name: clone lnbits-extensions, install jmeter and run tests
         run: |
           git clone https://github.com/lnbits/lnbits-extensions
+          git fetch
           git checkout v1_updates
           cd lnbits-extensions
           mkdir logs

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -36,8 +36,8 @@ jobs:
       - name: clone lnbits-extensions, install jmeter and run tests
         run: |
           git clone https://github.com/lnbits/lnbits-extensions
-          git fetch origin v1_updates:v1_updates
-          git checkout v1_updates
+          git fetch
+          git checkout --track origin/v1_updates
           cd lnbits-extensions
           mkdir logs
           mkdir reports

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -36,6 +36,7 @@ jobs:
       - name: clone lnbits-extensions, install jmeter and run tests
         run: |
           git clone https://github.com/lnbits/lnbits-extensions
+          git checkout v1_updates
           cd lnbits-extensions
           mkdir logs
           mkdir reports

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           git clone https://github.com/lnbits/lnbits-extensions
           git fetch
-          git checkout --track origin/v1_updates
+          git checkout origin/v1_updates
           cd lnbits-extensions
           mkdir logs
           mkdir reports

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -29,6 +29,7 @@ jobs:
           LNBITS_ADMIN_UI: true
           LNBITS_EXTENSIONS_DEFAULT_INSTALL: "watchonly, satspay, tipjar, tpos, lnurlp, withdraw"
           LNBITS_BACKEND_WALLET_CLASS: FakeWallet
+          LNBITS_EXTENSIONS_MANIFESTS: "https://raw.githubusercontent.com/lnbits/lnbits-extensions/refs/heads/v1_updates/extensions_v1.json"
         run: |
           poetry run lnbits &
           sleep 5

--- a/.github/workflows/jmeter.yml
+++ b/.github/workflows/jmeter.yml
@@ -36,8 +36,9 @@ jobs:
       - name: clone lnbits-extensions, install jmeter and run tests
         run: |
           git clone https://github.com/lnbits/lnbits-extensions
+          git remote update
           git fetch
-          git checkout origin/v1_updates
+          git checkout --track origin/v1_updates
           cd lnbits-extensions
           mkdir logs
           mkdir reports

--- a/lnbits/core/models/extensions.py
+++ b/lnbits/core/models/extensions.py
@@ -42,9 +42,8 @@ class ExplicitRelease(BaseModel):
     def is_version_compatible(self):
         if not self.min_lnbits_version:
             return True
-        # remove any suffixes from the version
-        lnbits_version = settings.version.split("-")[0].split("rc")[0]
-        return version_parse(self.min_lnbits_version) <= version_parse(lnbits_version)
+
+        return version_parse(self.min_lnbits_version) <= version_parse(settings.version)
 
 
 class GitHubRelease(BaseModel):

--- a/lnbits/core/models/extensions.py
+++ b/lnbits/core/models/extensions.py
@@ -42,7 +42,9 @@ class ExplicitRelease(BaseModel):
     def is_version_compatible(self):
         if not self.min_lnbits_version:
             return True
-        return version_parse(self.min_lnbits_version) <= version_parse(settings.version)
+        # remove any suffixes from the version
+        lnbits_version = settings.version.split("-")[0].split("rc")[0]
+        return version_parse(self.min_lnbits_version) <= version_parse(lnbits_version)
 
 
 class GitHubRelease(BaseModel):


### PR DESCRIPTION
This PR uses branch `v1_updates` of `lnbits-extensions`.