### PR TITLE
fix: include node balance in server status

### DIFF
--- a/lnbits/core/models/notifications.py
+++ b/lnbits/core/models/notifications.py
@@ -29,7 +29,9 @@ NOTIFICATION_TEMPLATES = {
         *In/Out payments*: `{in_payments_count}`/`{out_payments_count}`.
         *Pending payments*: `{pending_payments_count}`.
         *Failed payments*: `{failed_payments_count}`.
-        *LNbits balance*: `{lnbits_balance_sats}` sats.""",
+        *LNbits balance*: `{lnbits_balance_sats}` sats.
+        *Node balance*: `{node_balance_sats}` sats.""",
+
     "server_start_stop": """*SERVER*
         {message}
         *Time*: `{up_time}` seconds.

--- a/lnbits/core/models/notifications.py
+++ b/lnbits/core/models/notifications.py
@@ -31,7 +31,6 @@ NOTIFICATION_TEMPLATES = {
         *Failed payments*: `{failed_payments_count}`.
         *LNbits balance*: `{lnbits_balance_sats}` sats.
         *Node balance*: `{node_balance_sats}` sats.""",
-
     "server_start_stop": """*SERVER*
         {message}
         *Time*: `{up_time}` seconds.


### PR DESCRIPTION
Previous message did not include node balance:
```
LNbits Demo
SERVER STATUS
        Up time: 00:01:53.
        Accounts: xxx.
        Wallets: xxx.
        In/Out payments: xxx/yyy.
        Pending payments: xxxx.
        Failed payments: xxx.
        LNbits balance: xxx sats.
```