### PR TITLE
feat: add QR code for wallet keys

### DIFF
--- a/lnbits/core/templates/core/_api_docs.html
+++ b/lnbits/core/templates/core/_api_docs.html
@@ -48,6 +48,17 @@
               class="cursor-pointer q-ml-sm"
               @click="copyText(wallet.adminkey)"
             ></q-icon>
+            <q-icon name="qr_code" class="cursor-pointer q-ml-sm">
+              <q-popup-proxy>
+                <div class="q-pa-md">
+                  <lnbits-qrcode
+                    :value="wallet.adminkey"
+                    :options="{ width: 250 }"
+                    class="rounded-borders"
+                  ></lnbits-qrcode>
+                </div>
+              </q-popup-proxy>
+            </q-icon>
           </div>
         </q-item-section>
       </q-item>
@@ -70,6 +81,17 @@
               class="cursor-pointer q-ml-sm"
               @click="copyText(wallet.inkey)"
             ></q-icon>
+            <q-icon name="qr_code" class="cursor-pointer q-ml-sm">
+              <q-popup-proxy>
+                <div class="q-pa-md">
+                  <lnbits-qrcode
+                    :value="wallet.inkey"
+                    :options="{ width: 250 }"
+                    class="rounded-borders"
+                  ></lnbits-qrcode>
+                </div>
+              </q-popup-proxy>
+            </q-icon>
           </div>
         </q-item-section>
       </q-item>


### PR DESCRIPTION
Adds a QR popup on the wallet info sidebar.

![image](https://github.com/user-attachments/assets/e5b5f9bb-37ea-48e6-82ae-e725914333ad)


Closes #3191