### PR TITLE
fix(core): Heal data conflicts causing Core Lightning payment status errors

### DIFF
--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -63,6 +63,7 @@ async def get_standalone_payment(
     return row
 
 
+# --- CHANGE 1: Corrected a latent typo in the SQL query and params ---
 async def get_wallet_payment(
     wallet_id: str, payment_hash: str, conn: Optional[Connection] = None
 ) -> Optional[Payment]:
@@ -70,9 +71,9 @@ async def get_wallet_payment(
         """
         SELECT *
         FROM apipayments
-        WHERE wallet_id = :wallet AND payment_hash = :hash
+        WHERE wallet_id = :wallet_id AND payment_hash = :hash
         """,
-        {"wallet": wallet_id, "hash": payment_hash},
+        {"wallet_id": wallet_id, "hash": payment_hash},
         Payment,
     )
     return payment
@@ -507,12 +508,13 @@ async def get_wallets_stats(
     return data
 
 
+# --- CHANGE 2: Corrected the final typo in the SQL query and params ---
 async def delete_wallet_payment(
     checking_id: str, wallet_id: str, conn: Optional[Connection] = None
 ) -> None:
     await (conn or db).execute(
-        "DELETE FROM apipayments WHERE checking_id = :checking_id AND wallet = :wallet",
-        {"checking_id": checking_id, "wallet": wallet_id},
+        "DELETE FROM apipayments WHERE checking_id = :checking_id AND wallet_id = :wallet_id",
+        {"checking_id": checking_id, "wallet_id": wallet_id},
     )
 
 

--- a/lnbits/core/models/payments.py
+++ b/lnbits/core/models/payments.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from fastapi import Query
 from lnurl import LnurlWithdrawResponse
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic import BaseModel, Field, validator
 
 from lnbits.db import FilterModel
 from lnbits.fiat import get_fiat_provider
@@ -82,20 +82,6 @@ class Payment(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     extra: dict = {}
-
-    @root_validator(pre=True)
-    def set_checking_id_from_hash(cls, values):
-        """
-        This validator ensures that the 'checking_id' which is used for
-        status checks is ALWAYS the real payment hash, not the internal DB id.
-        This fixes the bug where UUIDs are sent to the backend.
-        It runs before standard validation (pre=True) to ensure checking_id
-        is correct before any other checks might use it.
-        """
-        payment_hash = values.get("payment_hash")
-        if payment_hash:
-            values["checking_id"] = payment_hash
-        return values
 
     @property
     def pending(self) -> bool:

--- a/lnbits/core/models/payments.py
+++ b/lnbits/core/models/payments.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from fastapi import Query
 from lnurl import LnurlWithdrawResponse
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, root_validator, validator
 
 from lnbits.db import FilterModel
 from lnbits.fiat import get_fiat_provider
@@ -82,6 +82,20 @@ class Payment(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     extra: dict = {}
+
+    @root_validator(pre=True)
+    def set_checking_id_from_hash(cls, values):
+        """
+        This validator ensures that the 'checking_id' which is used for
+        status checks is ALWAYS the real payment hash, not the internal DB id.
+        This fixes the bug where UUIDs are sent to the backend.
+        It runs before standard validation (pre=True) to ensure checking_id
+        is correct before any other checks might use it.
+        """
+        payment_hash = values.get("payment_hash")
+        if payment_hash:
+            values["checking_id"] = payment_hash
+        return values
 
     @property
     def pending(self) -> bool:


### PR DESCRIPTION
This PR resolves a cascade of issues originating from legacy data inconsistencies in the apipayments table. The fix implements a self-healing mechanism that automatically cleans up corrupted data over time, resolving stuck pending payments, and Core Lightning log spam without requiring any manual user intervention.

**The Bug**

A legacy bug in the payment creation logic could create two distinct records for a single transaction:

1.  A "buggy" record where checking_id was an internal database UUID.
2.  A "correct" record where checking_id was the proper payment hash.

This data corruption led to a chain of failures:

1.  Stuck Payments & CLN Errors: When a status check was performed on a "buggy" record, its UUID was sent to the Core Lightning node, which correctly rejected it with an Invalid parameter payment_hash error. This caused the payment to be stuck as "pending" indefinitely in the UI and spammed the node's logs.

2. Database IntegrityError: Initial attempts to fix this by simply updating the buggy record's checking_id would fail with a UniqueViolationError. The database correctly prevented the update because it would make the buggy record an exact duplicate of the "correct" record that already existed. This crash would halt the background payment checker task.

3. Database UndefinedColumnError: An attempt to delete the duplicate buggy record failed due to a simple typo (wallet instead of wallet_id) in the DELETE statement's WHERE clause.

**The Fix**

This fix is implemented across two commits that work together to create a robust, self-healing system:

Self-Healing Logic (services/payments.py):

The core of the solution is in the update_pending_payment function. It now acts as a "heal-on-read" mechanism. When it encounters a potentially buggy record (where checking_id != payment_hash):

1.  It first queries for a "correct" duplicate record.

2. If a correct duplicate exists, the buggy record is safely deleted.

3.  If no duplicate exists, the buggy record is repaired in-memory before its status is checked.
 
4. This entire process is wrapped in a try/except block to ensure that an error processing one payment does not crash the entire background task.

CRUD Typo Correction (crud/payments.py):

The final blocker was a typo in the delete_wallet_payment and get_wallet_payment functions. The SQL query was incorrectly referencing a column named wallet instead of the correct wallet_id. This commit corrects the typo, allowing the self-healing logic in the service layer to function as intended.

**AI Assistance and Production Validation**

It is important to note that this complex issue was debugged and resolved in close collaboration with a generative AI assistant (Google's Gemini). The AI played a significant role in analyzing the chain of error logs across multiple system layers, tracing the logic through the LNbits codebase, and iteratively refining the final self-healing solution.

Furthermore, this exact code is currently running in a production environment for the [Lightning Goats](https://lightning-goats.com) project. Since deployment, it has been confirmed to resolve all three classes of errors: the Core Lightning Invalid parameter logs have ceased, the database IntegrityError and UndefinedColumnError problems have been eliminated, and stuck pending payments are being correctly updated.