### PR TITLE
fix: prevent overflow on dialog

### DIFF
--- a/lnbits/templates/components.vue
+++ b/lnbits/templates/components.vue
@@ -370,7 +370,12 @@
       v-if="extras.length"
     >
       <template v-for="entry in extras">
-        <q-item v-if="!!entry.value" key="entry.key" class="text-grey-4">
+        <q-item
+          v-if="!!entry.value"
+          key="entry.key"
+          class="text-grey-4"
+          style="white-space: normal; word-break: break-all"
+        >
           <q-item-section>
             <q-item-label v-text="entry.key"></q-item-label>
             <q-item-label caption v-text="entry.value"></q-item-label>


### PR DESCRIPTION
Prevent large string to overflow on payment detail dialog.

<img width="1327" height="925" alt="image" src="https://github.com/user-attachments/assets/fef6f9e3-9e61-4342-b745-dd8da4bea9ea" />
