### PR TITLE
fix: account dropdown

### DIFF
--- a/lnbits/templates/components/lnbits-header.vue
+++ b/lnbits/templates/components/lnbits-header.vue
@@ -84,12 +84,15 @@
           <q-avatar v-else icon="account_circle" size="18px"></q-avatar>
         </template>
         <q-list style="max-width: 200px">
-          <q-item
-            v-if="
-              g.user && g.user?.extra?.picture && g.user?.extra?.picture !== ''
-            "
-          >
-            <q-item-section avatar v-if="g.user?.extra?.picture !== ''">
+          <q-item>
+            <q-item-section
+              avatar
+              v-if="
+                g.user &&
+                g.user?.extra?.picture &&
+                g.user?.extra?.picture !== ''
+              "
+            >
               <q-avatar size="md">
                 <img :src="g.user?.extra?.picture" />
               </q-avatar>


### PR DESCRIPTION
- if no image is set for avatar fallback to icon, and drop it inside menu
- remove user role inside menu
- hide the account dropdown in public pages