### PR TITLE
feat: allow query param for qrcode

### DIFF
--- a/lnbits/core/views/api.py
+++ b/lnbits/core/views/api.py
@@ -115,7 +115,7 @@ async def api_fiat_as_sats(data: ConversionData):
 
 @api_router.get("/api/v1/qrcode", response_class=StreamingResponse)
 @api_router.get("/api/v1/qrcode/{data}", response_class=StreamingResponse)
-async def img(data):
+async def img(data: str):
     qr = pyqrcode.create(data)
     stream = BytesIO()
     qr.svg(stream, scale=3)


### PR DESCRIPTION
Allow for URLs to be shown in the QR code

Before this returned 404:
http://localhost:5000/api/v1/qrcode/https%3A%2F%2Fcheckout.stripe.com

After, this can be used:
http://localhost:5000/api/v1/qrcode?data=https%3A%2F%2Fcheckout.stripe.com