### PR TITLE
[CHORE] add responsive text scaling with clamp() for wallet balance display

### DIFF
--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -59,9 +59,11 @@
                   <div class="col-7">
                     <div class="row">
                       <div class="col-auto">
-                        <div class="text-h3 q-my-none text-no-wrap">
+                        <div class="text-h3 q-my-none full-width">
                           <strong
                             v-text="walletFormatBalance(this.g.wallet.sat)"
+                            class="text-no-wrap"
+                            :style="{fontSize: 'clamp(0.75rem, 10vw, 3rem)', display: 'inline-block', maxWidth: '100%'}"
                           ></strong>
                         </div>
                       </div>


### PR DESCRIPTION
Implemented font size scaling using CSS clamp() function to make wallet balance
text responsive to viewport width. The balance now properly fills available
space while shrinking when constrained by smaller viewports, maintaining readability across all device sizes without text overflow issues.

- Min size: 0.75rem (12px) prevents text from becoming too small on mobile
- Scaling: 10vw provides smooth resizing relative to viewport width
- Max size: 3rem (48px) caps growth on larger screens

### Notes

- you may want to play with the values of the clamp function [mdn web docs clamp() fct](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp)


### Before
- mobile
![image](https://github.com/user-attachments/assets/db4b8265-d294-42dc-836f-1075e0565170)
- desktop
![image](https://github.com/user-attachments/assets/df053313-9d12-4dbb-bd7c-348fbe15be6d)



### After
- mobile
![image](https://github.com/user-attachments/assets/1658d8ad-44b5-4ffa-9668-ff7322ac7031)
- desktop
![image](https://github.com/user-attachments/assets/4d6f42f3-b54a-43bd-87a6-1f69f929b010)
