### PR TITLE
feat: add internal_invoice_queue_put to get rid of dynamic import

### DIFF
--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -20,6 +20,7 @@ from lnbits.exceptions import InvoiceError, PaymentError
 from lnbits.fiat import get_fiat_provider
 from lnbits.helpers import check_callback_url
 from lnbits.settings import settings
+from lnbits.tasks import create_task, internal_invoice_queue_put
 from lnbits.utils.crypto import fake_privkey, random_secret_and_hash
 from lnbits.utils.exchange_rates import fiat_amount_as_satoshis, satoshis_amount_as_fiat
 from lnbits.wallets import fake_wallet, get_funding_source
@@ -424,10 +425,7 @@ async def update_wallet_balance(
         )
         payment.status = PaymentState.SUCCESS
         await update_payment(payment, conn=conn)
-        # notify receiver asynchronously
-        from lnbits.tasks import internal_invoice_queue
-
-        await internal_invoice_queue.put(payment.checking_id)
+        await internal_invoice_queue_put(payment.checking_id)
 
 
 async def check_wallet_limits(

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -107,6 +107,13 @@ def register_invoice_listener(send_chan: asyncio.Queue, name: Optional[str] = No
 internal_invoice_queue: asyncio.Queue = asyncio.Queue(0)
 
 
+async def internal_invoice_queue_put(checking_id: str) -> None:
+    """
+    A method to call when it wants to notify about an internal invoice payment.
+    """
+    await internal_invoice_queue.put(checking_id)
+
+
 async def internal_invoice_listener() -> None:
     """
     internal_invoice_queue will be filled directly in core/services.py


### PR DESCRIPTION
adding a helper function to add to a queue takes care of  the circular import issue