### PR TITLE
fix: webhook call on invoice pay

### DIFF
--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -508,7 +508,7 @@ async def is_internal_status_success(
     return payment.status == PaymentState.SUCCESS.value
 
 
-async def mark_webhook_sent(payment_hash: str, status: int) -> None:
+async def mark_webhook_sent(payment_hash: str, status: str) -> None:
     await db.execute(
         """
         UPDATE apipayments SET webhook_status = :status

--- a/lnbits/core/models/payments.py
+++ b/lnbits/core/models/payments.py
@@ -64,7 +64,7 @@ class Payment(BaseModel):
     memo: str | None = None
     expiry: datetime | None = None
     webhook: str | None = None
-    webhook_status: int | None = None
+    webhook_status: str | None = None
     preimage: str | None = None
     tag: str | None = None
     extension: str | None = None


### PR DESCRIPTION
Reported here: https://github.com/lnbits/lnbits/issues/3114
- `webhook_status` is `TEXT` in DB
- use `payment.json()` instead of `payment.dict()`
- fix error logging (include error in message, not as extra param)
- add webhook unit test