### PR TITLE
fix: NWC mark and remove subs before sending close request

### DIFF
--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -408,7 +408,10 @@ class NWCConnection:
             if not sub_to_close["closed"]:
                 sub_to_close["closed"] = True
                 if send_event:
-                    await self._send(["CLOSE", sub_id])
+                    try:
+                        await self._send(["CLOSE", sub_id])
+                    except Exception as e:
+                        logger.error("Error closing subscription: " + str(e))
         return sub_to_close
 
     async def _close_subscription_by_eventid(
@@ -431,7 +434,10 @@ class NWCConnection:
             if not subscription["closed"]:
                 subscription["closed"] = True
                 if send_event:
-                    await self._send(["CLOSE", subscription["sub_id"]])
+                    try:
+                        await self._send(["CLOSE", subscription["sub_id"]])
+                    except Exception as e:
+                        logger.error("Error closing subscription: " + str(e))                    
         return subscription
 
     async def _wait_for_connection(self):

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -401,16 +401,14 @@ class NWCConnection:
         for subscription in self.subscriptions.values():
             if subscription["sub_id"] == sub_id:
                 sub_to_close = subscription
-                # send CLOSE event to the relay if the subscription
-                # is not already closed and sendEvent is True
-                if not subscription["closed"] and send_event:
-                    await self._send(["CLOSE", sub_id])
-                # mark as closed
-                subscription["closed"] = True
                 break
         # remove the subscription from the list
         if sub_to_close:
             self.subscriptions.pop(sub_to_close["event_id"], None)
+            if not sub_to_close["closed"]:
+                sub_to_close["closed"] = True
+                if send_event:
+                    await self._send(["CLOSE", sub_id])
         return sub_to_close
 
     async def _close_subscription_by_eventid(
@@ -430,12 +428,10 @@ class NWCConnection:
         # find and remove the subscription
         subscription = self.subscriptions.pop(event_id, None)
         if subscription:
-            # send CLOSE event to the relay if the subscription
-            # is not already closed and sendEvent is True
-            if not subscription["closed"] and send_event:
-                await self._send(["CLOSE", subscription["sub_id"]])
-            # mark as closed
-            subscription["closed"] = True
+            if not subscription["closed"]:
+                subscription["closed"] = True
+                if send_event:
+                    await self._send(["CLOSE", subscription["sub_id"]])
         return subscription
 
     async def _wait_for_connection(self):

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -437,7 +437,7 @@ class NWCConnection:
                     try:
                         await self._send(["CLOSE", subscription["sub_id"]])
                     except Exception as e:
-                        logger.error("Error closing subscription: " + str(e))                    
+                        logger.error("Error closing subscription: " + str(e))
         return subscription
 
     async def _wait_for_connection(self):


### PR DESCRIPTION
If the WebSocket is already closed when a subscription times out (e.g., due to a relay restart or dropped connection), the NWC funding source fails to send the CLOSE event, resulting in an exception. This prevents the subscription from being marked as closed and removed from the subscription list. Consequently, LNbits attempts to close the subscription repeatedly.

This PR resolves the issue by ensuring subscriptions are marked as closed and removed from the list before the CLOSE event is sent.