### PR TITLE
[fix] limit the size of the invoice description to 640 characters

### DIFF
--- a/lnbits/core/models/payments.py
+++ b/lnbits/core/models/payments.py
@@ -198,7 +198,7 @@ class CreateInvoice(BaseModel):
     internal: bool = False
     out: bool = True
     amount: float = Query(None, ge=0)
-    memo: str | None = Query(None, max_length=1024)
+    memo: str | None = Query(None, max_length=640)
     description_hash: str | None = None
     unhashed_description: str | None = None
     expiry: int | None = None

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -108,7 +108,7 @@ async def create_invoice(
     if not user_wallet:
         raise InvoiceError(f"Could not fetch wallet '{wallet_id}'.", status="failed")
 
-    invoice_memo = None if description_hash else memo[:1024]
+    invoice_memo = None if description_hash else memo[:640]
 
     # use the fake wallet if the invoice is for internal use only
     funding_source = fake_wallet if internal else get_funding_source()


### PR DESCRIPTION
The check is done on API level and on service level.
Fixes: https://github.com/lnbits/lnbits/issues/3034

See: https://github.com/lightning/bolts/issues/236#issuecomment-335970363

> Actually, the limit is 640 characters. That's because data_length is 10 bits long, and counts 5 bit values. So we can have 5*1024 bits == 640 bytes.

