### PR TITLE
fix: handle all lnurl exceptions on lnurlscan endpoint

### DIFF
--- a/lnbits/core/views/lnurl_api.py
+++ b/lnbits/core/views/lnurl_api.py
@@ -6,16 +6,17 @@ from fastapi import (
     Depends,
     HTTPException,
 )
-from lnurl import LnurlResponseException
-from lnurl import execute_login as lnurlauth
-from lnurl import handle as lnurl_handle
-from lnurl.models import (
+from lnurl import (
     LnurlAuthResponse,
     LnurlErrorResponse,
+    LnurlException,
     LnurlPayResponse,
-    LnurlResponseModel,
+    LnurlResponseException,
     LnurlWithdrawResponse,
 )
+from lnurl import execute_login as lnurlauth
+from lnurl import handle as lnurl_handle
+from lnurl.models import LnurlResponseModel
 from loguru import logger
 
 from lnbits.core.models import Payment
@@ -38,7 +39,7 @@ async def _handle(lnurl: str) -> LnurlResponseModel:
         res = await lnurl_handle(lnurl, user_agent=settings.user_agent, timeout=5)
         if isinstance(res, LnurlErrorResponse):
             raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=res.reason)
-    except LnurlResponseException as exc:
+    except LnurlException as exc:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST, detail=str(exc)
         ) from exc


### PR DESCRIPTION
related to #3448 but now an uppercase lnaddress still throws an error.

![screenshot-1761560474](https://github.com/user-attachments/assets/b8e89d05-371f-428a-8a78-53a95a584b93)
