### PR TITLE
fix: `_bcrypt.__about__.__version__` log warning

### DIFF
--- a/lnbits/core/models/misc.py
+++ b/lnbits/core/models/misc.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Callable
 
+import bcrypt
 from pydantic import BaseModel
 
 
 def _do_nothing(*_):
     pass
+
+
+@dataclass
+class SolveBugBcryptWarning:
+    __version__: str = getattr(bcrypt, "__version__")  # noqa
+
+
+# fix annoying warning in the logs
+setattr(bcrypt, "__about__", SolveBugBcryptWarning())  # noqa
 
 
 class CoreAppExtra:

--- a/lnbits/core/models/users.py
+++ b/lnbits/core/models/users.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from uuid import UUID
 
-import bcrypt
 from fastapi import Query
 from passlib.context import CryptContext
 from pydantic import BaseModel, Field
@@ -15,15 +13,6 @@ from lnbits.helpers import is_valid_email_address, is_valid_pubkey, is_valid_use
 from lnbits.settings import settings
 
 from .wallets import Wallet
-
-
-@dataclass
-class SolveBugBcryptWarning:
-    __version__: str = bcrypt.__version__
-
-
-# fix annoying warning in the logs
-bcrypt.__about__ = SolveBugBcryptWarning()
 
 
 class UserExtra(BaseModel):

--- a/lnbits/core/models/users.py
+++ b/lnbits/core/models/users.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from uuid import UUID
 
+import bcrypt
 from fastapi import Query
 from passlib.context import CryptContext
 from pydantic import BaseModel, Field
@@ -13,6 +15,15 @@ from lnbits.helpers import is_valid_email_address, is_valid_pubkey, is_valid_use
 from lnbits.settings import settings
 
 from .wallets import Wallet
+
+
+@dataclass
+class SolveBugBcryptWarning:
+    __version__: str = bcrypt.__version__
+
+
+# fix annoying warning in the logs
+bcrypt.__about__ = SolveBugBcryptWarning()
 
 
 class UserExtra(BaseModel):


### PR DESCRIPTION
https://github.com/pyca/bcrypt/issues/684#issuecomment-2430047176

```
WARNING:passlib.handlers.bcrypt:(trapped) error reading bcrypt version
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/lnbits-S_y84ukP-py3.12/lib/python3.12/site-packages/passlib/handlers/bcrypt.py", line 620, in _load_backend_mixin
    version = _bcrypt.__about__.__version__
              ^^^^^^^^^^^^^^^^^
AttributeError: module 'bcrypt' has no attribute '__about__'
```