### PR TITLE
build: add secp256k1 dependencies to Dockerfile build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim-bookworm AS builder
 
 RUN apt-get clean
 RUN apt-get update
-RUN apt-get install -y curl pkg-config build-essential libnss-myhostname
+RUN apt-get install -y automake build-essential curl libffi-dev libnss-myhostname libtool pkg-config
 
 RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5
 ENV PATH="/root/.local/bin:$PATH"
@@ -25,7 +25,7 @@ FROM python:3.12-slim-bookworm
 
 # needed for backups postgresql-client version 14 (pg_dump)
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get -y install gnupg2 curl lsb-release && \
+    apt-get -y install automake curl gnupg2 libffi-dev libtool lsb-release pkg-config && \
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \


### PR DESCRIPTION
`pkg-config` is a requirement to build `secp256k1`. In the `Dockerfile`, it is added to the `builder` stage, but missing from the final stage where `poetry install` is run for a second time. This change should fix the Docker build against `HEAD` / `dev`.

The current `dev` produces the following error with `docker build .`:

```
> docker build .
[+] Building 3.4s (19/19) FINISHED                                                                                                                                                              docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                            0.0s
 => => transferring dockerfile: 1.67kB                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/python:3.12-slim-bookworm                                                                                                                                    0.5s
 => [internal] load .dockerignore                                                                                                                                                                               0.0s
 => => transferring context: 274B                                                                                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                               0.0s
 => => transferring context: 18.39kB                                                                                                                                                                            0.0s
 => [builder 1/9] FROM docker.io/library/python:3.12-slim-bookworm@sha256:bae1a061b657f403aaacb1069a7f67d91f7ef5725ab17ca36abc5f1b2797ff92                                                                      0.0s
 => => resolve docker.io/library/python:3.12-slim-bookworm@sha256:bae1a061b657f403aaacb1069a7f67d91f7ef5725ab17ca36abc5f1b2797ff92                                                                              0.0s
 => CACHED [stage-1 2/7] RUN apt-get update && apt-get -y upgrade &&     apt-get -y install gnupg2 curl lsb-release &&     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg ma  0.0s
 => CACHED [stage-1 3/7] RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5                                                                                                            0.0s
 => CACHED [stage-1 4/7] WORKDIR /app                                                                                                                                                                           0.0s
 => CACHED [stage-1 5/7] COPY . .                                                                                                                                                                               0.0s
 => CACHED [builder 2/9] RUN apt-get clean                                                                                                                                                                      0.0s
 => CACHED [builder 3/9] RUN apt-get update                                                                                                                                                                     0.0s
 => CACHED [builder 4/9] RUN apt-get install -y curl pkg-config build-essential libnss-myhostname                                                                                                               0.0s
 => CACHED [builder 5/9] RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.8.5                                                                                                            0.0s
 => CACHED [builder 6/9] WORKDIR /app                                                                                                                                                                           0.0s
 => CACHED [builder 7/9] COPY pyproject.toml poetry.lock ./                                                                                                                                                     0.0s
 => CACHED [builder 8/9] RUN mkdir data                                                                                                                                                                         0.0s
 => CACHED [builder 9/9] RUN poetry install --only main                                                                                                                                                         0.0s
 => CACHED [stage-1 6/7] COPY --from=builder /app/.venv .venv                                                                                                                                                   0.0s
 => ERROR [stage-1 7/7] RUN poetry install --only main                                                                                                                                                          2.8s
------
 > [stage-1 7/7] RUN poetry install --only main:
0.860 Installing dependencies from lock file
1.062
1.062 Package operations: 1 install, 0 updates, 0 removals
1.062
1.066   - Installing secp256k1 (0.14.0)
2.633
2.633   ChefBuildError
2.633
2.633   Backend subprocess exited when trying to invoke get_requires_for_build_wheel
2.633
2.633   'pkg-config' is required to install this package. Please see the README for details.
2.633
2.633
2.633   at ~/.local/share/pypoetry/venv/lib/python3.12/site-packages/poetry/installation/chef.py:164 in _prepare
2.637       160│
2.637       161│                 error = ChefBuildError("\n\n".join(message_parts))
2.637       162│
2.637       163│             if error is not None:
2.637     → 164│                 raise error from None
2.637       165│
2.637       166│             return path
2.637       167│
2.637       168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
2.637
2.637 Note: This error originates from the build backend, and is likely not a problem with poetry but with secp256k1 (0.14.0) not supporting PEP 517 builds. You can verify this by running 'pip wheel --no-cache-dir --use-pep517 "secp256k1 (==0.14.0)"'.
2.637
------
Dockerfile:49
--------------------
  47 |     COPY --from=builder /app/.venv .venv
  48 |
  49 | >>> RUN poetry install --only main
  50 |
  51 |     ENV LNBITS_PORT="5000"
--------------------
ERROR: failed to solve: process "/bin/sh -c poetry install --only main" did not complete successfully: exit code: 1
```