### PR TITLE
fix: pay_invoice http error

### DIFF
--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -108,7 +108,8 @@ class OpenNodeWallet(Wallet):
 
         if r.is_error:
             error_message = r.json()["message"]
-            return PaymentResponse(ok=False, error_message=error_message)
+            logger.warning(error_message)
+            return PaymentResponse(ok=None, error_message=error_message)
 
         data = r.json()["data"]
         checking_id = data["id"]


### PR DESCRIPTION
### Summary
This PR fixes 2 issues:
  1. payment should not be considered failed if `pay_invoice` HTTP call return serror
  2. expired payments should be considered failed.

Point 2 fixes this:
```
  File "/app/lnbits/core/views/payment_api.py", line 187, in api_payments_paginated
    await update_pending_payment(payment)
  File "/app/lnbits/core/services/payments.py", line 343, in update_pending_payment
    status = await payment.check_status()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lnbits/core/models/payments.py", line 149, in check_status
    status = await funding_source.get_invoice_status(self.checking_id)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lnbits/wallets/opennode.py", line 127, in get_invoice_status
    return PaymentStatus(statuses[data.get("status")])
                         ~~~~~~~~^^^^^^^^^^^^^^^^^^^^
KeyError: 'expired'
```