### PR TITLE
fix: `/user/{user_id}/wallet` should return deleted wallet

### DIFF
--- a/lnbits/core/views/user_api.py
+++ b/lnbits/core/views/user_api.py
@@ -222,7 +222,7 @@ async def api_users_toggle_admin(user_id: str) -> SimpleStatus:
 
 @users_router.get("/user/{user_id}/wallet", name="Get wallets for user")
 async def api_users_get_user_wallet(user_id: str) -> list[Wallet]:
-    return await get_wallets(user_id, deleted=True)
+    return await get_wallets(user_id, deleted=None)
 
 
 @users_router.post("/user/{user_id}/wallet", name="Create a new wallet for user")


### PR DESCRIPTION
this was some kind of regression. ui will handle deleted wallets like in the screenshot below. by providing `None` you get all deleted and not deleted.
![screenshot-1767888964](https://github.com/user-attachments/assets/8b441c6f-5d93-48a9-871c-d6effcaaa8e5)
