### PR TITLE
fix: do not ask for NFC if not needed

### DIFF
--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -639,7 +639,7 @@
               >
                 <span
                   v-if="receive.lnurl"
-                  v-text="$t('withdraw_from') + receive.lnurl.domain"
+                  v-text="`${$t('withdraw_from')} ${receive.lnurl.domain}`"
                 ></span>
                 <span v-else v-text="$t('create_invoice')"></span>
               </q-btn>

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -261,7 +261,9 @@ window.WalletPageLogic = {
           this.receive.paymentReq = response.data.bolt11
           this.receive.amountMsat = response.data.amount
           this.receive.paymentHash = response.data.payment_hash
-          this.readNfcTag()
+          if (!this.receive.lnurl) {
+            this.readNfcTag()
+          }
           // TODO: lnurl_callback and lnurl_response
           // WITHDRAW
           if (response.data.lnurl_response !== null) {


### PR DESCRIPTION
There's no way to know when NFC is disabled. 

This PR checks if the user is trying to receive an LNURLw, is which case the create invoice doesn't need to start the NFC reader. 

On mobile, with NFC capability, if the user has NFC turned off, when trying to redeem an LNURLw, NDEFReader would fail and show an alert. That is completely unnecessary and unrelated to what the user is doing. 

Fixes #3128