### PR TITLE
perf: improve update pending payments logic

### DIFF
--- a/lnbits/core/services/__init__.py
+++ b/lnbits/core/services/__init__.py
@@ -13,8 +13,8 @@ from .payments import (
     fee_reserve_total,
     pay_invoice,
     service_fee,
-    update_pending_payments,
     update_wallet_balance,
+    update_wallet_pending_payments,
 )
 from .settings import (
     check_webpush_settings,
@@ -49,7 +49,7 @@ __all__ = [
     "fee_reserve_total",
     "pay_invoice",
     "service_fee",
-    "update_pending_payments",
+    "update_wallet_pending_payments",
     "update_wallet_balance",
     # settings
     "check_webpush_settings",

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -203,7 +203,8 @@ async def update_pending_payments(
     payments: list[Payment], delay: Optional[float] = None
 ) -> list[Payment]:
     for payment in payments:
-        await update_pending_payment(payment)
+        if payment.pending:
+            await update_pending_payment(payment)
         if delay is not None:
             await asyncio.sleep(delay)  # to avoid complete blocking
     return payments

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -15,7 +15,6 @@ from lnbits.db import Connection, Filters
 from lnbits.decorators import check_user_extension_access
 from lnbits.exceptions import InvoiceError, PaymentError
 from lnbits.settings import settings
-from lnbits.tasks import create_task
 from lnbits.utils.crypto import fake_privkey, random_secret_and_hash
 from lnbits.utils.exchange_rates import fiat_amount_as_satoshis, satoshis_amount_as_fiat
 from lnbits.wallets import fake_wallet, get_funding_source
@@ -569,6 +568,8 @@ async def _pay_external_invoice(
 
     fee_reserve_msat = fee_reserve(amount_msat, internal=False)
     service_fee_msat = service_fee(amount_msat, internal=False)
+
+    from lnbits.tasks import create_task
 
     task = create_task(
         _fundingsource_pay_invoice(checking_id, payment.bolt11, fee_reserve_msat)

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -68,7 +68,7 @@ from ..services import (
     create_invoice,
     fee_reserve_total,
     pay_invoice,
-    update_pending_payments,
+    update_wallet_pending_payments,
 )
 
 payment_router = APIRouter(prefix="/api/v1/payments", tags=["Payments"])
@@ -86,7 +86,7 @@ async def api_payments(
     key_info: WalletTypeInfo = Depends(require_invoice_key),
     filters: Filters = Depends(parse_filters(PaymentFilters)),
 ):
-    await update_pending_payments(key_info.wallet.id)
+    await update_wallet_pending_payments(key_info.wallet.id)
     return await get_payments(
         wallet_id=key_info.wallet.id,
         pending=True,
@@ -106,7 +106,7 @@ async def api_payments_history(
     group: DateTrunc = Query("day"),
     filters: Filters[PaymentFilters] = Depends(parse_filters(PaymentFilters)),
 ):
-    await update_pending_payments(key_info.wallet.id)
+    await update_wallet_pending_payments(key_info.wallet.id)
     return await get_payments_history(key_info.wallet.id, group, filters)
 
 
@@ -180,7 +180,7 @@ async def api_payments_paginated(
     key_info: WalletTypeInfo = Depends(require_invoice_key),
     filters: Filters = Depends(parse_filters(PaymentFilters)),
 ):
-    await update_pending_payments(key_info.wallet.id)
+    await update_wallet_pending_payments(key_info.wallet.id)
     page = await get_payments_paginated(
         wallet_id=key_info.wallet.id,
         filters=filters,

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -17,7 +17,7 @@ from lnbits.core.crud import (
     update_payment,
 )
 from lnbits.core.models import Payment, PaymentState
-from lnbits.core.services.payments import update_pending_payments
+from lnbits.core.services.payments import update_all_pending_payments
 from lnbits.settings import settings
 from lnbits.wallets import get_funding_source
 
@@ -172,16 +172,20 @@ async def check_pending_payments():
                 f"Task [{offset, offset+limit}]: "
                 "checking pending payments of last 31 days..."
             )
-            pending_payments = await update_pending_payments(
+            pending_payments = await update_all_pending_payments(
                 offset=offset, limit=limit, since=since
             )
+            for i, payment in enumerate(pending_payments):
+                logger.debug(f"Payment[{offset+i}] status: {payment.status}")
             count = len(pending_payments)
             offset += limit
-            logger.info(
-                f"Task: pending check finished for {count} payments "
-                f"(took {time.time() - start_time:0.3f} s)"
-            )
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.1)  # time to breathe
+
+        logger.info(
+            f"Task: pending check finished for {offset+count} payments "
+            f"(took {time.time() - start_time:0.3f} s)"
+        )
+
         await asyncio.sleep(sleep_time)
 
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -362,35 +362,6 @@ async def test_get_payments_paginated(client, inkey_fresh_headers_to, fake_payme
     assert paginated["total"] == len(fake_data)
 
 
-@pytest.mark.anyio
-async def test_get_payments_history(client, inkey_fresh_headers_to, fake_payments):
-    fake_data, filters = fake_payments
-
-    response = await client.get(
-        "/api/v1/payments/history",
-        params=filters,
-        headers=inkey_fresh_headers_to,
-    )
-
-    assert response.status_code == 200
-    data = response.json()
-    assert len(data) == 1
-    assert data[0]["income"] == sum(
-        [int(payment.amount * 1000) for payment in fake_data if not payment.out]
-    )
-    assert data[0]["spending"] == sum(
-        [int(payment.amount * 1000) for payment in fake_data if payment.out]
-    )
-
-    response = await client.get(
-        "/api/v1/payments/history?group=INVALID",
-        params=filters,
-        headers=inkey_fresh_headers_to,
-    )
-
-    assert response.status_code == 400
-
-
 # check POST /api/v1/payments/decode
 @pytest.mark.anyio
 async def test_decode_invoice(client, invoice: Payment):


### PR DESCRIPTION
Changes:
 - `tasks.py`:
     -  performance improvement:  do not fetch all pending tasks at once (tested with 10k), instead fetch chunks of 100 pending tasks
     - move update pending payments logic to the payments service
 - `payments.py`
    - refactor: extract `update_pending_payment`, `update_pending_payments`, `update_all_pending_payments`
    - avoid circular dependency from `tasks.py`
 - `payments_api.py`
     - remove unused `/history` endpoint (used in old wallet chart)
     - **!!!** `api_payments_paginated` **!!! do not refresh all wallet payments for paginated**
       - some wallets have thousands of pending payments, this made this endpoint very slow since all pending payments were re-checked
       - now only the pending payments on the returned page are re-checked. This means that sometimes a `Failed/Success` payment might be included when only pending payments were filtered.