### PR TITLE
fix:correct-checking-id

### DIFF
--- a/lnbits/core/models/payments.py
+++ b/lnbits/core/models/payments.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from fastapi import Query
 from lnurl import LnurlWithdrawResponse
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, root_validator, validator
 
 from lnbits.db import FilterModel
 from lnbits.fiat import get_fiat_provider
@@ -82,6 +82,20 @@ class Payment(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     extra: dict = {}
+
+    @root_validator(pre=True)
+    def set_checking_id_from_hash(cls, values):
+        """
+        This validator ensures that the 'checking_id' which is used for
+        status checks is ALWAYS the real payment hash, not the internal DB id.
+        This fixes the bug where UUIDs are sent to the backend.
+        It runs before standard validation (pre=True) to ensure checking_id
+        is correct before any other checks might use it.
+        """
+        payment_hash = values.get("payment_hash")
+        if payment_hash:
+            values["checking_id"] = payment_hash
+        return values
 
     @property
     def pending(self) -> bool:


### PR DESCRIPTION
Fixes a bug where internal database UUIDs were being sent to the Core Lightning node when checking payment statuses, causing `Invalid parameter payment_hash` errors in the logs.

The Bug:
When fetching payments from the database, particularly in API endpoints like `/api/v1/payments/paginated` used by the wallet view, the `Payment` Pydantic model was being created with a `checking_id` that sometimes contained the payment's internal database UUID.

When the application then tried to check the status of this payment (e.g., via `payment.check_status()`), it would pass this UUID to the Core Lightning funding source. The node, expecting a 32-byte hex payment hash, would correctly reject this parameter and log an error.

The Fix:
The fix is implemented by adding a Pydantic `@root_validator` to the `Payment` model in `lnbits/core/models/payments.py`.

This validator runs every time a `Payment` object is instantiated from database data. It forcefully overwrites the `checking_id` field with the value from the `payment_hash` field. This corrects the data at its source, guaranteeing that any `Payment` object used throughout the application will have a `checking_id` suitable for its funding source.