### PR TITLE
FIX: Backwards compatibility for creating invoice with lnbits funding source

### DIFF
--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -87,13 +87,15 @@ class LNbitsWallet(Wallet):
             r.raise_for_status()
             data = r.json()
 
-            if r.is_error or "bolt11" not in data:
+            # Backwards compatibility for pre-v1 which used the key "payment_request"
+            payment_str = data.get("bolt11") or data.get("payment_request")
+            if r.is_error or not payment_str:
                 error_message = data["detail"] if "detail" in data else r.text
                 return InvoiceResponse(
                     False, None, None, f"Server error: '{error_message}'"
                 )
 
-            return InvoiceResponse(True, data["checking_id"], data["bolt11"], None)
+            return InvoiceResponse(True, data["checking_id"], payment_str, None)
         except json.JSONDecodeError:
             return InvoiceResponse(
                 False, None, None, "Server error: 'invalid json response'"


### PR DESCRIPTION
## Description
This PR adds backwards compatibility to handle both the new `bolt11` and legacy `payment_request` field names when creating invoices using an lnbits funding source.

## Changes
- Added fallback to check for `payment_request` if `bolt11` is not present
- Used `data.get()` for safer key access

## Why
Previously, LNbits used `payment_request` as the key for BOLT11 invoices, but newer versions use `bolt11`. This change ensures our wallet implementation works with both versions, preventing potential issues when interacting with different LNbits instances.

## Testing
- [x] Tested with v1.0.0rc8 using v0.12.12 lnbits as funding source
- [ ] Tested with older LNbits instance using newer lnbits as funding source
- [ ] Verified invoice creation works in both cases
- [ ] Verified error handling remains intact

resolves #3024