### PR TITLE
fix: CI getting release upload url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref_name }}
         run: |
-          upload_url=$(gh release create "$tag" --generate-notes --draft --json upload_url -q '.upload_url')
+          gh release create "$tag" --generate-notes --draft
+          upload_url=$(gh release view $tag --repo lnbits/lnbits --json uploadUrl -q ".uploadUrl")
           echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
 
   docker:


### PR DESCRIPTION
release create does not have --json

```sh
dni@arch:~ $ gh release view v1.3.1 --repo lnbits/lnbits --json uploadUrl -q '.uploadUrl'
https://uploads.github.com/repos/lnbits/lnbits/releases/255294284/assets{?name,label}
```