### PR TITLE
fix: Normalize fee_reserve amount value 

### DIFF
--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -195,7 +195,6 @@ async def update_pending_payment(payment: Payment) -> bool:
 
 
 def fee_reserve_total(amount_msat: int, internal: bool = False) -> int:
-    amount_msat = abs(amount_msat)
     return fee_reserve(amount_msat, internal) + service_fee(amount_msat, internal)
 
 

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -195,10 +195,12 @@ async def update_pending_payment(payment: Payment) -> bool:
 
 
 def fee_reserve_total(amount_msat: int, internal: bool = False) -> int:
+    amount_msat = abs(amount_msat)
     return fee_reserve(amount_msat, internal) + service_fee(amount_msat, internal)
 
 
 def fee_reserve(amount_msat: int, internal: bool = False) -> int:
+    amount_msat = abs(amount_msat)
     return settings.fee_reserve(amount_msat, internal)
 
 
@@ -479,7 +481,7 @@ async def _pay_internal_invoice(
     ):
         raise PaymentError("Invalid invoice. Bolt11 changed.", status="failed")
 
-    fee_reserve_total_msat = fee_reserve_total(abs(amount_msat), internal=True)
+    fee_reserve_total_msat = fee_reserve_total(amount_msat, internal=True)
     create_payment_model.fee = abs(fee_reserve_total_msat)
 
     if wallet.balance_msat < abs(amount_msat) + fee_reserve_total_msat:


### PR DESCRIPTION
Ensure that fee_reserve always operate on the absolute value of amount_msat internally. This removes the need to call abs() in calling code and reduces the risk of inconsistent fee behavior.

Previously, this inconsistency caused the default 2000 msat limit to apply to all external payments, even for much larger amounts, due to percentage fee reserve being calculated on a negative input.