### PR TITLE
bug: add the defaults else it fails

### DIFF
--- a/lnbits/templates/print.html
+++ b/lnbits/templates/print.html
@@ -49,9 +49,17 @@
     <script src="{{ static_url_for('static', url) }}"></script>
     {% endfor %}
     <script>
+      const SITE_DESCRIPTION = {{ SITE_DESCRIPTION | tojson}}
+      const themes = {{ LNBITS_THEME_OPTIONS | tojson }}
+      const LNBITS_DENOMINATION = {{ LNBITS_DENOMINATION | tojson }}
+      const LNBITS_VERSION = {{ LNBITS_VERSION | tojson }}
       const LNBITS_QR_LOGO = {{ LNBITS_QR_LOGO | tojson }}
+      const USE_DEFAULT_REACTION = {{ USE_DEFAULT_REACTION | tojson }}
+      const USE_DEFAULT_THEME = {{ USE_DEFAULT_THEME | tojson }}
+      const USE_DEFAULT_BORDER = {{ USE_DEFAULT_BORDER | tojson }}
+      const USE_DEFAULT_GRADIENT = {{ USE_DEFAULT_GRADIENT | lower | tojson }}
+      const USE_DEFAULT_BGIMAGE = "{{ USE_DEFAULT_BGIMAGE or None | tojson }}"
     </script>
-    <!---->
     {% block scripts %}{% endblock %} {% for url in INCLUDED_COMPONENTS %}
     <script src="{{ static_url_for('static', url) }}"></script>
     {% endfor %}


### PR DESCRIPTION
Fixes all failing pages that rely on `print.html`

- after V1 is released we may have to comeback and make a proper print template