### PR TITLE
feat: add `normalize_path ` helper

### DIFF
--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -323,5 +323,5 @@ def path_segments(path: str) -> list[str]:
     return segments[0:]
 
 
-def normalize_url(url: str) -> str:
-    return "/" + "/".join(path_segments(url))
+def normalize_path(path: str) -> str:
+    return "/" + "/".join(path_segments(path))

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -312,3 +312,16 @@ def get_api_routes(routes: list) -> dict[str, str]:
             data["/".join(segments[0:4])] = segments[1].capitalize()
 
     return data
+
+def path_segments(path: str) -> list[str]:
+    path = path.strip("/")
+    segments = path.split("/")
+    if len(segments) < 2:
+        return segments
+    if segments[0] == "upgrades":
+        return segments[2:]
+    return segments[0:]
+
+
+def normalize_url(url: str) -> str:
+    return "/" + "/".join(path_segments(url))

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -313,6 +313,7 @@ def get_api_routes(routes: list) -> dict[str, str]:
 
     return data
 
+
 def path_segments(path: str) -> list[str]:
     path = path.strip("/")
     segments = path.split("/")
@@ -323,5 +324,6 @@ def path_segments(path: str) -> list[str]:
     return segments[0:]
 
 
-def normalize_path(path: str) -> str:
+def normalize_path(path: Optional[str]) -> str:
+    path = path or ""
     return "/" + "/".join(path_segments(path))

--- a/lnbits/middleware.py
+++ b/lnbits/middleware.py
@@ -15,7 +15,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from lnbits.core.db import core_app_extra
 from lnbits.core.models import AuditEntry
-from lnbits.helpers import template_renderer
+from lnbits.helpers import normalize_path, template_renderer
 from lnbits.settings import settings
 
 
@@ -156,6 +156,7 @@ class AuditMiddleware(BaseHTTPMiddleware):
             if settings.is_super_user(user_id):
                 user_id = "super_user"
             component = "core"
+            path = normalize_path(path)
             if path and not path.startswith("/api"):
                 component = path.split("/")[1]
 


### PR DESCRIPTION
Required in order to fix `/upgrades` path issues

Failing reason: waiting for a new rc