### PR TITLE
fix(corelightning): Explicitly set "pay" method in RPC call

### DIFF
--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -174,7 +174,8 @@ class CoreLightningWallet(Wallet):
                 "description": invoice.description,
             }
 
-            r = await run_sync(lambda: self.ln.call(self.pay, payload))
+            # FIX: Use the explicit "pay" command instead of the configurable self.pay
+            r = await run_sync(lambda: self.ln.call("pay", payload))
 
             fee_msat = -int(r["amount_sent_msat"] - r["amount_msat"])
             return PaymentResponse(


### PR DESCRIPTION
When paying an invoice, the CoreLightning wallet was making an RPC call without a method name, causing the node to return an "Unknown command ''" error.

This was because the method name was being read from a configurable setting that was not always present. The fix hardcodes the RPC method to "pay", ensuring the call is always correctly formatted and removing the dependency on a potentially missing configuration.