### PR TITLE
[fix] bandit sql warnings

### DIFF
--- a/lnbits/core/crud/audit.py
+++ b/lnbits/core/crud/audit.py
@@ -74,6 +74,8 @@ async def get_long_duration_stats(
         filters = Filters()
     clause = filters.where()
     long_duration_paths = await (conn or db).fetchall(
+        # This query is safe from SQL injection
+        # The `clause` is constructed from sanitized inputs
         query=f"""
             SELECT path as field, max(duration) as total FROM audit
             {clause}

--- a/lnbits/core/crud/audit.py
+++ b/lnbits/core/crud/audit.py
@@ -30,10 +30,11 @@ async def delete_expired_audit_entries(
     conn: Optional[Connection] = None,
 ):
     await (conn or db).execute(
-        f"""
+        """
             DELETE from audit
-            WHERE delete_at < {db.timestamp_now}
+            WHERE delete_at < :delete_at
         """,
+        {"delete_at": db.timestamp_now},
     )
 
 

--- a/lnbits/core/crud/audit.py
+++ b/lnbits/core/crud/audit.py
@@ -30,11 +30,11 @@ async def delete_expired_audit_entries(
     conn: Optional[Connection] = None,
 ):
     await (conn or db).execute(
-        """
+        # Timestamp placeholder is safe from SQL injection as it is not user input
+        f"""
             DELETE from audit
-            WHERE delete_at < :delete_at
-        """,
-        {"delete_at": db.timestamp_now},
+            WHERE delete_at < {db.timestamp_now}
+        """,  # noqa: S608
     )
 
 

--- a/lnbits/core/crud/audit.py
+++ b/lnbits/core/crud/audit.py
@@ -55,7 +55,7 @@ async def get_count_stats(
             {clause}
             GROUP BY {field}
             ORDER BY {field}
-        """,
+        """,  # noqa: S608
         values=filters.values(),
         model=AuditCountStat,
     )
@@ -77,7 +77,7 @@ async def get_long_duration_stats(
             GROUP BY path
             ORDER BY total DESC
             LIMIT 5
-        """,
+        """,  # noqa: S608
         values=filters.values(),
         model=AuditCountStat,
     )

--- a/lnbits/core/crud/audit.py
+++ b/lnbits/core/crud/audit.py
@@ -30,7 +30,7 @@ async def delete_expired_audit_entries(
     conn: Optional[Connection] = None,
 ):
     await (conn or db).execute(
-        # Timestamp placeholder is safe from SQL injection as it is not user input
+        # Timestamp placeholder is safe from SQL injection (not user input)
         f"""
             DELETE from audit
             WHERE delete_at < {db.timestamp_now}
@@ -49,6 +49,9 @@ async def get_count_stats(
         filters = Filters()
     clause = filters.where()
     data = await (conn or db).fetchall(
+        # SQL injection vectors safety:
+        # - `field` is a static string, not user input
+        # - `clause` is generated from filters, which are validated and sanitized
         query=f"""
             SELECT {field} as field, count({field}) as total
             FROM audit

--- a/lnbits/core/crud/extensions.py
+++ b/lnbits/core/crud/extensions.py
@@ -78,10 +78,13 @@ async def get_installed_extensions(
     active: Optional[bool] = None,
     conn: Optional[Connection] = None,
 ) -> list[InstallableExtension]:
-    where = "WHERE active = :active" if active is not None else ""
+    query = "SELECT * FROM installed_extensions"
+    if active is not None:
+        query += " WHERE active = :active"
+
     values = {"active": active} if active is not None else {}
     all_extensions = await (conn or db).fetchall(
-        f"SELECT * FROM installed_extensions {where}",
+        query,
         values,
         model=InstallableExtension,
     )

--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -55,7 +55,7 @@ async def get_standalone_payment(
         SELECT * FROM apipayments
         WHERE {clause}
         ORDER BY amount LIMIT 1
-        """,  # noqa: S608
+        """,
         values,
         Payment,
     )
@@ -88,7 +88,7 @@ async def get_latest_payments_by_extension(
         AND extra LIKE :ext_name
         AND extra LIKE :ext_id
         ORDER BY time DESC LIMIT {int(limit)}
-        """,  # noqa: S608
+        """,
         {
             "status": f"{PaymentState.SUCCESS}",
             "ext_name": f"%{ext_name}%",
@@ -238,7 +238,7 @@ async def delete_expired_invoices(
         DELETE FROM apipayments
         WHERE status = :status AND amount > 0
         AND time < {db.timestamp_placeholder("delta")}
-        """,  # noqa: S608
+        """,
         {"status": f"{PaymentState.PENDING}", "delta": int(time() - 2592000)},
     )
     # then we delete all invoices whose expiry date is in the past
@@ -511,11 +511,11 @@ async def check_internal(
     otherwise None
     """
     return await (conn or db).fetchone(
-        f"""
+        """
         SELECT * FROM apipayments
-        WHERE payment_hash = :hash AND status = '{PaymentState.PENDING}' AND amount > 0
+        WHERE payment_hash = :hash AND status = :status AND amount > 0
         """,
-        {"hash": payment_hash},
+        {"status": f"'{PaymentState.PENDING}'", "hash": payment_hash},
         Payment,
     )
 

--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -527,7 +527,7 @@ async def check_internal(
         SELECT * FROM apipayments
         WHERE payment_hash = :hash AND status = :status AND amount > 0
         """,
-        {"status": f"'{PaymentState.PENDING}'", "hash": payment_hash},
+        {"status": f"{PaymentState.PENDING}", "hash": payment_hash},
         Payment,
     )
 

--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -486,7 +486,7 @@ async def get_wallets_stats(
 
     data = await (conn or db).fetchall(
         # This query is safe from SQL injection
-        # The `clause` is constructed from sanitized inputs
+        # The `clauses` is constructed from sanitized inputs
         query=f"""
             SELECT apipayments.wallet_id,
                     MAX(wallets.name) AS wallet_name,

--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -55,7 +55,7 @@ async def get_standalone_payment(
         SELECT * FROM apipayments
         WHERE {clause}
         ORDER BY amount LIMIT 1
-        """,
+        """,  # noqa: S608
         values,
         Payment,
     )
@@ -88,7 +88,7 @@ async def get_latest_payments_by_extension(
         AND extra LIKE :ext_name
         AND extra LIKE :ext_id
         ORDER BY time DESC LIMIT {int(limit)}
-        """,
+        """,  # noqa: S608
         {
             "status": f"{PaymentState.SUCCESS}",
             "ext_name": f"%{ext_name}%",
@@ -238,17 +238,17 @@ async def delete_expired_invoices(
         DELETE FROM apipayments
         WHERE status = :status AND amount > 0
         AND time < {db.timestamp_placeholder("delta")}
-        """,
+        """,  # noqa: S608
         {"status": f"{PaymentState.PENDING}", "delta": int(time() - 2592000)},
     )
     # then we delete all invoices whose expiry date is in the past
     await (conn or db).execute(
         f"""
         DELETE FROM apipayments
-        WHERE status = '{PaymentState.PENDING}' AND amount > 0
+        WHERE status = :status AND amount > 0
         AND expiry < {db.timestamp_placeholder("now")}
-        """,
-        {"now": int(time())},
+        """,  # noqa: S608
+        {"status": f"{PaymentState.PENDING}", "now": int(time())},
     )
 
 
@@ -337,7 +337,7 @@ async def get_payments_history(
         {filters.where(where)}
         GROUP BY date
         ORDER BY date DESC
-        """,
+        """,  # noqa: S608
         filters.values(values),
     )
     if wallet_id:
@@ -389,7 +389,7 @@ async def get_payment_count_stats(
             {clause}
             GROUP BY {field}
             ORDER BY {field}
-        """,
+        """,  # noqa: S608
         values=filters.values(),
         model=PaymentCountStat,
     )
@@ -486,7 +486,7 @@ async def get_wallets_stats(
             {clauses}
             GROUP BY apipayments.wallet_id
             ORDER BY payments_count
-        """,
+        """,  # noqa: S608
         values=filters.values(),
         model=PaymentWalletStats,
     )

--- a/lnbits/core/crud/users.py
+++ b/lnbits/core/crud/users.py
@@ -118,7 +118,7 @@ async def delete_accounts_no_wallets(
             (updated_at is null AND created_at < :delta)
             OR updated_at < {db.timestamp_placeholder("delta")}
         )
-        """,
+        """,  # noqa: S608
         {"delta": delta},
     )
 

--- a/lnbits/core/crud/users.py
+++ b/lnbits/core/crud/users.py
@@ -110,6 +110,7 @@ async def delete_accounts_no_wallets(
 ) -> None:
     delta = int(time()) - time_delta
     await (conn or db).execute(
+        # Timestamp placeholder is safe from SQL injection (not user input)
         f"""
         DELETE FROM accounts
         WHERE NOT EXISTS (

--- a/lnbits/core/crud/wallets.py
+++ b/lnbits/core/crud/wallets.py
@@ -48,6 +48,7 @@ async def delete_wallet(
 ) -> None:
     now = int(time())
     await (conn or db).execute(
+        # Timestamp placeholder is safe from SQL injection (not user input)
         f"""
         UPDATE wallets
         SET deleted = :deleted, updated_at = {db.timestamp_placeholder('now')}
@@ -71,6 +72,7 @@ async def delete_wallet_by_id(
 ) -> Optional[int]:
     now = int(time())
     result = await (conn or db).execute(
+        # Timestamp placeholder is safe from SQL injection (not user input)
         f"""
         UPDATE wallets
         SET deleted = true, updated_at = {db.timestamp_placeholder('now')}

--- a/lnbits/core/crud/wallets.py
+++ b/lnbits/core/crud/wallets.py
@@ -52,7 +52,7 @@ async def delete_wallet(
         UPDATE wallets
         SET deleted = :deleted, updated_at = {db.timestamp_placeholder('now')}
         WHERE id = :wallet AND "user" = :user
-        """,
+        """,  # noqa: S608
         {"wallet": wallet_id, "user": user_id, "deleted": deleted, "now": now},
     )
 
@@ -75,7 +75,7 @@ async def delete_wallet_by_id(
         UPDATE wallets
         SET deleted = true, updated_at = {db.timestamp_placeholder('now')}
         WHERE id = :wallet
-        """,
+        """,  # noqa: S608
         {"wallet": wallet_id, "now": now},
     )
     return result.rowcount

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -222,7 +222,7 @@ async def m007_set_invoice_expiries(db: Connection):
             AND bolt11 IS NOT NULL
             AND expiry IS NULL
             AND time < {db.timestamp_now}
-            """
+            """  # noqa: S608
         )
         rows = result.mappings().all()
         if len(rows):
@@ -245,7 +245,7 @@ async def m007_set_invoice_expiries(db: Connection):
                     f"""
                     UPDATE apipayments SET expiry = {db.timestamp_placeholder('expiry')}
                     WHERE checking_id = :checking_id AND amount > 0
-                    """,
+                    """,  # noqa: S608
                     {"expiry": expiration_date, "checking_id": checking_id},
                 )
             except Exception as exc:
@@ -459,14 +459,14 @@ async def m017_add_timestamp_columns_to_accounts_and_wallets(db: Connection):
             f"""
             UPDATE wallets SET created_at = {db.timestamp_placeholder('now')}
             WHERE created_at IS NULL
-            """,
+            """,  # noqa: S608
             {"now": now},
         )
         await db.execute(
             f"""
             UPDATE accounts SET created_at = {db.timestamp_placeholder('now')}
             WHERE created_at IS NULL
-            """,
+            """,  # noqa: S608
             {"now": now},
         )
 
@@ -618,7 +618,7 @@ async def m027_update_apipayments_data(db: Connection):
         logger.info(f"Updating {offset} to {offset+limit}")
 
         result = await db.execute(
-            f"SELECT * FROM apipayments  ORDER BY time LIMIT {limit} OFFSET {offset}"
+            f"SELECT * FROM apipayments  ORDER BY time LIMIT {limit} OFFSET {offset}"  # noqa: S608
         )
         payments = result.mappings().all()
         logger.info(f"Payments count: {len(payments)}")
@@ -635,7 +635,7 @@ async def m027_update_apipayments_data(db: Connection):
                 UPDATE apipayments
                 SET tag = :tag, created_at = {tsph}, updated_at = {tsph}
                 WHERE checking_id = :checking_id
-                """,
+                """,  # noqa: S608
                 {
                     "tag": tag,
                     "created_at": created_at,

--- a/lnbits/core/migrations.py
+++ b/lnbits/core/migrations.py
@@ -214,6 +214,7 @@ async def m007_set_invoice_expiries(db: Connection):
     """
     try:
         result = await db.execute(
+            # Timestamp placeholder is safe from SQL injection (not user input)
             f"""
             SELECT bolt11, checking_id
             FROM apipayments
@@ -242,6 +243,7 @@ async def m007_set_invoice_expiries(db: Connection):
                     f" {invoice.payment_hash} to {expiration_date}"
                 )
                 await db.execute(
+                    # Timestamp placeholder is safe from SQL injection (not user input)
                     f"""
                     UPDATE apipayments SET expiry = {db.timestamp_placeholder('expiry')}
                     WHERE checking_id = :checking_id AND amount > 0
@@ -456,6 +458,7 @@ async def m017_add_timestamp_columns_to_accounts_and_wallets(db: Connection):
         # set all to now where they are null
         now = int(time())
         await db.execute(
+            # Timestamp placeholder is safe from SQL injection (not user input)
             f"""
             UPDATE wallets SET created_at = {db.timestamp_placeholder('now')}
             WHERE created_at IS NULL
@@ -463,6 +466,7 @@ async def m017_add_timestamp_columns_to_accounts_and_wallets(db: Connection):
             {"now": now},
         )
         await db.execute(
+            # Timestamp placeholder is safe from SQL injection (not user input)
             f"""
             UPDATE accounts SET created_at = {db.timestamp_placeholder('now')}
             WHERE created_at IS NULL
@@ -618,7 +622,12 @@ async def m027_update_apipayments_data(db: Connection):
         logger.info(f"Updating {offset} to {offset+limit}")
 
         result = await db.execute(
-            f"SELECT * FROM apipayments  ORDER BY time LIMIT {limit} OFFSET {offset}"  # noqa: S608
+            # Limit and Offset safe from SQL injection
+            # since they are integers and are not user input
+            f"""
+                SELECT * FROM apipayments
+                ORDER BY time LIMIT {int(limit)} OFFSET {int(offset)}
+            """  # noqa: S608
         )
         payments = result.mappings().all()
         logger.info(f"Payments count: {len(payments)}")
@@ -631,6 +640,7 @@ async def m027_update_apipayments_data(db: Connection):
                 tag = extra.get("tag")
             tsph = db.timestamp_placeholder("created_at")
             await db.execute(
+                # Timestamp placeholder is safe from SQL injection (not user input)
                 f"""
                 UPDATE apipayments
                 SET tag = :tag, created_at = {tsph}, updated_at = {tsph}

--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -252,7 +252,7 @@ class Connection(Compat):
                         {clause}
                         {group_by_string}
                     ) as count
-                    """,
+                    """,  # noqa: S608
                     parsed_values,
                 )
                 row = result.mappings().first()
@@ -597,7 +597,7 @@ def insert_query(table_name: str, model: BaseModel) -> str:
     # add quotes to keys to avoid SQL conflicts (e.g. `user` is a reserved keyword)
     fields = ", ".join([f'"{key}"' for key in keys])
     values = ", ".join(placeholders)
-    return f"INSERT INTO {table_name} ({fields}) VALUES ({values})"
+    return f"INSERT INTO {table_name} ({fields}) VALUES ({values})"  # noqa: S608
 
 
 def update_query(
@@ -615,7 +615,7 @@ def update_query(
         # add quotes to keys to avoid SQL conflicts (e.g. `user` is a reserved keyword)
         fields.append(f'"{field}" = {placeholder}')
     query = ", ".join(fields)
-    return f"UPDATE {table_name} SET {query} {where}"
+    return f"UPDATE {table_name} SET {query} {where}"  # noqa: S608
 
 
 def model_to_dict(model: BaseModel) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,10 +221,9 @@ classmethod-decorators = [
 # S602 `subprocess` call with `shell=True` identified, security issue
 # S603 `subprocess` call: check for execution of untrusted input
 # S607: Starting a process with a partial executable path
-# TODO: do not skip S608:
 # S608: Possible SQL injection vector through string-based query construction
 # S324 Probable use of insecure hash functions in `hashlib`: `md5`
-"lnbits/*" = ["S101", "S608"]
+"lnbits/*" = ["S101"]
 "lnbits/core/views/admin_api.py" = ["S602", "S603", "S607"]
 "crypto.py" = ["S324"]
 "test*.py" = ["S101", "S105", "S106", "S307"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ classmethod-decorators = [
 # S607: Starting a process with a partial executable path
 # S608: Possible SQL injection vector through string-based query construction
 # S324 Probable use of insecure hash functions in `hashlib`: `md5`
+# TODO: remove S101 ignore
 "lnbits/*" = ["S101"]
 "lnbits/core/views/admin_api.py" = ["S602", "S603", "S607"]
 "crypto.py" = ["S324"]
@@ -230,9 +231,6 @@ classmethod-decorators = [
 "tools*.py" = ["S101", "S608"]
 "tests/*" = ["S311"]
 "tests/regtest/helpers.py" = ["S603"]
-
-[tool.bandit]
-skips = ["B101", "B404"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10


### PR DESCRIPTION
Some SQL queries are built by string concatenation.
Even if the values are sanitized this is still a code smell (that `bandit`) reports.

This PR fixes some SQL queries to not use string concatenation. For the rest of them it adds comments explaining why they are safe.