### PR TITLE
feat: show wallet payments on search

### DIFF
--- a/lnbits/core/templates/users/index.html
+++ b/lnbits/core/templates/users/index.html
@@ -127,7 +127,17 @@
                   :label="props.row.wallet_count"
                   @click="fetchWallets(props.row.id)"
                 >
-                  <q-tooltip>Show Wallets</q-tooltip>
+                </q-btn>
+                <q-btn
+                  v-if="(users.length == 1) && searchData.wallet_id"
+                  round
+                  icon="menu"
+                  size="sm"
+                  color="secondary"
+                  class="q-ml-sm"
+                  @click="showWalletPayments(searchData.wallet_id)"
+                >
+                  <q-tooltip>Show Payments</q-tooltip>
                 </q-btn>
               </q-td>
 

--- a/lnbits/static/js/users.js
+++ b/lnbits/static/js/users.js
@@ -329,7 +329,7 @@ window.UsersPageLogic = {
         .catch(LNbits.utils.notifyApiError)
     },
     fetchWallets(userId) {
-      LNbits.api
+      return LNbits.api
         .request('GET', `/users/api/v1/user/${userId}/wallet`)
         .then(res => {
           this.wallets = res.data
@@ -378,8 +378,13 @@ window.UsersPageLogic = {
         this.activeUser.show = false
       }
     },
-    showPayments(wallet_id) {
-      this.paymentsWallet = this.wallets.find(wallet => wallet.id === wallet_id)
+    async showWalletPayments(walletId) {
+      this.activeUser.show = false
+      await this.fetchWallets(this.users[0].id)
+      await this.showPayments(walletId)
+    },
+    showPayments(walletId) {
+      this.paymentsWallet = this.wallets.find(wallet => wallet.id === walletId)
       this.paymentPage.show = true
     },
     searchUserBy(fieldName) {


### PR DESCRIPTION
Add button to go directly to the payments page when search for wallet is done:

![image](https://github.com/user-attachments/assets/c227ff21-905c-405b-bd6f-c53f70eab97c)
