### PR TITLE
fix: increase extension icon size in left nav

### DIFF
--- a/lnbits/templates/components.vue
+++ b/lnbits/templates/components.vue
@@ -129,7 +129,7 @@
     >
       <q-item-section side>
         <q-avatar size="md">
-          <q-img :src="extension.tile" style="max-width: 20px"></q-img>
+          <q-img :src="extension.tile" style="max-width: 32px"></q-img>
         </q-avatar>
       </q-item-section>
       <q-item-section>


### PR DESCRIPTION
## Summary
- Fixes extension icons being smaller (20px) than other icons (32px) in the left navigation drawer
- Updated extension icon max-width from 20px to 32px to match settings, admin, and other navigation icons

## Changes
- `lnbits/templates/components.vue` (line 132): Changed `max-width: 20px` to `max-width: 32px`

## Screenshot

<img width="3444" height="1610" alt="image" src="https://github.com/user-attachments/assets/3ee10961-d235-41fd-a95b-8feb11395331" />


## Visual Comparison
**Before:** Extension icons appeared noticeably smaller than other nav icons
**After:** Extension icons now match the size of other navigation icons (32px)

## Test plan
- [x] Tested with extension icons in left navigation
- [x] Verified icon size now matches other nav icons
- [x] Confirmed no layout issues or overlap

Fixes #3372

🤖 Generated with [Claude Code](https://claude.com/claude-code)