### PR TITLE
[Fix] Don't allow pay for expired invoice

### DIFF
--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -276,7 +276,10 @@ window.WalletPageLogic = {
             this.readNfcTag()
           }
           // WITHDRAW
-          if (response.data.extra.lnurl_response !== null) {
+          if (
+            this.receive.lnurl &&
+            response.data.extra?.lnurl_response !== null
+          ) {
             if (response.data.extra.lnurl_response === false) {
               response.data.extra.lnurl_response = `Unable to connect`
             }

--- a/lnbits/static/js/wallet.js
+++ b/lnbits/static/js/wallet.js
@@ -141,6 +141,7 @@ window.WalletPageLogic = {
     },
     canPay() {
       if (!this.parse.invoice) return false
+      if (this.parse.invoice.expired) return false
       return this.parse.invoice.sat <= this.g.wallet.sat
     },
     formattedAmount() {


### PR DESCRIPTION
Disables pay button if pasted invoice is expired

hotfix for running lnurlw logic if bolt11 is pasted

Closes #3285