### PR TITLE
[feat] fetch all payments for user

### DIFF
--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -95,6 +95,7 @@ async def get_latest_payments_by_extension(
 async def get_payments_paginated(
     *,
     wallet_id: Optional[str] = None,
+    wallet_ids: Optional[list[str]] = None,
     complete: bool = False,
     pending: bool = False,
     failed: bool = False,
@@ -121,6 +122,13 @@ async def get_payments_paginated(
     if wallet_id:
         values["wallet_id"] = wallet_id
         clause.append("wallet_id = :wallet_id")
+    elif wallet_ids:
+        wallet_id_clause = []
+        for i, wallet_id_value in enumerate(wallet_ids):
+            wallet_id_key = f"wallet_id_clause__{i}"
+            wallet_id_clause.append(f"wallet_id = :{wallet_id_key}")
+            values[wallet_id_key] = wallet_id_value
+        clause.append(" OR ".join(wallet_id_clause))
 
     if complete and pending:
         clause.append(

--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -1,7 +1,7 @@
 from time import time
 from typing import Any, Optional, Tuple
 
-from lnbits.core.crud.wallets import get_total_balance, get_wallet
+from lnbits.core.crud.wallets import get_total_balance, get_wallet, get_wallets_ids
 from lnbits.core.db import db
 from lnbits.core.models import PaymentState
 from lnbits.db import Connection, DateTrunc, Filters, Page
@@ -95,7 +95,7 @@ async def get_latest_payments_by_extension(
 async def get_payments_paginated(
     *,
     wallet_id: Optional[str] = None,
-    wallet_ids: Optional[list[str]] = None,
+    user_id: Optional[str] = None,
     complete: bool = False,
     pending: bool = False,
     failed: bool = False,
@@ -122,7 +122,8 @@ async def get_payments_paginated(
     if wallet_id:
         values["wallet_id"] = wallet_id
         clause.append("wallet_id = :wallet_id")
-    elif wallet_ids:
+    elif user_id:
+        wallet_ids = await get_wallets_ids(user_id=user_id, conn=conn)
         wallet_id_clause = []
         for i, wallet_id_value in enumerate(wallet_ids):
             wallet_id_key = f"wallet_id_clause__{i}"

--- a/lnbits/core/crud/wallets.py
+++ b/lnbits/core/crud/wallets.py
@@ -135,6 +135,20 @@ async def get_wallets(
     )
 
 
+async def get_wallets_ids(
+    user_id: str, deleted: Optional[bool] = None, conn: Optional[Connection] = None
+) -> list[str]:
+    where = "AND deleted = :deleted" if deleted is not None else ""
+    result = await (conn or db).fetchall(
+        f"""
+        SELECT id FROM wallets
+        WHERE "user" = :user {where}
+        """,
+        {"user": user_id, "deleted": deleted},
+    )
+    return [row["id"] for row in result]
+
+
 async def get_wallets_count():
     result = await db.execute("SELECT COUNT(*) as count FROM wallets")
     row = result.mappings().first()

--- a/lnbits/core/crud/wallets.py
+++ b/lnbits/core/crud/wallets.py
@@ -139,7 +139,7 @@ async def get_wallets_ids(
     user_id: str, deleted: Optional[bool] = None, conn: Optional[Connection] = None
 ) -> list[str]:
     where = "AND deleted = :deleted" if deleted is not None else ""
-    result = await (conn or db).fetchall(
+    result: list[dict] = await (conn or db).fetchall(
         f"""
         SELECT id FROM wallets
         WHERE "user" = :user {where}

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -264,13 +264,21 @@ async def _api_payments_create_invoice(data: CreateInvoice, wallet: Wallet):
     response_description="list of payments",
     response_model=Page[Payment],
     openapi_extra=generate_filter_params_openapi(PaymentFilters),
-    dependencies=[Depends(check_admin)],
 )
 async def api_all_payments_paginated(
     filters: Filters = Depends(parse_filters(PaymentFilters)),
+    user: User = Depends(check_user_exists),
 ):
+    if user.admin:
+        # admin user can see payments from all wallets
+        wallet_ids = None
+    else:
+        # regular user can only see payments from their wallets
+        wallet_ids = user.wallet_ids
+
     return await get_payments_paginated(
         filters=filters,
+        wallet_ids=wallet_ids,
     )
 
 

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -271,14 +271,14 @@ async def api_all_payments_paginated(
 ):
     if user.admin:
         # admin user can see payments from all wallets
-        wallet_ids = None
+        for_user_id = None
     else:
         # regular user can only see payments from their wallets
-        wallet_ids = user.wallet_ids
+        for_user_id = user.id
 
     return await get_payments_paginated(
         filters=filters,
-        wallet_ids=wallet_ids,
+        user_id=for_user_id,
     )
 
 

--- a/tests/unit/test_pay_invoice.py
+++ b/tests/unit/test_pay_invoice.py
@@ -640,3 +640,11 @@ async def test_get_payments_for_user(to_wallet: Wallet):
     total_after = all_payments.total
 
     assert total_after == total_before + 5, "Total payments should be updated."
+
+
+@pytest.mark.anyio
+async def test_get_payments_for_non_user():
+    user_payments = await get_payments_paginated(user_id="nonexistent")
+    assert (
+        user_payments.total == 0
+    ), "No payments should be found for non-existent user."


### PR DESCRIPTION
Update API to allow fetching all payments from all wallets for a particular user.
Filter criteria can apply.

Endpoint: `/api/v1/payments/all/paginated`

**Example** when user id login is allowed (`usr` query param present):
```curl
curl --location --request GET 'http://localhost:5000/api/v1/payments/all/paginated?limit=25&offset=0&sortby=created_at&direction=desc&usr=94c408ff520e42d1a16685eaea681563'
```

Example using an access token:
```curl
curl --location --request GET 'http://localhost:5000/api/v1/payments/all/paginated?limit=25&offset=0&sortby=created_at&direction=desc' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJ1c3IiOiI5NGM0MDhmZjUyMGU0MmQxYTE2Njg1ZWFlYTY4MTU2MyIsImF1dGhfdGltZSI6MTc0NTgzNjIwMCwiZXhwIjoxNzc3MzcyMjAwfQ.eKZsXeWCsG2lS8ItKogLZ2zQb4wvqIbDm8RuSDib_9A'
```