### PR TITLE
Feat (crypto): Add URL-safe encoding option to AESCipher

### DIFF
--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -224,18 +224,30 @@ def create_access_token(data: dict, token_expire_minutes: Optional[int] = None) 
     return jwt.encode(to_encode, settings.auth_secret_key, "HS256")
 
 
-def encrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
-    """Encrypt message with the internal secret key"""
+def encrypt_internal_message(m: Optional[str] = None, urlsafe: bool = False) -> Optional[str]:
+    """
+    Encrypt message with the internal secret key
+
+    Args:
+        m: Message to encrypt
+        urlsafe: Whether to use URL-safe base64 encoding
+    """
     if not m:
         return None
-    return AESCipher(key=settings.auth_secret_key).encrypt(m.encode())
+    return AESCipher(key=settings.auth_secret_key).encrypt(m.encode(), urlsafe=urlsafe)
 
 
-def decrypt_internal_message(m: Optional[str] = None) -> Optional[str]:
-    """Decrypt message with the internal secret key"""
+def decrypt_internal_message(m: Optional[str] = None, urlsafe: bool = False) -> Optional[str]:
+    """
+    Decrypt message with the internal secret key
+
+    Args:
+        m: Message to decrypt
+        urlsafe: Whether the message uses URL-safe base64 encoding
+    """
     if not m:
         return None
-    return AESCipher(key=settings.auth_secret_key).decrypt(m)
+    return AESCipher(key=settings.auth_secret_key).decrypt(m, urlsafe=urlsafe)
 
 
 def filter_dict_keys(data: dict, filter_keys: Optional[list[str]]) -> dict:

--- a/lnbits/utils/crypto.py
+++ b/lnbits/utils/crypto.py
@@ -63,10 +63,26 @@ class AESCipher:
             final_key += key
         return final_key[:output]
 
-    def decrypt(self, encrypted: str) -> str:
+    def decrypt(self, encrypted: str, urlsafe: bool = False) -> str:
         """Decrypts a string using AES-256-CBC."""
         passphrase = self.passphrase
-        encrypted_bytes = base64.b64decode(encrypted)
+        try:
+            # Try urlsafe first if specified
+            if urlsafe:
+                encrypted_bytes = base64.urlsafe_b64decode(encrypted)
+            else:
+                encrypted_bytes = base64.b64decode(encrypted)
+        except Exception:
+            # Fallback to other method if the first fails
+            try:
+                encrypted_bytes = (
+                    base64.urlsafe_b64decode(encrypted)
+                    if not urlsafe
+                    else base64.b64decode(encrypted)
+                )
+            except Exception as exc:
+                raise ValueError("Invalid base64 encoding") from exc
+
         assert encrypted_bytes[0:8] == b"Salted__"
         salt = encrypted_bytes[8:16]
         key_iv = self.bytes_to_key(passphrase.encode(), salt, 32 + 16)
@@ -78,13 +94,14 @@ class AESCipher:
         except UnicodeDecodeError as exc:
             raise ValueError("Wrong passphrase") from exc
 
-    def encrypt(self, message: bytes) -> str:
+    def encrypt(self, message: bytes, urlsafe: bool = False) -> str:
         passphrase = self.passphrase
         salt = Random.new().read(8)
         key_iv = self.bytes_to_key(passphrase.encode(), salt, 32 + 16)
         key = key_iv[:32]
         iv = key_iv[32:]
         aes = AES.new(key, AES.MODE_CBC, iv)
-        return base64.b64encode(
-            b"Salted__" + salt + aes.encrypt(self.pad(message))
+        encoded = b"Salted__" + salt + aes.encrypt(self.pad(message))
+        return (
+            base64.urlsafe_b64encode(encoded) if urlsafe else base64.b64encode(encoded)
         ).decode()


### PR DESCRIPTION
## Problem
extensions like [lnbits/nostrmarket](https://github.com/lnbits/nostrmarket) use `encrypt_internal_message()` to encrypt data that is later used as a URL parameter. The current implementation uses standard base64 encoding which can produce characters like '+' and '/' that need to be URL-encoded to be safely used in URLs.

### nostrmarket example
```python
relay_endpoint = encrypt_internal_message("relay")
on_open, on_message, on_error, on_close = self._ws_handlers()
ws = WebSocketApp(
    f"ws://localhost:{settings.port}/nostrclient/api/v1/{relay_endpoint}", # relay_endpoint is URL-unsafe!
```
> [Relevant code](https://github.com/lnbits/nostrmarket/blob/de7fe059b856baa790f0ff3d8cf217512ce24d56/nostr/nostr_client.py#L30-L47)

## Solution
Add an optional `urlsafe` parameter to AESCipher and helper methods to support URL-safe base64 encoding while maintaining backward compatibility.

## Other places in lnbits `encrypt_internal_messages` appears
https://github.com/search?q=org%3Alnbits%20encrypt_internal_message&type=code

### Changes
- Add `urlsafe` parameter to `AESCipher.encrypt()` and `decrypt()` methods
- Update `encrypt_internal_message()` and `decrypt_internal_message()` helpers to support URL-safe option
- Add fallback logic in `decrypt()` to handle both encoding types

Example usage:
```python
# URL-safe encryption (new)
encrypted = encrypt_internal_message("my message", urlsafe=True)

# Standard encryption (existing behavior)
encrypted = encrypt_internal_message("my message")
```

## Testing
- [ ] Verify standard encryption/decryption still works as before
- [ ] Verify URL-safe encryption produces valid URL parameters
- [ ] Verify decrypt handles both encoding types correctly
- [ ] Test with Extension_A using URL-safe encoding

## TODO
- [ ] Update documentation with new parameter descriptions (?)

## Migration
Extensions using encrypted values in URLs should update their calls to `encrypt_internal_message()` to use `urlsafe=True`. No changes needed for other usages.

Related to lnbits/nostrclient#30