### PR TITLE
fix: pay invoice dialog

### DIFF
--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -726,19 +726,19 @@
               </div>
               <div v-if="g.fiatTracking">
                 <div v-if="isFiatPriority">
+                  <h5 class="q-my-none text-bold">
+                    <span
+                      v-text="walletFormatBalance(parse.invoice.sat)"
+                    ></span>
+                  </h5>
+                </div>
+                <div v-else style="opacity: 0.75">
                   <div class="text-h5 text-italic">
                     <span
                       v-text="parse.invoice.fiatAmount"
                       style="opacity: 0.75"
                     ></span>
                   </div>
-                </div>
-                <div v-else style="opacity: 0.75">
-                  <h5 class="q-my-none text-bold">
-                    <span
-                      v-text="walletFormatBalance(parse.invoice.sat)"
-                    ></span>
-                  </h5>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Pay invoice dialog was showing sats twice, when it should show sats and fiat, if there was fiat tracking