### PR TITLE
Exclude gbp from Binance exchange rates

### DIFF
--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -319,7 +319,7 @@ class ExchangeProvidersSettings(LNbitsSettings):
                 name="Binance",
                 api_url="https://api.binance.com/api/v3/ticker/price?symbol=BTC{TO}",
                 path="$.price",
-                exclude_to=["czk"],
+                exclude_to=["czk", "gbp"],
                 ticker_conversion=["USD:USDT"],
             ),
             ExchangeRateProvider(


### PR DESCRIPTION
For an unknown reason, the Binance API returns the BTCGBP pair at around 40% of the value of other exchanges which results in an incorrect average BTCGBP value for fiat calculations.