### PR TITLE
feat: better server start logging

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import shutil
 import sys
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Callable, Optional
@@ -70,8 +71,9 @@ from .tasks import internal_invoice_listener, invoice_listener, run_interval
 
 
 async def startup(app: FastAPI):
+    logger.info(f"Starting LNbits Version: {settings.version}")
+    start = time.perf_counter()
     settings.lnbits_running = True
-
     # wait till migration is done
     await migrate_databases()
 
@@ -109,6 +111,9 @@ async def startup(app: FastAPI):
             "up_time": settings.lnbits_server_up_time,
         },
     )
+
+    end = time.perf_counter()
+    logger.success(f"LNbits started in {end - start:.2f} seconds.")
 
 
 async def shutdown():

--- a/lnbits/utils/logger.py
+++ b/lnbits/utils/logger.py
@@ -13,7 +13,7 @@ from lnbits.settings import settings
 
 
 def log_server_info():
-    logger.info("Starting LNbits")
+    logger.info("LNbits Info")
     logger.info(f"Version: {settings.version}")
     logger.info(f"Baseurl: {settings.lnbits_baseurl}")
     logger.info(f"Host: {settings.host}")


### PR DESCRIPTION
### Summary
The LNbits version was logged only after the migration was done. If something went wrong during the migration then we could not find the LNbits version from the logs.

**Extra**: add a log with the duration for the server to start.

New start log:
<img width="1593" height="105" alt="image" src="https://github.com/user-attachments/assets/13795334-f12b-461c-9893-ff9c86bc6e14" />

New time log:
<img width="1563" height="80" alt="image" src="https://github.com/user-attachments/assets/0d431413-f422-4f98-9fac-3b8ac9b4234e" />
