### PR TITLE
[fix] settings cleanup

### DIFF
--- a/lnbits/core/services/__init__.py
+++ b/lnbits/core/services/__init__.py
@@ -24,7 +24,6 @@ from .users import (
     check_admin_settings,
     create_user_account,
     create_user_account_no_ckeck,
-    init_admin_settings,
     update_user_account,
     update_user_extensions,
 )
@@ -58,7 +57,6 @@ __all__ = [
     "check_admin_settings",
     "create_user_account",
     "create_user_account_no_ckeck",
-    "init_admin_settings",
     "update_user_account",
     "update_user_extensions",
     # websockets

--- a/lnbits/core/services/users.py
+++ b/lnbits/core/services/users.py
@@ -175,7 +175,7 @@ async def check_admin_settings():
             )
     else:
         logger.warning("Super user not found in the database.")
-        settings.check_auth_secret_key(settings_db.super_user + str(datetime.now()))
+        settings.check_auth_secret_key(settings.super_user + str(datetime.now()))
 
     logger.success(
         "✔️ Admin UI is enabled. "

--- a/lnbits/core/services/users.py
+++ b/lnbits/core/services/users.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 from uuid import uuid4
@@ -136,54 +135,35 @@ async def check_admin_settings():
     if settings.super_user:
         settings.super_user = to_valid_user_id(settings.super_user).hex
 
-    if not settings.lnbits_admin_ui:
-        # set a temporary auth secret key if the admin did not configured it
-        settings.check_auth_secret_key(settings.super_user + str(datetime.now()))
+    if settings.lnbits_admin_ui:
+        settings_db = await get_super_settings()
+        if not settings_db:
+            # create new settings if table is empty
+            logger.warning("Settings DB empty. Inserting default settings.")
+            settings_db = await init_admin_settings(settings.super_user)
+            logger.warning("Initialized settings from environment variables.")
+
+        if settings.super_user and settings.super_user != settings_db.super_user:
+            # .env super_user overwrites DB super_user
+            settings_db = await update_super_user(settings.super_user)
+
+        update_cached_settings(settings_db.dict())
+
+        # saving superuser to {data_dir}/.super_user file
+        with open(Path(settings.lnbits_data_folder) / ".super_user", "w") as file:
+            file.write(settings.super_user)
+
+        account = await get_account(settings.super_user)
+        if account and account.extra and account.extra.provider == "env":
+            settings.first_install = True
+
         logger.success(
-            "✗ Admin UI is NOT enabled. Run `poetry run lnbits-cli superuser` "
+            "✔️ Admin UI is enabled. run `poetry run lnbits-cli superuser` "
             "to get the superuser."
         )
-        return
-
-    settings_db = await get_super_settings()
-    if not settings_db:
-        # create new settings if table is empty
-        logger.warning("Settings DB empty. Inserting default settings.")
-        settings_db = await _init_admin_settings(settings.super_user)
-        logger.warning("Initialized settings from environment variables.")
-
-    if settings.super_user and settings.super_user != settings_db.super_user:
-        # .env super_user overwrites DB super_user
-        settings_db = await update_super_user(settings.super_user)
-
-    update_cached_settings(settings_db.dict())
-
-    # saving superuser to {data_dir}/.super_user file
-    with open(Path(settings.lnbits_data_folder) / ".super_user", "w") as file:
-        file.write(settings.super_user)
-
-    account = await get_account(settings.super_user)
-    if account:
-        if account.extra.provider == "env":
-            # do not check the auth auth_secret on first install
-            # it will be set when the super user is configured
-            settings.first_install = True
-        else:
-            # The super user is forced to set a password
-            settings.check_auth_secret_key(
-                account.password_hash or str(account.created_at)
-            )
-    else:
-        logger.warning("Super user not found in the database.")
-        settings.check_auth_secret_key(settings.super_user + str(datetime.now()))
-
-    logger.success(
-        "✔️ Admin UI is enabled. "
-        "Access the app in the browser in order to set the super user credentials."
-    )
 
 
-async def _init_admin_settings(super_user: Optional[str] = None) -> SuperSettings:
+async def init_admin_settings(super_user: Optional[str] = None) -> SuperSettings:
     account = None
     if super_user:
         account = await get_account(super_user)

--- a/lnbits/core/views/auth_api.py
+++ b/lnbits/core/views/auth_api.py
@@ -459,7 +459,6 @@ async def first_install(data: UpdateSuperuserPassword) -> JSONResponse:
     account.hash_password(data.password)
     await update_account(account)
     settings.first_install = False
-    settings.check_auth_secret_key(account.password_hash or str(account.created_at))
     return _auth_success_response(account.username, account.id, account.email)
 
 

--- a/lnbits/core/views/auth_api.py
+++ b/lnbits/core/views/auth_api.py
@@ -459,6 +459,7 @@ async def first_install(data: UpdateSuperuserPassword) -> JSONResponse:
     account.hash_password(data.password)
     await update_account(account)
     settings.first_install = False
+    settings.check_auth_secret_key(account.password_hash or str(account.created_at))
     return _auth_success_response(account.username, account.id, account.email)
 
 

--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -10,7 +10,6 @@ from urllib.parse import urlparse
 import jinja2
 import jwt
 import shortuuid
-from fastapi import Request
 from fastapi.routing import APIRoute
 from packaging import version
 from pydantic.schema import field_schema
@@ -344,7 +343,3 @@ def path_segments(path: str) -> list[str]:
 def normalize_path(path: Optional[str]) -> str:
     path = path or ""
     return "/" + "/".join(path_segments(path))
-
-
-def normalized_path(request: Request) -> str:
-    return "/" + "/".join(path_segments(request.url.path))

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -11,6 +11,7 @@ from os import path
 from pathlib import Path
 from time import gmtime, strftime, time
 from typing import Any
+from uuid import uuid4
 
 from loguru import logger
 from pydantic import BaseModel, BaseSettings, Extra, Field, validator

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -807,7 +807,7 @@ class EnvSettings(LNbitsSettings):
         if self.auth_secret_key:
             return
         auth_key_file = Path(settings.lnbits_data_folder, ".lnbits_auth_key")
-        if auth_key_file.is_file():
+        if auth_key_file.exists() and auth_key_file.is_file():
             with open(auth_key_file) as file:
                 self.auth_secret_key = file.readline()
             return

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -807,6 +807,7 @@ class EnvSettings(LNbitsSettings):
     def check_auth_secret_key(self, extra_random: str):
         if self.auth_secret_key:
             return
+
 class PersistenceSettings(LNbitsSettings):
     lnbits_data_folder: str = Field(default="./data")
     lnbits_database_url: str = Field(default=None)

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.metadata
 import inspect
 import json
+import os
 import re
 from datetime import datetime, timezone
 from enum import Enum
@@ -806,6 +807,8 @@ class EnvSettings(LNbitsSettings):
     def check_auth_secret_key(self):
         if self.auth_secret_key:
             return
+        if not os.path.isdir(settings.lnbits_data_folder):
+            os.mkdir(settings.lnbits_data_folder)
         auth_key_file = Path(settings.lnbits_data_folder, ".lnbits_auth_key")
         if auth_key_file.is_file():
             with open(auth_key_file) as file:

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -274,9 +274,9 @@ class OpsSettings(LNbitsSettings):
 
 
 class FeeSettings(LNbitsSettings):
-    lnbits_reserve_fee_min: int = Field(default=2000)
-    lnbits_reserve_fee_percent: float = Field(default=1.0)
-    lnbits_service_fee: float = Field(default=0)
+    lnbits_reserve_fee_min: int = Field(default=2000, ge=0)
+    lnbits_reserve_fee_percent: float = Field(default=1.0, ge=0)
+    lnbits_service_fee: float = Field(default=0, ge=0)
     lnbits_service_fee_ignore_internal: bool = Field(default=True)
     lnbits_service_fee_max: int = Field(default=0)
     lnbits_service_fee_wallet: str | None = Field(default=None)
@@ -292,9 +292,9 @@ class FeeSettings(LNbitsSettings):
 
 
 class ExchangeProvidersSettings(LNbitsSettings):
-    lnbits_exchange_rate_cache_seconds: int = Field(default=30)
-    lnbits_exchange_history_size: int = Field(default=60)
-    lnbits_exchange_history_refresh_interval_seconds: int = Field(default=300)
+    lnbits_exchange_rate_cache_seconds: int = Field(default=30, ge=0)
+    lnbits_exchange_history_size: int = Field(default=60, ge=0)
+    lnbits_exchange_history_refresh_interval_seconds: int = Field(default=300, ge=0)
 
     lnbits_exchange_rate_providers: list[ExchangeRateProvider] = Field(
         default=[
@@ -359,7 +359,7 @@ class ExchangeProvidersSettings(LNbitsSettings):
 
 
 class SecuritySettings(LNbitsSettings):
-    lnbits_rate_limit_no: str = Field(default="200")
+    lnbits_rate_limit_no: int = Field(default=200, ge=0)
     lnbits_rate_limit_unit: str = Field(default="minute")
     lnbits_allowed_ips: list[str] = Field(default=[])
     lnbits_blocked_ips: list[str] = Field(default=[])
@@ -367,16 +367,16 @@ class SecuritySettings(LNbitsSettings):
         default=["^(?!\\d+\\.\\d+\\.\\d+\\.\\d+$)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$"]
     )
 
-    lnbits_wallet_limit_max_balance: int = Field(default=0)
-    lnbits_wallet_limit_daily_max_withdraw: int = Field(default=0)
-    lnbits_wallet_limit_secs_between_trans: int = Field(default=0)
+    lnbits_wallet_limit_max_balance: int = Field(default=0, ge=0)
+    lnbits_wallet_limit_daily_max_withdraw: int = Field(default=0, ge=0)
+    lnbits_wallet_limit_secs_between_trans: int = Field(default=0, ge=0)
     lnbits_only_allow_incoming_payments: bool = Field(default=False)
     lnbits_watchdog_switch_to_voidwallet: bool = Field(default=False)
-    lnbits_watchdog_interval_minutes: int = Field(default=60)
-    lnbits_watchdog_delta: int = Field(default=1_000_000)
+    lnbits_watchdog_interval_minutes: int = Field(default=60, gt=0)
+    lnbits_watchdog_delta: int = Field(default=1_000_000, gt=0)
 
-    lnbits_max_outgoing_payment_amount_sats: int = Field(default=10_000_000)
-    lnbits_max_incoming_payment_amount_sats: int = Field(default=10_000_000)
+    lnbits_max_outgoing_payment_amount_sats: int = Field(default=10_000_000, ge=0)
+    lnbits_max_incoming_payment_amount_sats: int = Field(default=10_000_000, ge=0)
 
     def is_wallet_max_balance_exceeded(self, amount):
         return (
@@ -405,9 +405,13 @@ class NotificationsSettings(LNbitsSettings):
     notification_balance_delta_changed: bool = Field(default=True)
     lnbits_notification_server_start_stop: bool = Field(default=True)
     lnbits_notification_watchdog: bool = Field(default=False)
-    lnbits_notification_server_status_hours: int = Field(default=24)
-    lnbits_notification_incoming_payment_amount_sats: int = Field(default=1_000_000)
-    lnbits_notification_outgoing_payment_amount_sats: int = Field(default=1_000_000)
+    lnbits_notification_server_status_hours: int = Field(default=24, gt=0)
+    lnbits_notification_incoming_payment_amount_sats: int = Field(
+        default=1_000_000, ge=0
+    )
+    lnbits_notification_outgoing_payment_amount_sats: int = Field(
+        default=1_000_000, ge=0
+    )
 
 
 class FakeWalletFundingSource(LNbitsSettings):
@@ -534,7 +538,7 @@ class BoltzFundingSource(LNbitsSettings):
 
 
 class LightningSettings(LNbitsSettings):
-    lightning_invoice_expiry: int = Field(default=3600)
+    lightning_invoice_expiry: int = Field(default=3600, gt=0)
 
 
 class FundingSourcesSettings(
@@ -561,7 +565,7 @@ class FundingSourcesSettings(
     lnbits_backend_wallet_class: str = Field(default="VoidWallet")
     # How long to wait for the payment to be confirmed before returning a pending status
     # It will not fail the payment, it will make it return pending after the timeout
-    lnbits_funding_source_pay_invoice_wait_seconds: int = Field(default=5)
+    lnbits_funding_source_pay_invoice_wait_seconds: int = Field(default=5, ge=0)
 
 
 class WebPushSettings(LNbitsSettings):
@@ -600,7 +604,7 @@ class AuthMethods(Enum):
 
 
 class AuthSettings(LNbitsSettings):
-    auth_token_expire_minutes: int = Field(default=525600)
+    auth_token_expire_minutes: int = Field(default=525600, gt=0)
     auth_all_methods = [a.value for a in AuthMethods]
     auth_allowed_methods: list[str] = Field(
         default=[
@@ -610,7 +614,7 @@ class AuthSettings(LNbitsSettings):
     )
     # How many seconds after login the user is allowed to update its credentials.
     # A fresh login is required afterwards.
-    auth_credetials_update_threshold: int = Field(default=120)
+    auth_credetials_update_threshold: int = Field(default=120, gt=0)
 
     def is_auth_method_allowed(self, method: AuthMethods):
         return method.value in self.auth_allowed_methods
@@ -642,7 +646,7 @@ class AuditSettings(LNbitsSettings):
     lnbits_audit_enabled: bool = Field(default=True)
 
     # number of days to keep the audit entry
-    lnbits_audit_retention_days: int = Field(default=7)
+    lnbits_audit_retention_days: int = Field(default=7, ge=0)
 
     lnbits_audit_log_ip_address: bool = Field(default=False)
     lnbits_audit_log_path_params: bool = Field(default=True)
@@ -779,7 +783,7 @@ class EnvSettings(LNbitsSettings):
     debug_database: bool = Field(default=False)
     bundle_assets: bool = Field(default=True)
     host: str = Field(default="127.0.0.1")
-    port: int = Field(default=5000)
+    port: int = Field(default=5000, gt=0)
     forwarded_allow_ips: str = Field(default="*")
     lnbits_title: str = Field(default="LNbits API")
     lnbits_path: str = Field(default=".")
@@ -791,18 +795,13 @@ class EnvSettings(LNbitsSettings):
     enable_log_to_file: bool = Field(default=True)
     log_rotation: str = Field(default="100 MB")
     log_retention: str = Field(default="3 months")
-    server_startup_time: int = Field(default=time())
-    cleanup_wallets_days: int = Field(default=90)
-    funding_source_max_retries: int = Field(default=4)
+
+    cleanup_wallets_days: int = Field(default=90, ge=0)
+    funding_source_max_retries: int = Field(default=4, ge=0)
 
     @property
     def has_default_extension_path(self) -> bool:
         return self.lnbits_extensions_path == "lnbits"
-
-    @property
-    def lnbits_server_up_time(self) -> str:
-        up_time = int(time() - self.server_startup_time)
-        return strftime("%H:%M:%S", gmtime(up_time))
 
     def check_auth_secret_key(self, extra_random: str):
         if self.auth_secret_key:
@@ -856,6 +855,13 @@ class TransientSettings(InstalledExtensionsSettings, ExchangeHistorySettings):
     latest_balance_delta_sats: int = Field(default=None)
 
     lnbits_all_extensions_ids: set[str] = Field(default=[])
+
+    server_startup_time: int = Field(default=time())
+
+    @property
+    def lnbits_server_up_time(self) -> str:
+        up_time = int(time() - self.server_startup_time)
+        return strftime("%H:%M:%S", gmtime(up_time))
 
     @classmethod
     def readonly_fields(cls):

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -807,12 +807,12 @@ class EnvSettings(LNbitsSettings):
         if self.auth_secret_key:
             return
         auth_key_file = Path(settings.lnbits_data_folder, ".lnbits_auth_key")
-        if auth_key_file.exists() and auth_key_file.is_file():
+        if auth_key_file.is_file():
             with open(auth_key_file) as file:
                 self.auth_secret_key = file.readline()
             return
         self.auth_secret_key = uuid4().hex
-        with open(auth_key_file, "w") as file:
+        with open(auth_key_file, "w+") as file:
             file.write(self.auth_secret_key)
 
 


### PR DESCRIPTION
- add validation for `int` and `float` settings
- remove SaaS settings and logic (use `first_install`) instead
- default to stronger default `auth_secret`
- create temporary `auth_secret` and store it in a file