### PR TITLE
fix: don't show when custom badge is not set

### DIFF
--- a/lnbits/core/templates/admin/_tab_theme.html
+++ b/lnbits/core/templates/admin/_tab_theme.html
@@ -83,7 +83,7 @@
                 filled
                 type="text"
                 tip="Custom Badge"
-                v-model="formData.lnbits_custom_badge"
+                v-model.trim="formData.lnbits_custom_badge"
                 label="Custom Badge 'USE WITH CAUTION - LNbits wallet is still in BETA'"
               ></q-input>
             </div>

--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -67,10 +67,11 @@
             </q-badge>
             {%endif%} {% if LNBITS_CUSTOM_BADGE is defined %}
             <q-badge
+              v-if="`{{LNBITS_CUSTOM_BADGE}}`.length > 0"
               v-show="$q.screen.gt.sm"
               color="{{ LNBITS_CUSTOM_BADGE_COLOR }}"
               class="q-mr-md"
-              label="{{LNBITS_CUSTOM_BADGE}}"
+              label="{{LNBITS_CUSTOM_BADGE|e}}"
             >
             </q-badge>
             {%endif%} {% if LNBITS_SERVICE_FEE > 0 %}


### PR DESCRIPTION
Proper remove CUSTOM BADGE if it's no text is set