### PR TITLE
chore: use modern websockets instead of legacy

### DIFF
--- a/lnbits/wallets/blink.py
+++ b/lnbits/wallets/blink.py
@@ -7,8 +7,7 @@ from typing import Optional
 import httpx
 from loguru import logger
 from pydantic import BaseModel
-from websockets.legacy.client import connect
-from websockets.typing import Subprotocol
+from websockets import Subprotocol, connect
 
 from lnbits import bolt11
 from lnbits.helpers import normalize_endpoint

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 import httpx
 from loguru import logger
-from websockets.legacy.client import connect
+from websockets import connect
 
 from lnbits.helpers import normalize_endpoint
 from lnbits.settings import settings
@@ -245,7 +245,9 @@ class EclairWallet(Wallet):
             try:
                 async with connect(
                     self.ws_url,
-                    extra_headers=[("Authorization", self.headers["Authorization"])],
+                    additional_headers=[
+                        ("Authorization", self.headers["Authorization"])
+                    ],
                 ) as ws:
                     while settings.lnbits_running:
                         message = await ws.recv()

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import httpx
 from loguru import logger
-from websockets.legacy.client import connect
+from websockets import connect
 
 from lnbits.helpers import normalize_endpoint
 from lnbits.settings import settings

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -10,7 +10,7 @@ from urllib.parse import parse_qs, unquote, urlparse
 import secp256k1
 from bolt11 import decode as bolt11_decode
 from loguru import logger
-from websockets.legacy.client import connect as ws_connect
+from websockets import connect as ws_connect
 
 from lnbits.settings import settings
 from lnbits.utils.nostr import (

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 import httpx
 from httpx import RequestError, TimeoutException
 from loguru import logger
-from websockets.legacy.client import connect
+from websockets import connect
 
 from lnbits.helpers import normalize_endpoint
 from lnbits.settings import settings
@@ -300,7 +300,9 @@ class PhoenixdWallet(Wallet):
             try:
                 async with connect(
                     self.ws_url,
-                    extra_headers=[("Authorization", self.headers["Authorization"])],
+                    additional_headers=[
+                        ("Authorization", self.headers["Authorization"])
+                    ],
                 ) as ws:
                     logger.info("connected to phoenixd invoices stream")
                     while settings.lnbits_running:

--- a/tests/wallets/test_nwc_wallets.py
+++ b/tests/wallets/test_nwc_wallets.py
@@ -9,7 +9,8 @@ import secp256k1
 from Cryptodome import Random
 from Cryptodome.Cipher import AES
 from Cryptodome.Util.Padding import pad, unpad
-from websockets.legacy.server import serve as ws_serve
+from websockets import ServerConnection
+from websockets import serve as ws_serve
 
 from lnbits.wallets.nwc import NWCWallet
 from tests.wallets.helpers import (
@@ -74,7 +75,9 @@ def sign_event(pub_key, priv_key, event):
     return event
 
 
-async def handle(wallet, mock_settings, data, websocket, path):  # noqa: C901
+async def handle(  # noqa: C901
+    wallet, mock_settings, data, websocket: ServerConnection
+):
     async for message in websocket:
         if not wallet:
             continue
@@ -162,8 +165,8 @@ async def run(data: WalletTest):
     if mock_settings is None:
         return
 
-    async def handler(websocket, path):
-        return await handle(wallet, mock_settings, data, websocket, path)
+    def handler(websocket):
+        return handle(wallet, mock_settings, data, websocket)
 
     if mock_settings is not None:
         async with ws_serve(handler, "localhost", mock_settings["port"]) as server:


### PR DESCRIPTION
closes #3228

upgrade docs:
https://websockets.readthedocs.io/en/stable/howto/upgrade.html