### PR TITLE
fix(lndrest): use boolean for allow_self_payment instead of integer

### DIFF
--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -178,7 +178,7 @@ class LndRestWallet(Wallet):
             "no_inflight_updates": True,
         }
         if settings.lnd_rest_allow_self_payment:
-            req["allow_self_payment"] = 1
+            req["allow_self_payment"] = True
 
         try:
             r = await self.client.post(


### PR DESCRIPTION
## Description

### Problem
When `lnd_rest_allow_self_payment` is enabled in LNbits settings, all outgoing payments via LndRestWallet fail with a 400 Bad Request error from LND.

The error from LND:
```json
{"code":3, "message":"proto: (line 1:395): invalid value for bool type: 1", "details":[]}
```

### Root Cause
In `lnbits/wallets/lndrest.py` line 181, the `allow_self_payment` field is set to integer `1` instead of boolean `True`:

```python
if settings.lnd_rest_allow_self_payment:
    req["allow_self_payment"] = 1  # Bug: sends integer 1
```

LND's `/v2/router/send` endpoint expects `allow_self_payment` to be a JSON boolean (`true`/`false`), not an integer. When the JSON is serialized, `1` remains as `1`, but LND's protobuf parser requires a boolean value.

### Fix
Change the value from `1` to `True`:

```python
if settings.lnd_rest_allow_self_payment:
    req["allow_self_payment"] = True  # Correct: sends boolean true
```

### Testing
Tested with:
- LND v0.19.3-beta
- LNbits v1.4.0

Before fix:
```
LndRestWallet pay_invoice POST error: Client error '400 Bad Request' for url 'https://<lnd-server-ip>:8080/v2/router/send'
```

After fix:
```
payment successful
<payment_hash>
```

### Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tested in production
- [x] No new dependencies required

---

## Files Changed

### lnbits/wallets/lndrest.py

```diff
@@ -178,7 +178,7 @@ class LndRestWallet(Wallet):
             "no_inflight_updates": True,
         }
         if settings.lnd_rest_allow_self_payment:
-            req["allow_self_payment"] = 1
+            req["allow_self_payment"] = True

         try:
             r = await self.client.post(

