### PR TITLE
fix: convert `BigDecimal` object to `int` (postgres only)

### DIFF
--- a/lnbits/core/services/funding_source.py
+++ b/lnbits/core/services/funding_source.py
@@ -22,7 +22,7 @@ async def get_balance_delta() -> BalanceDelta:
     status = await funding_source.status()
     lnbits_balance = await get_total_balance()
     return BalanceDelta(
-        lnbits_balance_sats=lnbits_balance // 1000,
+        lnbits_balance_sats=int(lnbits_balance) // 1000,
         node_balance_sats=status.balance_msat // 1000,
     )
 


### PR DESCRIPTION
Fixes this error:
![image](https://github.com/user-attachments/assets/fb3e7388-30c1-4ba2-a6dc-3406962aceb4)
