### PR TITLE
fix: remove uneven padding from Repo button

### DIFF
--- a/lnbits/core/templates/core/extensions.html
+++ b/lnbits/core/templates/core/extensions.html
@@ -916,7 +916,6 @@
                 :href="selectedExtensionDetails.repo"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="q-pr-xs"
                 ><q-tooltip>repository</q-tooltip></q-btn
               >
             </div>


### PR DESCRIPTION
## Summary
- Fixes uneven padding on the Repo button in extension details dialog
- Removed `q-pr-xs` class which was causing padding-right: 4px while left padding was 16px
- Button now has balanced padding on both sides

## Changes
- `lnbits/core/templates/core/extensions.html` (line 919): Removed `class="q-pr-xs"` from Repo button

## Screenshot

<img width="3444" height="1630" alt="image" src="https://github.com/user-attachments/assets/3d8f7c3c-7a46-42ed-88a4-831464ba4cd5" />


## Test plan
- [x] Tested on local dev server (port 5001)
- [x] Verified button padding is now equal on left and right sides
- [x] Confirmed visual appearance matches other buttons in the UI

Fixes #3371

🤖 Generated with [Claude Code](https://claude.com/claude-code)