### PR TITLE
bug: propergate LnurlErrorResponse in lnurl service and dont checks for redundant `LnurlPayActionResponse`

### DIFF
--- a/lnbits/core/services/lnurl.py
+++ b/lnbits/core/services/lnurl.py
@@ -17,7 +17,6 @@ async def get_pr_from_lnurl(lnurl: str, amount_msat: int) -> str:
     if isinstance(res, LnurlErrorResponse):
         raise LnurlResponseException(res.reason)
     if not isinstance(res, LnurlPayResponse):
-
         raise LnurlResponseException(
             "Invalid LNURL response. Expected LnurlPayResponse."
         )
@@ -29,10 +28,6 @@ async def get_pr_from_lnurl(lnurl: str, amount_msat: int) -> str:
     )
     if isinstance(res2, LnurlErrorResponse):
         raise LnurlResponseException(res2.reason)
-    if not isinstance(res, LnurlPayActionResponse):
-        raise LnurlResponseException(
-            "Invalid LNURL pay response. Expected LnurlPayActionResponse."
-        )
     return res2.pr
 
 

--- a/lnbits/core/services/lnurl.py
+++ b/lnbits/core/services/lnurl.py
@@ -17,6 +17,7 @@ async def get_pr_from_lnurl(lnurl: str, amount_msat: int) -> str:
     if isinstance(res, LnurlErrorResponse):
         raise LnurlResponseException(res.reason)
     if not isinstance(res, LnurlPayResponse):
+
         raise LnurlResponseException(
             "Invalid LNURL response. Expected LnurlPayResponse."
         )
@@ -26,6 +27,8 @@ async def get_pr_from_lnurl(lnurl: str, amount_msat: int) -> str:
         user_agent=settings.user_agent,
         timeout=10,
     )
+    if isinstance(res2, LnurlErrorResponse):
+        raise LnurlResponseException(res2.reason)
     if not isinstance(res, LnurlPayActionResponse):
         raise LnurlResponseException(
             "Invalid LNURL pay response. Expected LnurlPayActionResponse."

--- a/lnbits/core/services/lnurl.py
+++ b/lnbits/core/services/lnurl.py
@@ -1,4 +1,5 @@
 from lnurl import (
+    LnurlErrorResponse,
     LnurlPayActionResponse,
     LnurlPayResponse,
     LnurlResponseException,
@@ -13,6 +14,8 @@ from lnbits.utils.exchange_rates import fiat_amount_as_satoshis
 
 async def get_pr_from_lnurl(lnurl: str, amount_msat: int) -> str:
     res = await handle(lnurl, user_agent=settings.user_agent, timeout=10)
+    if isinstance(res, LnurlErrorResponse):
+        raise LnurlResponseException(res.reason)
     if not isinstance(res, LnurlPayResponse):
         raise LnurlResponseException(
             "Invalid LNURL response. Expected LnurlPayResponse."


### PR DESCRIPTION
 dont check for redundant `LnurlPayActionResponse` this somehow failed but lnurl lib actually already verifies it.