### PR TITLE
Replaced admin > settings page horizontal header nav with drop down nav

### DIFF
--- a/lnbits/core/templates/admin/index.html
+++ b/lnbits/core/templates/admin/index.html
@@ -76,27 +76,33 @@ import window_vars with context %} {% block scripts %} {{ window_vars(user) }}
 <div class="row q-col-gutter-md justify-center">
   <div class="col q-gutter-y-md">
     <q-card>
-      <!-- Mobile: Horizontal tabs at top -->
-      <q-tabs
-        v-if="$q.screen.lt.md"
-        @update:model-value="showExchangeProvidersTab"
-        v-model="tab"
-        dense
-        active-color="primary"
-        inline-label
-        class="text-primary"
-      >
-        <q-tab name="funding" icon="account_balance_wallet" label="Fund" />
-        <q-tab name="security" icon="security" label="Sec" />
-        <q-tab name="server" icon="settings" label="Srv" />
-        <q-tab name="exchange_providers" icon="swap_horiz" label="Exch" />
-        <q-tab name="fiat_providers" icon="account_balance" label="Fiat" />
-        <q-tab name="extensions" icon="extension" label="Ext" />
-        <q-tab name="notifications" icon="notifications" label="Not" />
-        <q-tab name="audit" icon="receipt_long" label="Aud" />
-        <q-tab name="site_customisation" icon="language" label="Site" />
-        <q-tab name="library" icon="image" label="Lib" />
-      </q-tabs>
+      <!-- Mobile: Dropdown menu at top -->
+      <div v-if="$q.screen.lt.md" class="q-px-md q-pt-md">
+        <q-select
+          v-model="tab"
+          :options="[
+            { value: 'funding', label: $t('funding') },
+            { value: 'security', label: $t('security') },
+            { value: 'server', label: $t('payments') },
+            { value: 'exchange_providers', label: $t('exchanges') },
+            { value: 'fiat_providers', label: $t('fiat_providers') },
+            { value: 'users', label: $t('users') },
+            { value: 'extensions', label: $t('extensions') },
+            { value: 'notifications', label: $t('notifications') },
+            { value: 'audit', label: $t('audit') },
+            { value: 'library', label: $t('Library') },
+            { value: 'site_customisation', label: $t('site_customisation') }
+          ]"
+          option-value="value"
+          option-label="label"
+          emit-value
+          map-options
+          filled
+          dense
+          @update:model-value="showExchangeProvidersTab"
+        >
+        </q-select>
+      </div>
 
       <!-- Desktop: Vertical sidebar with splitter -->
       <q-splitter v-if="$q.screen.gt.sm">


### PR DESCRIPTION
Replaced admin /settings page horizontal header nav with drop down navigation:

The abbreviated section titles are confusing. Drop down nav is easier to use.

Before:
<img width="487" height="556" alt="image" src="https://github.com/user-attachments/assets/7e1fac91-b780-4631-a298-3532b16dc580" />


After:
<img width="518" height="493" alt="image" src="https://github.com/user-attachments/assets/baf6fcbd-3190-4659-ae43-a7024b03ea37" />

<img width="445" height="832" alt="image" src="https://github.com/user-attachments/assets/45cadada-c215-4382-9132-79382113ae91" />
