### PR TITLE
fix: lnbits/upgrades where not ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ lnbits-backup.zip
 
 # Ignore extensions (post installable extension PR)
 /lnbits/extensions
-/upgrades/
+/lnbits/upgrades/
 
 # builded python package
 dist


### PR DESCRIPTION
after updating extension i saw a dirty repo with the upgrades, this one ignores them for sure