### PR TITLE
feat: denom in the service fee badge, makes no sense

### DIFF
--- a/lnbits/templates/base.html
+++ b/lnbits/templates/base.html
@@ -89,7 +89,7 @@
             >
               {% if LNBITS_SERVICE_FEE_MAX > 0 %}
               <span
-                v-text='$t("service_fee_max_badge", { amount: "{{ LNBITS_SERVICE_FEE }}", max: "{{ LNBITS_SERVICE_FEE_MAX }}", denom: "{{ LNBITS_DENOMINATION }}"})'
+                v-text='$t("service_fee_max_badge", { amount: "{{ LNBITS_SERVICE_FEE }}", max: "{{ LNBITS_SERVICE_FEE_MAX }} {{ LNBITS_DENOMINATION }}"})'
               ></span>
               {%else%}
               <span


### PR DESCRIPTION
Its always sats or always some fakewallet denom.
Neither user base needs to be aware
