### PR TITLE
[feat] install extensions from dir

### DIFF
--- a/lnbits/core/models/extensions.py
+++ b/lnbits/core/models/extensions.py
@@ -169,11 +169,7 @@ class Extension(BaseModel):
             name=ext_info.name,
             short_description=ext_info.short_description,
             tile=ext_info.icon,
-            upgrade_hash=(
-                ext_info.hash
-                if settings.extension_has_been_activated(ext_info.id)
-                else ""
-            ),
+            upgrade_hash=ext_info.hash if ext_info.ext_upgrade_dir.is_dir() else "",
         )
 
 

--- a/lnbits/core/models/extensions.py
+++ b/lnbits/core/models/extensions.py
@@ -552,6 +552,39 @@ class InstallableExtension(BaseModel):
         )
 
     @classmethod
+    def from_ext_dir(cls, ext_id: str) -> Optional[InstallableExtension]:
+        try:
+            conf_path = Path(
+                settings.lnbits_extensions_path, "extensions", ext_id, "config.json"
+            )
+            with open(conf_path, "r+") as json_file:
+                config_json = json.load(json_file)
+                version = config_json.get("version", "0.0")
+
+                return InstallableExtension(
+                    id=ext_id,
+                    name=config_json.get("name", ext_id),
+                    active=True,
+                    version=version,
+                    short_description=config_json.get("short_description"),
+                    icon=config_json.get("tile"),
+                    meta=ExtensionMeta(
+                        installed_release=ExtensionRelease(
+                            name=ext_id,
+                            version=version,
+                            archive=f"{conf_path}",
+                            source_repo=f"{conf_path}",
+                            min_lnbits_version=config_json.get("min_lnbits_version"),
+                        )
+                    ),
+                )
+
+        except Exception as e:
+            logger.warning(e)
+
+        return None
+
+    @classmethod
     async def get_installable_extensions(
         cls,
     ) -> list[InstallableExtension]:

--- a/lnbits/core/models/extensions.py
+++ b/lnbits/core/models/extensions.py
@@ -553,6 +553,8 @@ class InstallableExtension(BaseModel):
             conf_path = Path(
                 settings.lnbits_extensions_path, "extensions", ext_id, "config.json"
             )
+            if not conf_path.is_file():
+                return None
             with open(conf_path, "r+") as json_file:
                 config_json = json.load(json_file)
                 version = config_json.get("version", "0.0")

--- a/lnbits/core/templates/core/extensions.html
+++ b/lnbits/core/templates/core/extensions.html
@@ -1023,6 +1023,10 @@
             })
             if (this.uninstallAndDropDb) {
               this.showDropDb()
+            } else {
+              setTimeout(() => {
+                window.location.reload()
+              }, 300)
             }
           })
           .catch(err => {
@@ -1051,6 +1055,9 @@
               type: 'positive',
               message: 'Extension DB deleted!'
             })
+            setTimeout(() => {
+              window.location.reload()
+            }, 300)
           })
           .catch(err => {
             LNbits.utils.notifyApiError(err)
@@ -1073,6 +1080,7 @@
           })
           .catch(err => {
             LNbits.utils.notifyApiError(err)
+            extension.isActive = false
             extension.inProgress = false
           })
       },

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -129,10 +129,6 @@ class InstalledExtensionsSettings(LNbitsSettings):
     # list of all extension ids
     lnbits_all_extensions_ids: set[str] = Field(default=[])
 
-    # list of all extension ids that have been activated at least once
-    # only add to this set, do not remove
-    lnbits_activated_paths_extensions_ids: set[str] = Field(default=[])
-
     def find_extension_redirect(
         self, path: str, req_headers: list[tuple[bytes, bytes]]
     ) -> Optional[RedirectPath]:
@@ -165,14 +161,10 @@ class InstalledExtensionsSettings(LNbitsSettings):
             self._activate_extension_redirects(ext_id, ext_redirects)
 
         self.lnbits_all_extensions_ids.add(ext_id)
-        self.lnbits_activated_paths_extensions_ids.add(ext_id)
 
     def deactivate_extension_paths(self, ext_id: str):
         self.lnbits_deactivated_extensions.add(ext_id)
         self._remove_extension_redirects(ext_id)
-
-    def extension_has_been_activated(self, ext_id: str) -> bool:
-        return ext_id in settings.lnbits_activated_paths_extensions_ids
 
     def extension_upgrade_hash(self, ext_id: str) -> str:
         return settings.lnbits_upgraded_extensions.get(ext_id, "")


### PR DESCRIPTION
### Summary
 - allow the installation of extensions by simply 
      - pasting the extension files at the  `LNBITS_EXTENSIONS_PATH`
      - creating a symbolic link from the extension dir to the `LNBITS_EXTENSIONS_PATH
           - eg: `ln -s $(pwd) /bla/bla/lnbits/data/extensions/extensions`
 - improve the logic for determining if an extension is first install or upgrade
 - minor UI refresh fixes