### PR TITLE
fix: Explicitly convert lndrest fee_msat to int

### DIFF
--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -266,7 +266,7 @@ class LndRestWallet(Wallet):
                     if payment is not None and payment.get("status"):
                         return PaymentStatus(
                             paid=statuses[payment["status"]],
-                            fee_msat=payment.get("fee_msat"),
+                            fee_msat=int(payment["fee_msat"]) if payment.get("fee_msat") else None, # LND REST API returns fee_msat as a string, explicitly convert to int
                             preimage=payment.get("payment_preimage"),
                         )
                     else:

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -266,7 +266,11 @@ class LndRestWallet(Wallet):
                     if payment is not None and payment.get("status"):
                         return PaymentStatus(
                             paid=statuses[payment["status"]],
-                            fee_msat=int(payment["fee_msat"]) if payment.get("fee_msat") else None, # LND REST API returns fee_msat as a string, explicitly convert to int
+                            fee_msat=(
+                                int(payment["fee_msat"])
+                                if payment.get("fee_msat")
+                                else None
+                            ),  # LND REST API returns fee_msat as a string, explicitly convert to int
                             preimage=payment.get("payment_preimage"),
                         )
                     else:

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -266,11 +266,12 @@ class LndRestWallet(Wallet):
                     if payment is not None and payment.get("status"):
                         return PaymentStatus(
                             paid=statuses[payment["status"]],
+                            # API returns fee_msat as string, explicitly convert to int
                             fee_msat=(
                                 int(payment["fee_msat"])
                                 if payment.get("fee_msat")
                                 else None
-                            ),  # LND REST API returns fee_msat as a string, explicitly convert to int
+                            ),
                             preimage=payment.get("payment_preimage"),
                         )
                     else:


### PR DESCRIPTION
I've run into this error:

> asyncpg.exceptions.DataError: invalid input for query argument $5: '0' ('str' object cannot be interpreted as an integer) 

This occurred during an UPDATE on the apipayments table, where the fee column (expected to be an INTEGER) was given a string '0'.

I've tracked it to this line in tasks.py:

`payment.fee = status.fee_msat or 0`

While fee is declared as an int in the Payment model, the source of fee_msat (status.fee_msat) can occasionally be a string (e.g., '0'). This can happen when LN backend APIs (such as lnd) return large integers as strings in JSON.

So I'm suggesting this little fix for lndrest. 