### PR TITLE
fix: Add timeout to wait_for_connection

### DIFF
--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -440,11 +440,14 @@ class NWCConnection:
                         logger.error("Error closing subscription: " + str(e))
         return subscription
 
-    async def _wait_for_connection(self):
+    async def _wait_for_connection(self, timeout=60 * 2):
         """
         Waits until the connection is ready
         """
+        t = time.time()
         while not self.connected:
+            if time.time() - t > timeout:
+                raise Exception("Connection timeout, cannot connect to NWC service")
             if self._is_shutting_down():
                 raise Exception("Connection is closing")
             logger.debug("Waiting for connection...")

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -440,7 +440,7 @@ class NWCConnection:
                         logger.error("Error closing subscription: " + str(e))
         return subscription
 
-    async def _wait_for_connection(self, timeout=60 * 2):
+    async def _wait_for_connection(self, timeout: int = 60 * 2):
         """
         Waits until the connection is ready
         """


### PR DESCRIPTION
Gives up connecting to the nwc service if it doesn't respond for 2 minutes.

Closes https://github.com/lnbits/lnbits/issues/2883 .
