### PR TITLE
feat: preimages for incoming payments, fundingsource saves preimage on `create_invoice` 

### DIFF
--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -261,6 +261,8 @@ async def create_payment(
     assert previous_payment is None, "Payment already exists"
     extra = data.extra or {}
 
+    print("### create_payment 100", data.preimage)
+
     payment = Payment(
         checking_id=checking_id,
         status=status,

--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -261,8 +261,6 @@ async def create_payment(
     assert previous_payment is None, "Payment already exists"
     extra = data.extra or {}
 
-    print("### create_payment 100", data.preimage)
-
     payment = Payment(
         checking_id=checking_id,
         status=status,

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -145,7 +145,7 @@ async def create_invoice(
         or not payment_response.checking_id
     ):
         raise InvoiceError(
-            payment_response.error_message or "unexpected backend error.",
+            message=payment_response.error_message or "unexpected backend error.",
             status="pending",
         )
 

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -487,6 +487,9 @@ async def _pay_internal_invoice(
     if wallet.balance_msat < abs(amount_msat) + fee_reserve_total_msat:
         raise PaymentError("Insufficient balance.", status="failed")
 
+    # release the preimage
+    create_payment_model.preimage = internal_invoice.preimage
+
     internal_id = f"internal_{create_payment_model.payment_hash}"
     logger.debug(f"creating temporary internal payment with id {internal_id}")
     payment = await create_payment(

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -132,6 +132,7 @@ async def create_invoice(
             status="failed",
         )
 
+    print("### create_invoice 303 funding_source", funding_source)
     payment_response = await funding_source.create_invoice(
         amount=amount_sat,
         memo=invoice_memo,
@@ -144,7 +145,7 @@ async def create_invoice(
         or not payment_response.payment_request
         or not payment_response.checking_id
     ):
-        print("### create_invoice 300", payment_response)
+        print("### create_invoice 305", payment_response)
         raise InvoiceError(
             message=payment_response.error_message or "unexpected backend error.",
             status="pending",

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -144,23 +144,24 @@ async def create_invoice(
         or not payment_response.payment_request
         or not payment_response.checking_id
     ):
+        print("### create_invoice 300", payment_response)
         raise InvoiceError(
             message=payment_response.error_message or "unexpected backend error.",
             status="pending",
         )
-
+    print("### create_invoice 310", payment_response.preimage)
     invoice = bolt11_decode(payment_response.payment_request)
 
     create_payment_model = CreatePayment(
         wallet_id=wallet_id,
         bolt11=payment_response.payment_request,
         payment_hash=invoice.payment_hash,
+        preimage=payment_response.preimage,
         amount_msat=amount_sat * 1000,
         expiry=invoice.expiry_date,
         memo=memo,
         extra=extra,
         webhook=webhook,
-        preimage=payment_response.preimage,
     )
 
     payment = await create_payment(

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -132,7 +132,6 @@ async def create_invoice(
             status="failed",
         )
 
-    print("### create_invoice 303 funding_source", funding_source)
     payment_response = await funding_source.create_invoice(
         amount=amount_sat,
         memo=invoice_memo,
@@ -145,12 +144,10 @@ async def create_invoice(
         or not payment_response.payment_request
         or not payment_response.checking_id
     ):
-        print("### create_invoice 305", payment_response)
         raise InvoiceError(
             message=payment_response.error_message or "unexpected backend error.",
             status="pending",
         )
-    print("### create_invoice 310", payment_response.preimage)
     invoice = bolt11_decode(payment_response.payment_request)
 
     create_payment_model = CreatePayment(

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -203,7 +203,8 @@ async def invoice_callback_dispatcher(checking_id: str, is_internal: bool = Fals
     if payment and payment.is_in:
         status = await payment.check_status()
         payment.fee = status.fee_msat or 0
-        payment.preimage = status.preimage
+        # only overwrite preimage if status.preimage provides it
+        payment.preimage = status.preimage if status.preimage else payment.preimage
         payment.status = PaymentState.SUCCESS
         await update_payment(payment)
         internal = "internal" if is_internal else ""

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -204,7 +204,7 @@ async def invoice_callback_dispatcher(checking_id: str, is_internal: bool = Fals
         status = await payment.check_status()
         payment.fee = status.fee_msat or 0
         # only overwrite preimage if status.preimage provides it
-        payment.preimage = status.preimage if status.preimage else payment.preimage
+        payment.preimage = status.preimage or payment.preimage
         payment.status = PaymentState.SUCCESS
         await update_payment(payment)
         internal = "internal" if is_internal else ""

--- a/lnbits/wallets/alby.py
+++ b/lnbits/wallets/alby.py
@@ -99,10 +99,12 @@ class AlbyWallet(Wallet):
 
             checking_id = data["payment_hash"]
             payment_request = data["payment_request"]
+            preimage = data.get("payment_preimage")
             return InvoiceResponse(
                 ok=True,
                 checking_id=checking_id,
                 payment_request=payment_request,
+                preimage=preimage,
             )
         except KeyError as exc:
             logger.warning(exc)

--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -20,6 +20,7 @@ class InvoiceResponse(NamedTuple):
     checking_id: str | None = None  # payment_hash, rpc_id
     payment_request: str | None = None
     error_message: str | None = None
+    preimage: str | None = None
 
     @property
     def success(self) -> bool:

--- a/lnbits/wallets/cliche.py
+++ b/lnbits/wallets/cliche.py
@@ -99,6 +99,7 @@ class ClicheWallet(Wallet):
             ok=True,
             checking_id=checking_id,
             payment_request=payment_request,
+            preimage=data["result"].get("preimage"),
         )
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -119,7 +119,7 @@ class CoreLightningWallet(Wallet):
                 ok=True,
                 checking_id=r["payment_hash"],
                 payment_request=r["bolt11"],
-                preimage=r.get("r_hash"),
+                preimage=r.get("payment_preimage"),
             )
         except RpcError as exc:
             logger.warning(exc)

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -103,7 +103,10 @@ class CoreLightningWallet(Wallet):
             if unhashed_description and not self.supports_description_hash:
                 raise UnsupportedError("unhashed_description")
 
-            preimage, _ = random_secret_and_hash()
+            preimage = kwargs.get("preimage")
+            if not preimage:
+                preimage, _ = random_secret_and_hash()
+
             r: dict = self.ln.invoice(  # type: ignore
                 amount_msat=msat,
                 label=label,

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -119,6 +119,7 @@ class CoreLightningWallet(Wallet):
                 ok=True,
                 checking_id=r["payment_hash"],
                 payment_request=r["bolt11"],
+                preimage=r.get("r_hash"),
             )
         except RpcError as exc:
             logger.warning(exc)

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -1,6 +1,7 @@
 import asyncio
 import random
-from typing import Any, AsyncGenerator, Optional
+from collections.abc import AsyncGenerator
+from typing import Any, Optional
 
 from bolt11.decode import decode as bolt11_decode
 from bolt11.exceptions import Bolt11Exception
@@ -9,6 +10,7 @@ from pyln.client import LightningRpc, RpcError
 
 from lnbits.nodes.cln import CoreLightningNode
 from lnbits.settings import settings
+from lnbits.utils.crypto import random_secret_and_hash
 
 from .base import (
     InvoiceResponse,
@@ -100,6 +102,8 @@ class CoreLightningWallet(Wallet):
                 )
             if unhashed_description and not self.supports_description_hash:
                 raise UnsupportedError("unhashed_description")
+
+            preimage, _ = random_secret_and_hash()
             r: dict = self.ln.invoice(  # type: ignore
                 amount_msat=msat,
                 label=label,
@@ -107,6 +111,7 @@ class CoreLightningWallet(Wallet):
                     unhashed_description.decode() if unhashed_description else memo
                 ),
                 exposeprivatechannels=True,
+                preimage=preimage,
                 deschashonly=(
                     True if unhashed_description else False
                 ),  # we can't pass None here
@@ -119,7 +124,7 @@ class CoreLightningWallet(Wallet):
                 ok=True,
                 checking_id=r["payment_hash"],
                 payment_request=r["bolt11"],
-                preimage=r.get("payment_preimage"),
+                preimage=preimage,
             )
         except RpcError as exc:
             logger.warning(exc)

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -156,6 +156,7 @@ class CoreLightningRestWallet(Wallet):
                     ok=False, error_message="Server error: 'missing required fields'"
                 )
 
+            print("### create_invoice corelightningrest", data)
             return InvoiceResponse(
                 ok=True,
                 checking_id=data["payment_hash"],

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -160,6 +160,7 @@ class CoreLightningRestWallet(Wallet):
                 ok=True,
                 checking_id=data["payment_hash"],
                 payment_request=data["bolt11"],
+                preimage=data.get("preimage"),
             )
         except json.JSONDecodeError:
             return InvoiceResponse(

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -10,6 +10,7 @@ from loguru import logger
 from websockets.client import connect
 
 from lnbits.settings import settings
+from lnbits.utils.crypto import random_secret_and_hash
 
 from .base import (
     InvoiceResponse,
@@ -99,6 +100,9 @@ class EclairWallet(Wallet):
         else:
             data["description"] = memo
 
+        preimage, _ = random_secret_and_hash()
+        data["paymentPreimage"] = preimage
+
         try:
             r = await self.client.post("/createinvoice", data=data, timeout=40)
             r.raise_for_status()
@@ -120,6 +124,7 @@ class EclairWallet(Wallet):
                 ok=True,
                 checking_id=data["paymentHash"],
                 payment_request=data["serialized"],
+                preimage=preimage,
             )
         except json.JSONDecodeError:
             return InvoiceResponse(

--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -100,7 +100,7 @@ class FakeWallet(Wallet):
             ok=True,
             checking_id=payment_hash,
             payment_request=payment_request,
-            # preimage=preimage.hex(),
+            preimage=preimage.hex(),
         )
 
     async def pay_invoice(self, bolt11: str, _: int) -> PaymentResponse:

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -99,7 +99,7 @@ class LNbitsWallet(Wallet):
                 ok=True,
                 checking_id=data["checking_id"],
                 payment_request=payment_str,
-                preimage=data["preimage"],
+                preimage=data.get("preimage"),
             )
         except json.JSONDecodeError:
             return InvoiceResponse(

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -96,7 +96,10 @@ class LNbitsWallet(Wallet):
                 )
 
             return InvoiceResponse(
-                ok=True, checking_id=data["checking_id"], payment_request=payment_str
+                ok=True,
+                checking_id=data["checking_id"],
+                payment_request=payment_str,
+                preimage=data["preimage"],
             )
         except json.JSONDecodeError:
             return InvoiceResponse(

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -1,6 +1,6 @@
 import asyncio
 import base64
-from hashlib import sha256
+import hashlib
 from os import environ
 from typing import AsyncGenerator, Dict, Optional
 
@@ -139,21 +139,22 @@ class LndWallet(Wallet):
         if description_hash:
             data["description_hash"] = description_hash
         elif unhashed_description:
-            data["description_hash"] = sha256(unhashed_description).digest()
+            data["description_hash"] = hashlib.sha256(
+                unhashed_description
+            ).digest()  # as bytes directly
 
         try:
             req = ln.Invoice(**data)
             resp = await self.rpc.AddInvoice(req)
         except Exception as exc:
             logger.warning(exc)
-            return InvoiceResponse(ok=False, error_message=str(exc))
+            error_message = str(exc)
+            return InvoiceResponse(ok=False, error_message=error_message)
 
         checking_id = bytes_to_hex(resp.r_hash)
         payment_request = str(resp.payment_request)
         return InvoiceResponse(
-            ok=True,
-            checking_id=checking_id,
-            payment_request=payment_request,
+            ok=True, checking_id=checking_id, payment_request=payment_request
         )
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
@@ -196,18 +197,16 @@ class LndWallet(Wallet):
             fee_msat = -resp.htlcs[-1].route.total_fees_msat
             preimage = resp.payment_preimage
             checking_id = resp.payment_hash
-            return PaymentResponse(
-                ok=True, checking_id=checking_id, fee_msat=fee_msat, preimage=preimage
-            )
         elif statuses[resp.status] is False:
             error_message = failure_reasons[resp.failure_reason]
-            return PaymentResponse(ok=False, error_message=error_message)
-        else:
-            return PaymentResponse(
-                ok=None,
-                checking_id=checking_id,
-                error_message="Payment in flight or non-existant.",
-            )
+
+        return PaymentResponse(
+            ok=statuses[resp.status],
+            checking_id=checking_id,
+            fee_msat=fee_msat,
+            preimage=preimage,
+            error_message=error_message,
+        )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
         try:
@@ -218,8 +217,10 @@ class LndWallet(Wallet):
                 raise ValueError
 
             resp = await self.rpc.LookupInvoice(ln.PaymentHash(r_hash=r_hash))
+
+            # todo: where is the FAILED status
             if resp.settled:
-                return PaymentSuccessStatus(preimage=resp.r_preimage.hex())
+                return PaymentSuccessStatus()
 
             return PaymentPendingStatus()
         except grpc.RpcError as exc:

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -145,6 +145,7 @@ class LndWallet(Wallet):
 
         data["r_hash"] = sha256(preimage).digest()
         data["r_preimage"] = preimage
+        print("### create_invoice preimage 200", preimage.hex())
         try:
             req = ln.Invoice(**data)
             resp = await self.rpc.AddInvoice(req)
@@ -156,11 +157,13 @@ class LndWallet(Wallet):
             #    "payment_addr": <bytes>,
             # }
         except Exception as exc:
+            print("### create_invoice exc 201", exc)
             logger.warning(exc)
             return InvoiceResponse(ok=False, error_message=str(exc))
 
         checking_id = bytes_to_hex(resp.r_hash)
         payment_request = str(resp.payment_request)
+        print("### create_invoice preimage 210", preimage.hex())
         return InvoiceResponse(
             ok=True,
             checking_id=checking_id,

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -230,10 +230,8 @@ class LndWallet(Wallet):
                 raise ValueError
 
             resp = await self.rpc.LookupInvoice(ln.PaymentHash(r_hash=r_hash))
-
-            # todo: where is the FAILED status
             if resp.settled:
-                return PaymentSuccessStatus()
+                return PaymentSuccessStatus(preimage=resp.r_preimage.hex())
 
             return PaymentPendingStatus()
         except grpc.RpcError as exc:

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -141,7 +141,12 @@ class LndWallet(Wallet):
         elif unhashed_description:
             data["description_hash"] = sha256(unhashed_description).digest()
 
-        preimage, payment_hash = random_secret_and_hash()
+        preimage = kwargs.get("preimage")
+        if preimage:
+            payment_hash = sha256(preimage.encode()).hexdigest()
+        else:
+            preimage, payment_hash = random_secret_and_hash()
+
         data["r_hash"] = bytes.fromhex(payment_hash)
         data["r_preimage"] = bytes.fromhex(preimage)
         try:

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -142,8 +142,7 @@ class LndWallet(Wallet):
             data["description_hash"] = sha256(unhashed_description).digest()
 
         preimage, payment_hash = random_secret_and_hash()
-
-        data["r_hash"] = payment_hash
+        data["r_hash"] = bytes.fromhex(payment_hash)
         data["r_preimage"] = bytes.fromhex(preimage)
         try:
             req = ln.Invoice(**data)

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -1,6 +1,6 @@
 import asyncio
 import base64
-import hashlib
+from hashlib import sha256
 from os import environ
 from typing import AsyncGenerator, Dict, Optional
 
@@ -139,22 +139,21 @@ class LndWallet(Wallet):
         if description_hash:
             data["description_hash"] = description_hash
         elif unhashed_description:
-            data["description_hash"] = hashlib.sha256(
-                unhashed_description
-            ).digest()  # as bytes directly
+            data["description_hash"] = sha256(unhashed_description).digest()
 
         try:
             req = ln.Invoice(**data)
             resp = await self.rpc.AddInvoice(req)
         except Exception as exc:
             logger.warning(exc)
-            error_message = str(exc)
-            return InvoiceResponse(ok=False, error_message=error_message)
+            return InvoiceResponse(ok=False, error_message=str(exc))
 
         checking_id = bytes_to_hex(resp.r_hash)
         payment_request = str(resp.payment_request)
         return InvoiceResponse(
-            ok=True, checking_id=checking_id, payment_request=payment_request
+            ok=True,
+            checking_id=checking_id,
+            payment_request=payment_request,
         )
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
@@ -197,16 +196,18 @@ class LndWallet(Wallet):
             fee_msat = -resp.htlcs[-1].route.total_fees_msat
             preimage = resp.payment_preimage
             checking_id = resp.payment_hash
+            return PaymentResponse(
+                ok=True, checking_id=checking_id, fee_msat=fee_msat, preimage=preimage
+            )
         elif statuses[resp.status] is False:
             error_message = failure_reasons[resp.failure_reason]
-
-        return PaymentResponse(
-            ok=statuses[resp.status],
-            checking_id=checking_id,
-            fee_msat=fee_msat,
-            preimage=preimage,
-            error_message=error_message,
-        )
+            return PaymentResponse(ok=False, error_message=error_message)
+        else:
+            return PaymentResponse(
+                ok=None,
+                checking_id=checking_id,
+                error_message="Payment in flight or non-existant.",
+            )
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
         try:
@@ -217,10 +218,8 @@ class LndWallet(Wallet):
                 raise ValueError
 
             resp = await self.rpc.LookupInvoice(ln.PaymentHash(r_hash=r_hash))
-
-            # todo: where is the FAILED status
             if resp.settled:
-                return PaymentSuccessStatus()
+                return PaymentSuccessStatus(preimage=resp.r_preimage.hex())
 
             return PaymentPendingStatus()
         except grpc.RpcError as exc:

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -152,10 +152,12 @@ class LndRestWallet(Wallet):
             payment_request = data["payment_request"]
             payment_hash = base64.b64decode(data["r_hash"]).hex()
             checking_id = payment_hash
+            preimage = data.get("r_preimage")
             return InvoiceResponse(
                 ok=True,
                 checking_id=checking_id,
                 payment_request=payment_request,
+                preimage=preimage,
             )
 
         except json.JSONDecodeError:

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from lnbits.nodes.lndrest import LndRestNode
 from lnbits.settings import settings
-from lnbits.utils.crypto import AESCipher
+from lnbits.utils.crypto import AESCipher, random_secret_and_hash
 
 from .base import (
     InvoiceResponse,
@@ -110,24 +110,28 @@ class LndRestWallet(Wallet):
         unhashed_description: Optional[bytes] = None,
         **kwargs,
     ) -> InvoiceResponse:
-        data: Dict = {
+        _data: Dict = {
             "value": amount,
             "private": settings.lnd_rest_route_hints,
             "memo": memo or "",
         }
         if kwargs.get("expiry"):
-            data["expiry"] = kwargs["expiry"]
+            _data["expiry"] = kwargs["expiry"]
         if description_hash:
-            data["description_hash"] = base64.b64encode(description_hash).decode(
+            _data["description_hash"] = base64.b64encode(description_hash).decode(
                 "ascii"
             )
         elif unhashed_description:
-            data["description_hash"] = base64.b64encode(
+            _data["description_hash"] = base64.b64encode(
                 hashlib.sha256(unhashed_description).digest()
             ).decode("ascii")
 
+        preimage, _payment_hash = random_secret_and_hash()
+        _data["r_hash"] = base64.b64encode(bytes.fromhex(_payment_hash)).decode()
+        _data["r_preimage"] = base64.b64encode(bytes.fromhex(preimage)).decode()
+
         try:
-            r = await self.client.post(url="/v1/invoices", json=data)
+            r = await self.client.post(url="/v1/invoices", json=_data)
             r.raise_for_status()
             data = r.json()
 
@@ -152,7 +156,6 @@ class LndRestWallet(Wallet):
             payment_request = data["payment_request"]
             payment_hash = base64.b64decode(data["r_hash"]).hex()
             checking_id = payment_hash
-            preimage = data.get("r_preimage")
             return InvoiceResponse(
                 ok=True,
                 checking_id=checking_id,

--- a/lnbits/wallets/lntips.py
+++ b/lnbits/wallets/lntips.py
@@ -98,6 +98,7 @@ class LnTipsWallet(Wallet):
             ok=True,
             checking_id=data["payment_hash"],
             payment_request=data["payment_request"],
+            preimage=data.get("preimage"),
         )
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -215,7 +215,7 @@ class NWCWallet(Wallet):
                     "preimage", None
                 )
                 if not settled:
-                    return PaymentResponse(ok=None, checking_id=payment_hash)
+                    return PaymentResponse(checking_id=payment_hash)
                 else:
                     fee_msat = payment_data.get("fees_paid", None)
                     return PaymentResponse(
@@ -228,7 +228,7 @@ class NWCWallet(Wallet):
                 # Workaround: some nwc service providers might not store the invoice
                 # right away, so this call may raise an exception.
                 # We will assume the payment is pending anyway
-                return PaymentResponse(ok=None, checking_id=payment_hash)
+                return PaymentResponse(checking_id=payment_hash)
         except NWCError as e:
             logger.error("Error paying invoice: " + str(e))
             failure_codes = [
@@ -251,7 +251,7 @@ class NWCWallet(Wallet):
             msg = "Error paying invoice: " + str(e)
             logger.error(msg)
             # assume pending
-            return PaymentResponse(ok=None, error_message=msg)
+            return PaymentResponse(error_message=msg)
 
     async def get_invoice_status(self, checking_id: str) -> PaymentStatus:
         return await self.get_payment_status(checking_id)
@@ -625,10 +625,9 @@ class NWCConnection:
                     ):  # receive messages until the connection is shutting down
                         try:
                             reply = await ws.recv()
-                            if isinstance(reply, (bytes, bytearray)):
+                            reply_str = ""
+                            if isinstance(reply, bytes):
                                 reply_str = reply.decode("utf-8")
-                            elif isinstance(reply, memoryview):
-                                reply_str = reply.tobytes().decode("utf-8")
                             else:
                                 reply_str = reply
                             await self._on_message(ws, reply_str)

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -138,10 +138,12 @@ class PhoenixdWallet(Wallet):
 
             checking_id = data["paymentHash"]
             payment_request = data["serialized"]
+            preimage = data.get("preimage", None)
             return InvoiceResponse(
                 ok=True,
                 checking_id=checking_id,
                 payment_request=payment_request,
+                preimage=preimage,
             )
         except json.JSONDecodeError:
             return InvoiceResponse(

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -138,7 +138,7 @@ class PhoenixdWallet(Wallet):
 
             checking_id = data["paymentHash"]
             payment_request = data["serialized"]
-            preimage = data.get("preimage", None)
+            preimage = data.get("paymentPreimage", None)  # if available
             return InvoiceResponse(
                 ok=True,
                 checking_id=checking_id,

--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -140,6 +140,7 @@ class SparkWallet(Wallet):
                 ok=True,
                 payment_request=r["bolt11"],
                 checking_id=label,
+                preimage=r.get("preimage"),
             )
         except (SparkError, UnknownError) as e:
             return InvoiceResponse(ok=False, error_message=str(e))

--- a/lnbits/wallets/zbd.py
+++ b/lnbits/wallets/zbd.py
@@ -94,10 +94,12 @@ class ZBDWallet(Wallet):
         data = r.json()["data"]
         checking_id = data["id"]  # this is a zbd id
         payment_request = data["invoice"]["request"]
+        preimage = data["invoice"].get("preimage")
         return InvoiceResponse(
             ok=True,
             checking_id=checking_id,
             payment_request=payment_request,
+            preimage=preimage,
         )
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:

--- a/tests/regtest/test_real_invoice.py
+++ b/tests/regtest/test_real_invoice.py
@@ -101,6 +101,8 @@ async def test_create_real_invoice(client, adminkey_headers_from, inkey_headers_
         balance = await get_node_balance_sats()
         assert balance - prev_balance == create_invoice.amount
 
+        assert response.get("preimage") is not None
+
         # exit out of infinite loop
         raise FakeError()
 

--- a/tests/regtest/test_real_invoice.py
+++ b/tests/regtest/test_real_invoice.py
@@ -101,7 +101,7 @@ async def test_create_real_invoice(client, adminkey_headers_from, inkey_headers_
         balance = await get_node_balance_sats()
         assert balance - prev_balance == create_invoice.amount
 
-        assert response.get("preimage") is not None
+        assert payment_status.get("preimage") is not None
 
         # exit out of infinite loop
         raise FakeError()

--- a/tests/regtest/test_services_create_invoice.py
+++ b/tests/regtest/test_services_create_invoice.py
@@ -17,6 +17,8 @@ async def test_create_invoice(from_wallet):
         amount=1000,
         memo=description,
     )
+    assert payment.preimage
+
     invoice = decode(payment.bolt11)
     assert invoice.payment_hash == payment.payment_hash
     assert invoice.amount_msat == 1000000
@@ -33,6 +35,8 @@ async def test_create_internal_invoice(from_wallet):
     payment = await create_invoice(
         wallet_id=from_wallet.id, amount=1000, memo=description, internal=True
     )
+    assert payment.preimage
+
     invoice = decode(payment.bolt11)
     assert invoice.payment_hash == payment.payment_hash
     assert invoice.amount_msat == 1000000

--- a/tests/regtest/test_services_pay_invoice.py
+++ b/tests/regtest/test_services_pay_invoice.py
@@ -19,6 +19,7 @@ async def test_services_pay_invoice(to_wallet, real_invoice):
     assert payment
     assert payment.status == PaymentState.SUCCESS
     assert payment.memo == description
+    assert payment.preimage
 
 
 @pytest.mark.anyio

--- a/tests/wallets/fixtures/json/fixtures_rpc.json
+++ b/tests/wallets/fixtures/json/fixtures_rpc.json
@@ -326,11 +326,12 @@
           "call_params": {
             "amount": 555,
             "memo": "Test Invoice",
-            "label": "test-label"
+            "label": "test-label",
+            "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
           },
           "expect": {
             "success": true,
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96",
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417",
             "payment_request": "lnbc5550n1pnq9jg3sp52rvwstvjcypjsaenzdh0h30jazvzsf8aaye0julprtth9kysxtuspp5e5s3z7felv4t9zrcc6wpn7ehvjl5yzewanzl5crljdl3jgeffyhqdq2f38xy6t5wvxqzjccqpjrzjq0yzeq76ney45hmjlnlpvu0nakzy2g35hqh0dujq8ujdpr2e42pf2rrs6vqpgcsqqqqqqqqqqqqqqeqqyg9qxpqysgqwftcx89k5pp28435pgxfl2vx3ksemzxccppw2j9yjn0ngr6ed7wj8ztc0d5kmt2mvzdlcgrludhz7jncd5l5l9w820hc4clpwhtqj3gq62g66n",
             "error_message": null
           },
@@ -355,7 +356,7 @@
                       "response_type": "data",
                       "response": {
                         "ln_invoice": {
-                          "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96",
+                          "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417",
                           "bolt11": "lnbc5550n1pnq9jg3sp52rvwstvjcypjsaenzdh0h30jazvzsf8aaye0julprtth9kysxtuspp5e5s3z7felv4t9zrcc6wpn7ehvjl5yzewanzl5crljdl3jgeffyhqdq2f38xy6t5wvxqzjccqpjrzjq0yzeq76ney45hmjlnlpvu0nakzy2g35hqh0dujq8ujdpr2e42pf2rrs6vqpgcsqqqqqqqqqqqqqqeqqyg9qxpqysgqwftcx89k5pp28435pgxfl2vx3ksemzxccppw2j9yjn0ngr6ed7wj8ztc0d5kmt2mvzdlcgrludhz7jncd5l5l9w820hc4clpwhtqj3gq62g66n"
                         }
                       }
@@ -378,12 +379,13 @@
                           "expiry": null,
                           "exposeprivatechannels": true,
                           "label": "test-label",
-                          "amount_msat": 555000
+                          "amount_msat": 555000,
+                          "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
                         }
                       },
                       "response_type": "json",
                       "response": {
-                        "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96",
+                        "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417",
                         "bolt11": "lnbc5550n1pnq9jg3sp52rvwstvjcypjsaenzdh0h30jazvzsf8aaye0julprtth9kysxtuspp5e5s3z7felv4t9zrcc6wpn7ehvjl5yzewanzl5crljdl3jgeffyhqdq2f38xy6t5wvxqzjccqpjrzjq0yzeq76ney45hmjlnlpvu0nakzy2g35hqh0dujq8ujdpr2e42pf2rrs6vqpgcsqqqqqqqqqqqqqqeqqyg9qxpqysgqwftcx89k5pp28435pgxfl2vx3ksemzxccppw2j9yjn0ngr6ed7wj8ztc0d5kmt2mvzdlcgrludhz7jncd5l5l9w820hc4clpwhtqj3gq62g66n"
                       }
                     }
@@ -402,12 +404,14 @@
                         "kwargs": {
                           "value": 555,
                           "private": true,
-                          "memo": "Test Invoice"
+                          "memo": "Test Invoice",
+                          "__eval__:r_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")",
+                          "__eval__:r_preimage": "bytes.fromhex(\"0000000000000000000000000000000000000000000000000000000000000001\")"
                         }
                       },
                       "response_type": "data",
                       "response": {
-                        "__eval__:r_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")",
+                        "__eval__:r_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")",
                         "payment_request": "lnbc5550n1pnq9jg3sp52rvwstvjcypjsaenzdh0h30jazvzsf8aaye0julprtth9kysxtuspp5e5s3z7felv4t9zrcc6wpn7ehvjl5yzewanzl5crljdl3jgeffyhqdq2f38xy6t5wvxqzjccqpjrzjq0yzeq76ney45hmjlnlpvu0nakzy2g35hqh0dujq8ujdpr2e42pf2rrs6vqpgcsqqqqqqqqqqqqqqeqqyg9qxpqysgqwftcx89k5pp28435pgxfl2vx3ksemzxccppw2j9yjn0ngr6ed7wj8ztc0d5kmt2mvzdlcgrludhz7jncd5l5l9w820hc4clpwhtqj3gq62g66n"
                       }
                     }
@@ -422,7 +426,8 @@
           "call_params": {
             "amount": 555,
             "memo": "Test Invoice",
-            "label": "test-label"
+            "label": "test-label",
+            "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
           },
           "expect": {
             "success": false,
@@ -470,7 +475,8 @@
                           "expiry": null,
                           "exposeprivatechannels": true,
                           "label": "test-label",
-                          "amount_msat": 555000
+                          "amount_msat": 555000,
+                          "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
                         }
                       },
                       "response_type": "exception",
@@ -491,7 +497,8 @@
                           "expiry": null,
                           "exposeprivatechannels": true,
                           "label": "test-label",
-                          "amount_msat": 555000
+                          "amount_msat": 555000,
+                          "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
                         }
                       },
                       "response_type": "json",
@@ -515,7 +522,9 @@
                         "kwargs": {
                           "value": 555,
                           "private": true,
-                          "memo": "Test Invoice"
+                          "memo": "Test Invoice",
+                          "__eval__:r_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")",
+                          "__eval__:r_preimage": "bytes.fromhex(\"0000000000000000000000000000000000000000000000000000000000000001\")"
                         }
                       },
                       "response_type": "exception",
@@ -534,7 +543,8 @@
           "call_params": {
             "amount": 555,
             "memo": "Test Invoice",
-            "label": "test-label"
+            "label": "test-label",
+            "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
           },
           "expect": {
             "success": false,
@@ -559,7 +569,8 @@
                           "expiry": null,
                           "exposeprivatechannels": true,
                           "label": "test-label",
-                          "amount_msat": 555000
+                          "amount_msat": 555000,
+                          "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
                         }
                       },
                       "response_type": "json",
@@ -576,7 +587,8 @@
           "call_params": {
             "amount": 555,
             "memo": "Test Invoice",
-            "label": "test-label"
+            "label": "test-label",
+            "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
           },
           "expect": {
             "success": false,
@@ -601,7 +613,8 @@
                           "expiry": null,
                           "exposeprivatechannels": true,
                           "label": "test-label",
-                          "amount_msat": 555000
+                          "amount_msat": 555000,
+                          "preimage": "0000000000000000000000000000000000000000000000000000000000000001"
                         }
                       },
                       "response_type": "exception",
@@ -689,7 +702,7 @@
           "expect": {
             "error_message": null,
             "success": true,
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96",
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417",
             "fee_msat": 50,
             "preimage": "0000000000000000000000000000000000000000000000000000000000000000"
           },
@@ -739,7 +752,7 @@
                       "response": {
                         "amount_sent_msat": 21000,
                         "amount_msat": 21050,
-                        "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96",
+                        "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417",
                         "payment_preimage": "0000000000000000000000000000000000000000000000000000000000000000"
                       }
                     }
@@ -774,7 +787,7 @@
                               }
                             ],
                             "payment_preimage": "0000000000000000000000000000000000000000000000000000000000000000",
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         }
                       }
@@ -806,7 +819,7 @@
                               }
                             ],
                             "payment_preimage": "0000000000000000000000000000000000000000000000000000000000000000",
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         }
                       }
@@ -1237,7 +1250,7 @@
         {
           "description": "success",
           "call_params": {
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
           },
           "expect": {
             "success": true,
@@ -1276,7 +1289,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1291,7 +1304,7 @@
                           "invoices": [
                             {
                               "status": "paid",
-                              "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                              "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                             }
                           ]
                         }
@@ -1315,12 +1328,13 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.lightning_pb2.PaymentHash",
                         "kwargs": {
-                          "__eval__:r_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:r_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "data",
                       "response": {
-                        "settled": true
+                        "settled": true,
+                        "__eval__:r_preimage": "bytes.fromhex(\"0000000000000000000000000000000000000000000000000000000000000001\")"
                       }
                     }
                   }
@@ -1332,7 +1346,7 @@
         {
           "description": "pending",
           "call_params": {
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
           },
           "expect": {
             "success": false,
@@ -1364,7 +1378,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1376,7 +1390,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1395,7 +1409,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1407,7 +1421,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "exception",
@@ -1432,7 +1446,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1444,7 +1458,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "exception",
@@ -1463,7 +1477,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1475,7 +1489,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1492,7 +1506,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1504,7 +1518,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1528,7 +1542,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1540,7 +1554,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1548,7 +1562,7 @@
                           "invoices": [
                             {
                               "status": "unpaid",
-                              "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                              "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                             }
                           ]
                         }
@@ -1573,7 +1587,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.lightning_pb2.PaymentHash",
                         "kwargs": {
-                          "__eval__:r_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:r_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "data",
@@ -1591,7 +1605,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.lightning_pb2.PaymentHash",
                         "kwargs": {
-                          "__eval__:r_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:r_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "exception",
@@ -1611,7 +1625,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.lightning_pb2.PaymentHash",
                         "kwargs": {
-                          "__eval__:r_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:r_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "exception",
@@ -1691,7 +1705,7 @@
           "description": "failed",
           "description1": "pending should be false in the 'expect', this is a bug",
           "call_params": {
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
           },
           "expect": {
             "success": false,
@@ -1731,7 +1745,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1743,7 +1757,7 @@
                         "request_type": "function",
                         "request_data": {
                           "kwargs": {
-                            "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                            "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                           }
                         },
                         "response_type": "json",
@@ -1751,7 +1765,7 @@
                           "invoices": [
                             {
                               "status": "expired",
-                              "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                              "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                             }
                           ]
                         }
@@ -1823,7 +1837,7 @@
         {
           "description": "success",
           "call_params": {
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
           },
           "expect": {
             "success": true,
@@ -1872,7 +1886,7 @@
                           "pays": [
                             {
                               "status": "complete",
-                              "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96",
+                              "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417",
                               "preimage": "0000000000000000000000000000000000000000000000000000000000000000",
                               "amount_sent_msat": 21000,
                               "amount_msat": 21050
@@ -1900,7 +1914,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",
@@ -1933,7 +1947,7 @@
         {
           "description": "success status, no payment found",
           "call_params": {
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
           },
           "expect": {
             "success": true,
@@ -1960,7 +1974,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",
@@ -1980,7 +1994,7 @@
         {
           "description": "pending",
           "call_params": {
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
           },
           "expect": {
             "success": false,
@@ -2073,7 +2087,7 @@
                           "pays": [
                             {
                               "status": "pending",
-                              "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                              "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                             }
                           ]
                         }
@@ -2117,7 +2131,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",
@@ -2138,7 +2152,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",
@@ -2154,7 +2168,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",
@@ -2170,7 +2184,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",
@@ -2198,7 +2212,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",
@@ -2226,7 +2240,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",
@@ -2254,7 +2268,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "exception",
@@ -2316,7 +2330,7 @@
           "description": "failed",
           "description1": "pending should be false in the 'expect', this is a bug",
           "call_params": {
-            "checking_id": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+            "checking_id": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
           },
           "expect": {
             "success": false,
@@ -2360,7 +2374,7 @@
                           "pays": [
                             {
                               "status": "failed",
-                              "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
+                              "payment_hash": "c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417"
                             }
                           ]
                         }
@@ -2385,7 +2399,7 @@
                       "request_data": {
                         "klass": "lnbits.wallets.lnd_grpc_files.router_pb2.TrackPaymentRequest",
                         "kwargs": {
-                          "__eval__:payment_hash": "bytes.fromhex(\"e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96\")"
+                          "__eval__:payment_hash": "bytes.fromhex(\"c386d8e8d07342f2e39e189c8e6c57bb205bb373fe4e3a6f69404a8bb767b417\")"
                         }
                       },
                       "response_type": "__aiter__",


### PR DESCRIPTION
pass the preimage generated in `create_invoice` from `InvoiceResponse` to the service to be persistent in the payment model and database

- issue incoming payments did not have the preimage
- issue were `PaymentSuccessStatus()` overwrote an existing preimage with None