### PR TITLE
fix: condition for available, but not installed extension

### DIFF
--- a/lnbits/exceptions.py
+++ b/lnbits/exceptions.py
@@ -151,7 +151,7 @@ def register_exception_handlers(app: FastAPI):
         status_code = HTTPStatus.NOT_FOUND
         message: str = "Page not found."
 
-        if path in settings.lnbits_all_extensions_ids:
+        if settings.is_ready_to_install_extension_id(path):
             status_code = HTTPStatus.FORBIDDEN
             message = f"Extension '{path}' not installed. Ask the admin to install it."
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -1026,6 +1026,12 @@ class Settings(EditableSettings, ReadOnlySettings, TransientSettings, BaseSettin
     def is_installed_extension_id(self, ext_id: str) -> bool:
         return ext_id in self.lnbits_installed_extensions_ids
 
+    def is_ready_to_install_extension_id(self, ext_id: str) -> bool:
+        return (
+            ext_id not in self.lnbits_installed_extensions_ids
+            and ext_id in self.lnbits_all_extensions_ids
+        )
+
 
 class SuperSettings(EditableSettings):
     super_user: str


### PR DESCRIPTION
### Summary
Fix condition for when an extension is available, but not installed yet.

**Problem**: the error message for a not found page was a 403 even if an extension was installed

**Before**: `403 Extension 'tpos' not installed. Ask the admin to install it.`
![image](https://github.com/user-attachments/assets/2df04a09-490b-4863-86dd-cae159ccf84d)


**After**: `404 Page Not found`
![image](https://github.com/user-attachments/assets/01cc08ed-0bb9-44c5-b6d4-e1ec23ac86be)
