### PR TITLE
fix: check_callback_url in dispatch_webhook was not handled

### DIFF
--- a/lnbits/core/services/notifications.py
+++ b/lnbits/core/services/notifications.py
@@ -241,6 +241,10 @@ async def dispatch_webhook(payment: Payment):
     async with httpx.AsyncClient(headers=headers) as client:
         try:
             check_callback_url(payment.webhook)
+        except ValueError as exc:
+            await mark_webhook_sent(payment.payment_hash, "-1")
+            logger.warning(f"Invalid webhook URL {payment.webhook}: {exc!s}")
+        try:
             r = await client.post(payment.webhook, json=payment.json(), timeout=40)
             r.raise_for_status()
             await mark_webhook_sent(payment.payment_hash, str(r.status_code))


### PR DESCRIPTION
only `httpx.HTTPStatusError` and `httpx.RequestError` where handled, not the ValueError that check_callback_url can raise. that never marked the webhook  as sent/failed. 