### PR TITLE
refactor: move from settings.py model to fiat_provider utils

### DIFF
--- a/lnbits/core/models/users.py
+++ b/lnbits/core/models/users.py
@@ -16,6 +16,7 @@ from lnbits.helpers import (
     is_valid_username,
 )
 from lnbits.settings import settings
+from lnbits.utils.fiat_provider import get_fiat_providers_for_user
 
 from .wallets import Wallet
 
@@ -127,7 +128,7 @@ class Account(BaseModel):
         super().__init__(**data)
         self.is_super_user = settings.is_super_user(self.id)
         self.is_admin = settings.is_admin_user(self.id)
-        self.fiat_providers = settings.get_fiat_providers_for_user(self.id)
+        self.fiat_providers = get_fiat_providers_for_user(self.id)
 
     def hash_password(self, password: str) -> str:
         """sets and returns the hashed password"""

--- a/lnbits/core/services/fiat_providers.py
+++ b/lnbits/core/services/fiat_providers.py
@@ -10,7 +10,7 @@ from lnbits.core.models import CreatePayment, Payment, PaymentState
 from lnbits.core.models.misc import SimpleStatus
 from lnbits.db import Connection
 from lnbits.fiat import get_fiat_provider
-from lnbits.settings import settings
+from lnbits.utils.fiat_provider import get_fiat_provider_limits
 
 
 async def handle_fiat_payment_confirmation(
@@ -36,7 +36,7 @@ async def _credit_fiat_service_fee_wallet(
     if payment.fee == 0:
         return
 
-    limits = settings.get_fiat_provider_limits(fiat_provider_name)
+    limits = get_fiat_provider_limits(fiat_provider_name)
     if not limits:
         return
 
@@ -71,7 +71,7 @@ async def _debit_fiat_service_faucet_wallet(
     if not fiat_provider_name:
         return
 
-    limits = settings.get_fiat_provider_limits(fiat_provider_name)
+    limits = get_fiat_provider_limits(fiat_provider_name)
     if not limits:
         return
 

--- a/lnbits/fiat/__init__.py
+++ b/lnbits/fiat/__init__.py
@@ -6,7 +6,7 @@ from enum import Enum
 from loguru import logger
 
 from lnbits.fiat.base import FiatProvider
-from lnbits.settings import settings
+from lnbits.utils.fiat_provider import is_fiat_provider_enabled
 
 from .stripe import StripeWallet
 
@@ -38,7 +38,7 @@ async def get_fiat_provider(name: str) -> FiatProvider | None:
 
 
 def _init_fiat_provider(fiat_provider: FiatProviderType) -> FiatProvider | None:
-    if not settings.is_fiat_provider_enabled(fiat_provider.name):
+    if not is_fiat_provider_enabled(fiat_provider.name):
         logger.warning(f"Fiat provider '{fiat_provider.name}' not enabled.")
         return None
     provider_constructor = getattr(fiat_module, fiat_provider.value)

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -609,7 +609,7 @@ class FiatProviderLimits(BaseModel):
     service_faucet_wallet_id: str | None = Field(default="")
 
 
-class StripeFiatProvider(LNbitsSettings):
+class StripeFiatSettings(LNbitsSettings):
     stripe_enabled: bool = Field(default=False)
     stripe_api_endpoint: str = Field(default="https://api.stripe.com")
     stripe_api_secret_key: str | None = Field(default=None)
@@ -656,40 +656,6 @@ class FundingSourcesSettings(
     # How long to wait for the payment to be confirmed before returning a pending status
     # It will not fail the payment, it will make it return pending after the timeout
     lnbits_funding_source_pay_invoice_wait_seconds: int = Field(default=5, ge=0)
-
-
-class FiatProvidersSettings(StripeFiatProvider):
-
-    def is_fiat_provider_enabled(self, provider: str | None) -> bool:
-        """
-        Checks if a specific fiat provider is enabled.
-        """
-        if not provider:
-            return False
-        if provider == "stripe":
-            return self.stripe_enabled
-        # Add checks for other fiat providers here as needed
-        return False
-
-    def get_fiat_providers_for_user(self, user_id: str) -> list[str]:
-        """
-        Returns a list of fiat payment methods allowed for the user.
-        """
-        allowed_providers = []
-        if self.stripe_enabled and (
-            not self.stripe_limits.allowed_users
-            or user_id in self.stripe_limits.allowed_users
-        ):
-            allowed_providers.append("stripe")
-
-        # Add other fiat providers here as needed
-        return allowed_providers
-
-    def get_fiat_provider_limits(self, provider_name: str) -> FiatProviderLimits | None:
-        """
-        Returns the limits for a specific fiat provider.
-        """
-        return getattr(self, provider_name + "_limits", None)
 
 
 class WebPushSettings(LNbitsSettings):
@@ -864,7 +830,6 @@ class EditableSettings(
     SecuritySettings,
     NotificationsSettings,
     FundingSourcesSettings,
-    FiatProvidersSettings,
     LightningSettings,
     WebPushSettings,
     NodeUISettings,
@@ -874,6 +839,7 @@ class EditableSettings(
     GoogleAuthSettings,
     GitHubAuthSettings,
     KeycloakAuthSettings,
+    StripeFiatSettings,
 ):
     @validator(
         "lnbits_admin_users",

--- a/lnbits/utils/fiat_provider.py
+++ b/lnbits/utils/fiat_provider.py
@@ -1,0 +1,30 @@
+from lnbits.settings import FiatProviderLimits, settings
+
+
+def get_fiat_providers_for_user(user_id: str) -> list[str]:
+    """
+    Returns a list of fiat payment methods allowed for the user.
+    """
+    allowed_providers = []
+    if settings.stripe_enabled and (
+        not settings.stripe_limits.allowed_users
+        or user_id in settings.stripe_limits.allowed_users
+    ):
+        allowed_providers.append("stripe")
+
+    # Add other fiat providers here as needed
+    return allowed_providers
+
+
+def get_fiat_provider_limits(provider: str) -> FiatProviderLimits | None:
+    """
+    Returns the limits for a specific fiat provider.
+    """
+    return getattr(settings, provider + "_limits", None)
+
+
+def is_fiat_provider_enabled(provider: str) -> bool:
+    """
+    Checks if a specific fiat provider is enabled.
+    """
+    return getattr(settings, provider + "_enabled", False)


### PR DESCRIPTION
just to keep `settings.py` and the configuration simpler