### PR TITLE
feat: dont reset superuser on delete settings endpoint

### DIFF
--- a/lnbits/core/crud/__init__.py
+++ b/lnbits/core/crud/__init__.py
@@ -43,6 +43,7 @@ from .settings import (
     delete_admin_settings,
     get_admin_settings,
     get_super_settings,
+    reset_core_settings,
     update_admin_settings,
     update_super_user,
 )
@@ -129,6 +130,7 @@ __all__ = [
     "get_super_settings",
     "update_admin_settings",
     "update_super_user",
+    "reset_core_settings",
     # tinyurl
     "create_tinyurl",
     "delete_tinyurl",

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -61,7 +61,7 @@ async def update_super_user(super_user: str) -> SuperSettings:
 
 
 async def delete_admin_settings(tag: Optional[str] = "core") -> None:
-    await db.execute("DELETE FROM settings WHERE tag = :tag", {"tag": tag})
+    await db.execute("DELETE FROM system_settings WHERE tag = :tag", {"tag": tag})
 
 
 async def create_admin_settings(super_user: str, new_settings: dict) -> SuperSettings:

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -62,9 +62,15 @@ async def update_super_user(super_user: str) -> SuperSettings:
 
 async def delete_admin_settings(tag: Optional[str] = "core") -> None:
     await db.execute(
+        "DELETE FROM system_settings WHERE tag = :tag",
+        {"tag": tag},
+    )
+
+
+async def reset_core_settings() -> None:
+    await db.execute(
         """
-        DELETE FROM system_settings
-        WHERE tag = :tag
+        DELETE FROM system_settings WHERE tag = 'core'
         AND (
             tag != 'core'
             OR id NOT IN (
@@ -74,7 +80,6 @@ async def delete_admin_settings(tag: Optional[str] = "core") -> None:
             )
         )
         """,
-        {"tag": tag},
     )
 
 

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -71,13 +71,10 @@ async def reset_core_settings() -> None:
     await db.execute(
         """
         DELETE FROM system_settings WHERE tag = 'core'
-        AND (
-            tag != 'core'
-            OR id NOT IN (
-                'super_user',
-                'lnbits_webpush_pubkey',
-                'lnbits_webpush_privkey'
-            )
+        AND id NOT IN (
+            'super_user',
+            'lnbits_webpush_pubkey',
+            'lnbits_webpush_privkey'
         )
         """,
     )

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -65,9 +65,16 @@ async def delete_admin_settings(tag: Optional[str] = "core") -> None:
         """
         DELETE FROM system_settings
         WHERE tag = :tag
-        AND id NOT IN ('super_user', 'lnbits_webpush_pubkey', 'lnbits_webpush_privkey')
+        AND (
+            tag != 'core'
+            OR id NOT IN (
+                'super_user',
+                'lnbits_webpush_pubkey',
+                'lnbits_webpush_privkey'
+            )
+        )
         """,
-        {"tag": tag}
+        {"tag": tag},
     )
 
 

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -61,7 +61,14 @@ async def update_super_user(super_user: str) -> SuperSettings:
 
 
 async def delete_admin_settings(tag: Optional[str] = "core") -> None:
-    await db.execute("DELETE FROM system_settings WHERE tag = :tag", {"tag": tag})
+    await db.execute(
+        """
+        DELETE FROM system_settings
+        WHERE tag = :tag
+        AND id NOT IN ('super_user', 'lnbits_webpush_pubkey', 'lnbits_webpush_privkey')
+        """,
+        {"tag": tag}
+    )
 
 
 async def create_admin_settings(super_user: str, new_settings: dict) -> SuperSettings:

--- a/lnbits/core/views/admin_api.py
+++ b/lnbits/core/views/admin_api.py
@@ -28,7 +28,7 @@ from lnbits.settings import AdminSettings, Settings, UpdateSettings, settings
 from lnbits.tasks import invoice_listeners
 
 from .. import core_app_extra
-from ..crud import delete_admin_settings, get_admin_settings, update_admin_settings
+from ..crud import get_admin_settings, reset_core_settings, update_admin_settings
 
 admin_router = APIRouter(tags=["Admin UI"], prefix="/admin")
 file_upload = File(...)
@@ -112,7 +112,7 @@ async def api_reset_settings(field_name: str):
 @admin_router.delete("/api/v1/settings", status_code=HTTPStatus.OK)
 async def api_delete_settings(user: User = Depends(check_super_user)) -> None:
     enqueue_notification(NotificationType.settings_update, {"username": user.username})
-    await delete_admin_settings()
+    await reset_core_settings()
     server_restart.set()
 
 

--- a/lnbits/static/js/admin.js
+++ b/lnbits/static/js/admin.js
@@ -549,7 +549,7 @@ window.AdminPageLogic = {
                   'Success! Restored settings to defaults. Restarting...',
                 icon: null
               })
-              localStorage.clear()
+              this.$q.localStorage.clear()
             })
             .catch(LNbits.utils.notifyApiError)
         })

--- a/lnbits/static/js/admin.js
+++ b/lnbits/static/js/admin.js
@@ -546,10 +546,10 @@ window.AdminPageLogic = {
               Quasar.Notify.create({
                 type: 'positive',
                 message:
-                  'Success! Restored settings to defaults, restart required!',
+                  'Success! Restored settings to defaults. Restarting...',
                 icon: null
               })
-              this.needsRestart = true
+              localStorage.clear()
             })
             .catch(LNbits.utils.notifyApiError)
         })


### PR DESCRIPTION
✅ Deletes settings and not reset super_user
✅ Deletes localstorage settings
✅ Already resarts, so removes need to restart.
Unsure if this is also used to reset super_user somewhere?