### PR TITLE
[fix] admin errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -186,7 +186,7 @@ LNBITS_ADMIN_USERS=""
 # SUPER_USER=""
 
 # Extensions only admin can access
-LNBITS_ADMIN_EXTENSIONS="ngrok, admin"
+LNBITS_ADMIN_EXTENSIONS="ngrok, nostrclient"
 # Extensions enabled by default when a user is created
 LNBITS_USER_DEFAULT_EXTENSIONS="lnurlp"
 

--- a/lnbits/core/templates/admin/_tab_theme.html
+++ b/lnbits/core/templates/admin/_tab_theme.html
@@ -61,8 +61,8 @@
             v-model="formData.lnbits_denomination"
             label="sats"
             :hint="$t('denomination_hint')"
-            :rules="[(val) => !val || val.length = 3 || val === 'sats' || $t('denomination_error')]"
           ></q-input>
+          <!-- :rules="[(val) => !val || val.length = 3 || val === 'sats' || $t('denomination_error')]" -->
         </div>
         <div class="col-12 col-md-4">
           <p><span v-text="$t('ui_qr_code_logo')"></span></p>


### PR DESCRIPTION
- `admin` is not an extension
- temp disable a js rule that was causing
![image](https://github.com/user-attachments/assets/48889dbf-567d-41b0-9261-79328a694cdc)
