### PR TITLE
fix: add spacing to the logo

### DIFF
--- a/lnbits/templates/components/lnbits-header.vue
+++ b/lnbits/templates/components/lnbits-header.vue
@@ -22,7 +22,7 @@
         @click="g.visibleDrawer = !g.visibleDrawer"
       ></q-btn>
       <q-toolbar-title>
-        <q-btn flat no-caps dense size="lg" type="a" href="/">
+        <q-btn flat no-caps dense class="q-mr-sm" size="lg" type="a" href="/">
           <q-img
             v-if="customLogoUrl"
             height="30px"


### PR DESCRIPTION
before
![screenshot-1765349608](https://github.com/user-attachments/assets/17043ffe-e72e-45cd-aef7-f9777bf759d1)
![screenshot-1765349826](https://github.com/user-attachments/assets/0000cc0f-38cf-4a13-b737-2b58f3aaf5b3)


after

![screenshot-1765349602](https://github.com/user-attachments/assets/f7aec22a-bcac-4f60-9280-ecd95cf83a55)
