### PR TITLE
fix: overlapping input

### DIFF
--- a/lnbits/core/templates/admin/_tab_notifications.html
+++ b/lnbits/core/templates/admin/_tab_notifications.html
@@ -76,19 +76,25 @@
                 icon="add"
               ></q-btn>
             </q-input>
-            <div>
-              <q-chip
-                v-for="identifier in formData.lnbits_nostr_notifications_identifiers"
-                :key="identifier"
-                removable
-                @remove="removeNostrNotificationIdentifier(identifier)"
-                color="primary"
-                text-color="white"
-                ><span class="ellipsis" v-text="identifier"></span
-              ></q-chip>
-            </div>
           </q-item-section>
         </q-item>
+        <div>
+          <q-chip
+            v-for="identifier in formData.lnbits_nostr_notifications_identifiers"
+            :key="identifier"
+            removable
+            @remove="removeNostrNotificationIdentifier(identifier)"
+            color="primary"
+            text-color="white"
+            class="ellipsis"
+            :label="identifier"
+            ><q-tooltip
+              v-if="identifier"
+              anchor="top middle"
+              self="bottom middle"
+              ><span v-text="identifier"></span></q-tooltip
+          ></q-chip>
+        </div>
       </div>
 
       <div class="col-sm-12 col-md-6">


### PR DESCRIPTION
Fix for overlapping input in notifications tab:

<img width="803" height="686" alt="image" src="https://github.com/user-attachments/assets/fa6190bb-d191-4c1f-9bd7-fb25e40e5c60" />


Closes #3382