### PR TITLE
perf: optimisation to avoid double db calls

### DIFF
--- a/lnbits/core/crud/payments.py
+++ b/lnbits/core/crud/payments.py
@@ -4,6 +4,7 @@ from typing import Any
 from lnbits.core.crud.wallets import get_total_balance, get_wallet, get_wallets_ids
 from lnbits.core.db import db
 from lnbits.core.models import PaymentState
+from lnbits.core.models.wallets import Wallet
 from lnbits.db import Connection, DateTrunc, Filters, Page
 
 from ..models import (
@@ -109,6 +110,7 @@ async def get_latest_payments_by_extension(
 async def get_payments_paginated(  # noqa: C901
     *,
     wallet_id: str | None = None,
+    wallet: Wallet | None = None,  # perf optimization to avoid double db calls
     user_id: str | None = None,
     complete: bool = False,
     pending: bool = False,
@@ -133,8 +135,9 @@ async def get_payments_paginated(  # noqa: C901
     if since is not None:
         clause.append(f"time > {db.timestamp_placeholder('time')}")
 
-    if wallet_id:
-        wallet = await get_wallet(wallet_id)
+    if wallet_id or wallet:
+        if not wallet and wallet_id:
+            wallet = await get_wallet(wallet_id)
         if not wallet or not wallet.can_view_payments:
             return Page(data=[], total=0)
 

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -187,7 +187,7 @@ async def api_payments_paginated(
     filters: Filters = Depends(parse_filters(PaymentFilters)),
 ) -> Page[Payment]:
     page = await get_payments_paginated(
-        wallet_id=key_info.wallet.id,
+        wallet=key_info.wallet,
         filters=filters,
     )
     if not recheck_pending:


### PR DESCRIPTION
### Summary
The get paginated payments for wallet API is one of the most called ones.

This PR reduces one call to get the wallet.