### PR TITLE
fix: mask for fiat amount

### DIFF
--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -961,8 +961,8 @@
                     dense
                     v-model.number="parse.data.amount"
                     :label="$t('amount') + ' (' + parse.data.unit + ') *'"
-                    :mask="parse.data.unit != 'sat' ? '#.##' : '#'"
-                    :step="parse.data.unit != 'sat' ? '0.01' : '1'"
+                    :mask="parse.data.unit == 'sat' ? '#' : ''"
+                    :step="parse.data.unit == 'sat' ? '1': '0.01'"
                     fill-mask="0"
                     reverse-fill-mask
                     :min="parse.lnurlpay.minSendable / 1000"


### PR DESCRIPTION
Reported here: https://github.com/lnbits/lnbits/issues/3117

Also added a small refactoring for using positive conditions (`==` instead of `!=`)