### PR TITLE
fix: allow str instead of number

### DIFF
--- a/lnbits/templates/components/admin/assets-config.vue
+++ b/lnbits/templates/components/admin/assets-config.vue
@@ -120,7 +120,7 @@
         </p>
         <q-input
           filled
-          v-model.number="newNoLimitUser"
+          v-model="newNoLimitUser"
           @keydown.enter="addNewNoLimitUser()"
           :label="$t('assets_no_limit_users')"
           :hint="$t('assets_no_limit_users_desc')"


### PR DESCRIPTION
`v-model.number` was preventing to add the user string