### PR TITLE
fix: better naming

### DIFF
--- a/lnbits/templates/pages/wallet.vue
+++ b/lnbits/templates/pages/wallet.vue
@@ -135,7 +135,8 @@
                 class="q-mr-md"
                 @click="showParseDialog"
                 :disable="!this.g.wallet.canSendPayments"
-                :label="$t('paste_request')"
+                :label="$t('receive')"
+                icon="file_download"
               ></q-btn>
               <q-btn
                 unelevated
@@ -143,7 +144,8 @@
                 class="q-mr-md"
                 @click="showReceiveDialog"
                 :disable="!this.g.wallet.canReceivePayments"
-                :label="$t('create_invoice')"
+                :label="$t('send')"
+                icon="file_upload"
               ></q-btn>
               <q-btn
                 unelevated


### PR DESCRIPTION
To mirror phone UI
<img height="100" alt="image" src="https://github.com/user-attachments/assets/b904c871-a7b6-45f5-8e62-27ec2d831dcc" />
<img height="202" alt="image" src="https://github.com/user-attachments/assets/24654004-2b4a-47df-8b4b-d5e3a7e4a0d4" />

