### PR TITLE
[FIX] Fix database compatibility issue in search query builder for payments filter

### DIFF
--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -554,9 +554,9 @@ class Filters(BaseModel, Generic[TFilterModel]):
             for page_filter in self.filters:
                 where_stmts.append(page_filter.statement)
         if self.search and self.model and self.model.__search_fields__:
-            where_stmts.append(
-                f"lower(concat({', '.join(self.model.__search_fields__)})) LIKE :search"
-            )
+            # Use COALESCE to handle NULL values and || for cross-database compatible string concatenation
+            search_expr = " || ".join(f"COALESCE({field}, '')" for field in self.model.__search_fields__)
+            where_stmts.append(f"lower({search_expr}) LIKE :search")
 
         if where_stmts:
             return "WHERE " + " AND ".join(where_stmts)

--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -557,7 +557,9 @@ class Filters(BaseModel, Generic[TFilterModel]):
             # Use `COALESCE` to handle `NULL` values and `||`
             # for cross-database compatible string concatenation
             _fields = self.model.__search_fields__
-            search_expr = " || ".join(f"COALESCE({field}, '')" for field in _fields)
+            search_expr = " || ".join(
+                f"COALESCE(CAST({field} AS TEXT), '')" for field in _fields
+            )
             where_stmts.append(f"lower({search_expr}) LIKE :search")
 
         if where_stmts:

--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -580,7 +580,7 @@ class Filters(BaseModel, Generic[TFilterModel]):
                     for key, value in page_filter.values.items():
                         values[key] = value
         if self.search and self.model:
-            values["search"] = f"%{self.search}%"
+            values["search"] = f"%{self.search.lower()}%"
         return values
 
 

--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -554,8 +554,10 @@ class Filters(BaseModel, Generic[TFilterModel]):
             for page_filter in self.filters:
                 where_stmts.append(page_filter.statement)
         if self.search and self.model and self.model.__search_fields__:
-            # Use COALESCE to handle NULL values and || for cross-database compatible string concatenation
-            search_expr = " || ".join(f"COALESCE({field}, '')" for field in self.model.__search_fields__)
+            # Use `COALESCE` to handle `NULL` values and `||`
+            # for cross-database compatible string concatenation
+            _fields = self.model.__search_fields__
+            search_expr = " || ".join(f"COALESCE({field}, '')" for field in _fields)
             where_stmts.append(f"lower({search_expr}) LIKE :search")
 
         if where_stmts:


### PR DESCRIPTION
## Description
This PR resolves an issue with the search functionality that was failing in SQLite environments due to the use of the `concat()` function, which is not available in SQLite. The fix replaces this with the SQL standard string concatenation operator `||`, which is supported across SQLite, PostgreSQL, and CockroachDB.

## Changes
- Modified the `where()` method to use the `||` operator for string concatenation
- Added handling for NULL values using COALESCE to prevent NULL propagation in search expressions

## Issue
When attempting to perform searches on SQLite databases, the application was throwing the following error:
```
(sqlite3.OperationalError) no such function: concat 
[SQL: SELECT * FROM apipayments WHERE wallet_id = ? AND status != ? AND lower(concat(memo, amount, wallet_id, tag, status, time)) LIKE ? ORDER BY time desc LIMIT 10 ] 
[parameters: ('<redacted>', 'failed', '%be%')]
```

## Testing
- [x] Tested with SQLite database - search now works correctly
- [ ] Verified compatibility with PostgreSQL
- [ ] Verified compatibility with CockroachDB
