### PR TITLE
build: add POETRY_INSTALL_ARGS build argument to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
     POETRY_CACHE_DIR=/tmp/poetry_cache
 
-RUN poetry install --only main
+ARG POETRY_INSTALL_ARGS="--only main"
+RUN poetry install ${POETRY_INSTALL_ARGS}
 
 FROM python:3.12-slim-bookworm
 
@@ -46,7 +47,8 @@ WORKDIR /app
 COPY . .
 COPY --from=builder /app/.venv .venv
 
-RUN poetry install --only main
+ARG POETRY_INSTALL_ARGS="--only main"
+RUN poetry install ${POETRY_INSTALL_ARGS}
 
 ENV LNBITS_PORT="5000"
 ENV LNBITS_HOST="0.0.0.0"

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -170,6 +170,12 @@ mkdir data
 docker run --detach --publish 5000:5000 --name lnbits --volume ${PWD}/.env:/app/.env --volume ${PWD}/data/:/app/data lnbits/lnbits
 ```
 
+You can optionally override the arguments that are passed to `poetry install` during the build process by setting the Docker build argument named `POETRY_INSTALL_ARGS`. For example, to enable the Breez funding source, build the Docker image with the command:
+
+```sh
+docker build --build-arg POETRY_INSTALL_ARGS="-E breez" -t lnbits/lnbits .
+```
+
 ## Option 5: Fly.io
 
 Fly.io is a docker container hosting platform that has a generous free tier. You can host LNbits for free on Fly.io for personal use.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -150,7 +150,7 @@ SUPER_USER=be54db7f245346c8833eaa430e1e0405 LNBITS_ADMIN_UI=true ./result/bin/ln
 
 ## Option 4: Docker
 
-use latest version from docker hub
+Use latest version from Docker Hub.
 
 ```sh
 docker pull lnbits/lnbits
@@ -159,7 +159,7 @@ mkdir data
 docker run --detach --publish 5000:5000 --name lnbits --volume ${PWD}/.env:/app/.env --volume ${PWD}/data/:/app/data lnbits/lnbits
 ```
 
-build the image yourself
+Build the image yourself.
 
 ```sh
 git clone https://github.com/lnbits/lnbits.git


### PR DESCRIPTION
This PR allows community users to reuse the Dockerfile with more flexibility by overriding the default arguments to `poetry install` with `--build-arg POETRY_INSTALL_ARGS="-E breez"`, for example. Specifically enables the `breez` and `liquid` optional dependencies, among other options supported by the `poetry install` command.

The build argument defaults to `--only main` as per the prior hardcoded value and installation documentation.

Example usage: `docker build --build-arg POETRY_INSTALL_ARGS="-E breez" -t lnbits-with-breez .`
