### PR TITLE
feat: add verify_preimage utility function

### DIFF
--- a/lnbits/utils/crypto.py
+++ b/lnbits/utils/crypto.py
@@ -23,6 +23,12 @@ def fake_privkey(secret: str) -> str:
     ).hex()
 
 
+def verify_preimage(preimage: str, payment_hash: str) -> bool:
+    preimage_bytes = bytes.fromhex(preimage)
+    calculated_hash = sha256(preimage_bytes).hexdigest()
+    return calculated_hash == payment_hash
+
+
 class AESCipher:
     """This class is compatible with crypto-js/aes.js
 


### PR DESCRIPTION
Utility function that verifies Lightning Network payment preimages against corresponding payment hashes.

- Takes a hex-encoded preimage and expected payment hash
- Calculates SHA-256 hash of the preimage
- Compares calculated hash with the provided payment hash
- Returns a boolean indicating if the preimage is valid

Written to be used anywhere preimages should be verified, such as in my Strike wallet implementation.