### PR TITLE
feat: add ssl proxy settings to docker and `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -167,10 +167,10 @@ KEYCLOAK_DISCOVERY_URL=""
 
 ######################################
 
-# uvicorn variable, uncomment to allow https behind a proxy
+# uvicorn variable, allow https behind a proxy
 # IMPORTANT: this also needs the webserver to be configured to forward the headers
 # http://docs.lnbits.org/guide/installation.html#running-behind-an-apache2-reverse-proxy-over-https
-# FORWARDED_ALLOW_IPS="*"
+FORWARDED_ALLOW_IPS="*"
 
 # Server security, rate limiting ips, blocked ips, allowed ips
 LNBITS_RATE_LIMIT_NO="200"

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,4 @@ ENV LNBITS_HOST="0.0.0.0"
 
 EXPOSE 5000
 
-CMD ["sh", "-c", "poetry run lnbits --port $LNBITS_PORT --host $LNBITS_HOST"]
+CMD ["sh", "-c", "poetry run lnbits --port $LNBITS_PORT --host $LNBITS_HOST --forwarded-allow-ips='*'"]


### PR DESCRIPTION
i hope with this defaults no so many people will run into https issues with lnurl.