### PR TITLE
fix: use canonical values in rate limit unit select

### DIFF
--- a/lnbits/templates/components/admin/security.vue
+++ b/lnbits/templates/components/admin/security.vue
@@ -311,9 +311,9 @@
               <q-select
                 filled
                 :options="[
-                  { label: $t('second'), value: 'second' },
-                  { label: $t('minute'), value: 'minute' },
-                  { label: $t('hour'), value: 'hour' }
+                  {label: $t('second'), value: 'second'},
+                  {label: $t('minute'), value: 'minute'},
+                  {label: $t('hour'), value: 'hour'}
                 ]"
                 emit-value
                 map-options


### PR DESCRIPTION
**Bug description:**
Using a non-english display language, such as Pirate, where `minute`, `second` and `hour` i18n variables differ from the variable names, and then changing and saving the `lnbits_rate_limit_unit` will cause a HTTP 500 error on all subsequent HTTP requests.
Here is an example of what appears in the log:
```2026-01-30 21:10:43.71 | INFO | 192.168.0.2:44882 - "PUT /admin/api/v1/settings HTTP/1.1" 200
  + Exception Group Traceback (most recent call last):
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 77, in collapse_excgroups
  |     yield
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 183, in __call__
  |     async with anyio.create_task_group() as task_group:
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 783, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__
    |     with recv_stream, send_stream, collapse_excgroups():
    |   File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    |     self.gen.throw(value)
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    |     raise exc
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 130, in dispatch
    |     error_response, should_inject_headers = sync_check_limits(
    |                                             ^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 77, in sync_check_limits
    |     return exception_handler(request, exc), _bool  # type: ignore
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/extension.py", line 81, in _rate_limit_exceeded_handler
    |     {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
    |                                       ^^^^^^^^^^
    | AttributeError: 'ValueError' object has no attribute 'detail'
    +------------------------------------
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    raise exc
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 130, in dispatch
    error_response, should_inject_headers = sync_check_limits(
                                            ^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 77, in sync_check_limits
    return exception_handler(request, exc), _bool  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/extension.py", line 81, in _rate_limit_exceeded_handler
    {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
                                      ^^^^^^^^^^
AttributeError: 'ValueError' object has no attribute 'detail'
2026-01-30 21:10:46.52 | ERROR | Exception ID: WStw9ZvNLPmMg3wL5UX7TY
'ValueError' object has no attribute 'detail'
2026-01-30 21:10:46.52 | INFO | 192.168.0.2:44882 - "GET /node/api/v1/info HTTP/1.1" 500
2026-01-30 21:10:46.52 | ERROR | Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 77, in collapse_excgroups
  |     yield
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 183, in __call__
  |     async with anyio.create_task_group() as task_group:
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 783, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__
    |     with recv_stream, send_stream, collapse_excgroups():
    |   File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    |     self.gen.throw(value)
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    |     raise exc
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 130, in dispatch
    |     error_response, should_inject_headers = sync_check_limits(
    |                                             ^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 77, in sync_check_limits
    |     return exception_handler(request, exc), _bool  # type: ignore
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/extension.py", line 81, in _rate_limit_exceeded_handler
    |     {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
    |                                       ^^^^^^^^^^
    | AttributeError: 'ValueError' object has no attribute 'detail'
    +------------------------------------
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    raise exc
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 130, in dispatch
    error_response, should_inject_headers = sync_check_limits(
                                            ^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 77, in sync_check_limits
    return exception_handler(request, exc), _bool  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/extension.py", line 81, in _rate_limit_exceeded_handler
    {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
                                      ^^^^^^^^^^
AttributeError: 'ValueError' object has no attribute 'detail'
2026-01-30 21:10:46.52 | ERROR | Exception ID: g6uvXQMDdFAAK9gPRDnGUY
'ValueError' object has no attribute 'detail'
2026-01-30 21:10:46.52 | INFO | 192.168.0.2:41858 - "GET /node/api/v1/rank HTTP/1.1" 500
2026-01-30 21:10:46.52 | ERROR | Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 77, in collapse_excgroups
  |     yield
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 183, in __call__
  |     async with anyio.create_task_group() as task_group:
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 783, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__
    |     with recv_stream, send_stream, collapse_excgroups():
    |   File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    |     self.gen.throw(value)
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    |     raise exc
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 130, in dispatch
    |     error_response, should_inject_headers = sync_check_limits(
    |                                             ^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 77, in sync_check_limits
    |     return exception_handler(request, exc), _bool  # type: ignore
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/extension.py", line 81, in _rate_limit_exceeded_handler
    |     {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
    |                                       ^^^^^^^^^^
    | AttributeError: 'ValueError' object has no attribute 'detail'
    +------------------------------------
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    raise exc
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 130, in dispatch
    error_response, should_inject_headers = sync_check_limits(
                                            ^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 77, in sync_check_limits
    return exception_handler(request, exc), _bool  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/extension.py", line 81, in _rate_limit_exceeded_handler
    {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
                                      ^^^^^^^^^^
AttributeError: 'ValueError' object has no attribute 'detail'
2026-01-30 21:10:47.64 | ERROR | Exception ID: MyXyLEAwVbbwZc8hS26MTm
'ValueError' object has no attribute 'detail'
2026-01-30 21:10:47.64 | INFO | 192.168.0.2:41872 - "GET /admin/api/v1/settings HTTP/1.1" 500
2026-01-30 21:10:47.64 | ERROR | Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 77, in collapse_excgroups
  |     yield
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 183, in __call__
  |     async with anyio.create_task_group() as task_group:
  |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 783, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__
    |     with recv_stream, send_stream, collapse_excgroups():
    |   File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    |     self.gen.throw(value)
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    |     raise exc
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__
    |     response = await self.dispatch_func(request, call_next)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 130, in dispatch
    |     error_response, should_inject_headers = sync_check_limits(
    |                                             ^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 77, in sync_check_limits
    |     return exception_handler(request, exc), _bool  # type: ignore
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/extension.py", line 81, in _rate_limit_exceeded_handler
    |     {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
    |                                       ^^^^^^^^^^
    | AttributeError: 'ValueError' object has no attribute 'detail'
    +------------------------------------
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 182, in __call__
    with recv_stream, send_stream, collapse_excgroups():
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 83, in collapse_excgroups
    raise exc
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/starlette/middleware/base.py", line 184, in __call__
    response = await self.dispatch_func(request, call_next)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 130, in dispatch
    error_response, should_inject_headers = sync_check_limits(
                                            ^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/middleware.py", line 77, in sync_check_limits
    return exception_handler(request, exc), _bool  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/lnbits/.venv/lib/python3.12/site-packages/slowapi/extension.py", line 81, in _rate_limit_exceeded_handler
    {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
                                      ^^^^^^^^^^
AttributeError: 'ValueError' object has no attribute 'detail'
```
**Fix:**
This PR adds labels (display) to the dropdown, mapped to their coresponding english/canonical values.