### PR TITLE
chore: qr button tweak (quasar classes should always be used)

### DIFF
--- a/lnbits/templates/components.vue
+++ b/lnbits/templates/components.vue
@@ -649,7 +649,7 @@
     </div>
     <div
       v-if="showButtons"
-      class="qrcode__buttons row q-gutter-x-sm items-center justify-end no-wrap full-width "
+      class="qrcode__buttons row q-gutter-x-sm items-center justify-end no-wrap full-width"
     >
       <q-btn
         v-if="nfc && nfcSupported"


### PR DESCRIPTION
buttons also need to be a block to avoid elements leaking into them