### PR TITLE
[fix]: rate limiter init

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -81,6 +81,7 @@ async def startup(app: FastAPI):
 
     # setup admin settings
     await check_admin_settings()
+    core_app_extra.register_new_ratelimiter()
     await check_webpush_settings()
 
     # check extensions after restart


### PR DESCRIPTION
call the rate limiter init after the settings have been loaded from DB