### PR TITLE
fix: hide splitter on mobile

### DIFF
--- a/lnbits/templates/pages/admin.vue
+++ b/lnbits/templates/pages/admin.vue
@@ -100,8 +100,8 @@
           </q-select>
         </div>
 
-        <q-splitter>
-          <template v-slot:before>
+        <q-splitter :separator-style="$q.screen.lt.md && 'display: none'">
+          <template v-slot:before v-if="$q.screen.gt.sm">
             <q-tabs v-model="tab" vertical active-color="primary">
               <q-tab
                 name="funding"


### PR DESCRIPTION
Small UI nitpick.

- hide the left isde icons when on mobile (there's a select on top)
- hide the splitter separator

<img width="787" height="951" alt="image" src="https://github.com/user-attachments/assets/1cd410ae-d958-416e-bb7d-84203eaa4419" />
