### PR TITLE
chore: remove unused full withdraw

### DIFF
--- a/lnbits/core/models/wallets.py
+++ b/lnbits/core/models/wallets.py
@@ -4,12 +4,10 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 
-from lnurl import encode as lnurl_encode
 from pydantic import BaseModel, Field
 
 from lnbits.core.models.lnurl import StoredPayLinks
 from lnbits.db import FilterModel
-from lnbits.helpers import url_for
 from lnbits.settings import settings
 
 
@@ -195,14 +193,6 @@ class Wallet(BaseModel):
     @property
     def withdrawable_balance(self) -> int:
         return self.balance_msat - settings.fee_reserve(self.balance_msat)
-
-    @property
-    def lnurlwithdraw_full(self) -> str:
-        url = url_for("/withdraw", external=True, usr=self.user, wal=self.id)
-        try:
-            return lnurl_encode(url)
-        except Exception:
-            return ""
 
     @property
     def is_lightning_wallet(self) -> bool:

--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -239,27 +239,6 @@
               <q-separator></q-separator>
 
               <q-list>
-                {% if wallet.lnurlwithdraw_full %}
-                <q-expansion-item
-                  group="extras"
-                  icon="crop_free"
-                  :label="$t('drain_funds')"
-                >
-                  <q-card>
-                    <q-card-section>
-                      <lnbits-qrcode
-                        value="lightning:{{wallet.lnurlwithdraw_full}}"
-                        href="lightning:{{wallet.lnurlwithdraw_full}}"
-                      ></lnbits-qrcode>
-                      <p
-                        class="text-center"
-                        v-text="$t('drain_funds_desc')"
-                      ></p>
-                    </q-card-section>
-                  </q-card>
-                </q-expansion-item>
-                <q-separator></q-separator>
-                {% endif %}
                 <q-expansion-item
                   group="extras"
                   icon="qr_code"


### PR DESCRIPTION
- will add this as feature after the wallet.html refactor seems like completly dead code, the `/withdraw` endpoint does not seem to exist anymore nor was this wallet option shown for a long time

https://github.com/lnbits/lnbits/issues/3545
![screenshot-1763648736](https://github.com/user-attachments/assets/9e03a722-32c2-46ba-8bd0-3ccf13a3f6b8)
![screenshot-1763648483](https://github.com/user-attachments/assets/f9f8c720-050b-48b8-b209-6e897ac51dd0)
