### PR TITLE
fix: `/error` should not be a generic route

### DIFF
--- a/lnbits/core/views/generic.py
+++ b/lnbits/core/views/generic.py
@@ -221,7 +221,6 @@ async def index(
 
 
 @generic_router.get("/")
-@generic_router.get("/error")
 @generic_router.get("/node/public")
 @generic_router.get("/first_install", dependencies=[Depends(check_first_install)])
 async def index_public(request: Request) -> HTMLResponse:


### PR DESCRIPTION
i think i mistakenly added it to generic.

if added it renders a weird errorpage without error, by removing it from here, it will render the proper `error.html` for page not found.

`/error` is just a dynamic vue route and hard reloading on that `path` should lead to a 404