### PR TITLE
feat: create new user from the command line

### DIFF
--- a/lnbits/commands.py
+++ b/lnbits/commands.py
@@ -279,8 +279,8 @@ async def create_user(username: str, password: str):
         username=username,
     )
     account.hash_password(password)
-    account = await create_user_account_no_ckeck(account)
-    click.echo(f"User '{account.username}' created. Id: '{account.id}'")
+    user = await create_user_account_no_ckeck(account)
+    click.echo(f"User '{user.username}' created. Id: '{user.id}'")
 
 
 @users.command("cleanup-accounts")


### PR DESCRIPTION
Related to: https://github.com/lnbits/lnbits/issues/3096
### New command:
```sh
Usage: lnbits-cli users [OPTIONS] COMMAND [ARGS]...

  Users related commands

Options:
  --help  Show this message and exit.

Commands:
  cleanup-accounts  Delete all accounts that have no wallets
  new               Create a new user bypassing the system...
``` 

### How to run:
```sh
$ poetry run lnbits-cli users new -u new_user_05 -p secret1234

User 'new_user_05' created. Id: '60d9973cc8ce4412b75cc9bec0d5a919'
```

This PR also fixes the `delete-settings` command which was still using the old DB Table name.