### PR TITLE
nix: Re-enable and fix basic nix flake check for nix package and module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,6 +145,7 @@
             nixpkgs.overlays = [ self.overlays.${system}.default ];
           };
 
-          checks = { };
+          checks =
+            import ./nix/tests { inherit pkgs; flake = self; };
         });
 }

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, makeTest, inputs }:
+{ pkgs, flake }:
 {
-  vmTest = import ./nixos-module { inherit pkgs makeTest inputs; };
+  vmTest = import ./nixos-module { inherit pkgs flake; };
 }

--- a/nix/tests/nixos-module/default.nix
+++ b/nix/tests/nixos-module/default.nix
@@ -1,16 +1,19 @@
-{ pkgs, makeTest, inputs }:
-makeTest {
+{ pkgs, flake }:
+pkgs.nixosTest {
   name = "lnbits-nixos-module";
   nodes = {
     client = { config, pkgs, ... }: {
       environment.systemPackages = [ pkgs.curl ];
     };
     lnbits = { ... }: {
-      imports = [ inputs.self.nixosModules.default ];
+      imports = [ flake.nixosModules.${pkgs.system}.default ];
       services.lnbits = {
         enable = true;
         openFirewall = true;
         host = "0.0.0.0";
+        env = {
+          LNBITS_ADMIN_UI = "false";
+        };
       };
     };
   };
@@ -19,8 +22,10 @@ makeTest {
     lnbits.wait_for_open_port(${toString nodes.lnbits.config.services.lnbits.port})
     client.wait_for_unit("multi-user.target")
     with subtest("Check that the lnbits webserver can be reached."):
-        assert "<title>LNbits</title>" in client.succeed(
-            "curl -sSf http:/lnbits:8231/ | grep title"
+        output = client.succeed(
+            "curl -sSf http://lnbits:8231/ | grep title | head -n1"
         )
+
+        assert "<title>LNbits</title>" in output;
   '';
 }


### PR DESCRIPTION
This fixes the basic vmTest which was in place. At the moment just checks that that the index page contains "<title>LNbits</title>"

Currently `nix flake check` still fails due to another issue with the flake setup, but the test can be run using:

```
nix build .#checks.x86_64-linux.vmTest.driver
./result/bin/nixos-test-driver ./result/test-script
```