### PR TITLE
fix: use absolute paths for dynamic extension routes

### DIFF
--- a/lnbits/static/js/init-app.js
+++ b/lnbits/static/js/init-app.js
@@ -26,8 +26,14 @@ const DynamicComponent = {
             path: r.path,
             name: r.name,
             component: async () => {
-              await LNbits.utils.loadTemplate(r.template)
-              await LNbits.utils.loadScript(r.component)
+              const templatePath = r.template.startsWith('/')
+                ? r.template
+                : `/${name}/${r.template}`
+              const componentPath = r.component.startsWith('/')
+                ? r.component
+                : `/${name}/${r.component}`
+              await LNbits.utils.loadTemplate(templatePath)
+              await LNbits.utils.loadScript(componentPath)
               return window[r.name]
             }
           })


### PR DESCRIPTION
Fixes a regression where dynamic extension routes (e.g., LNURL-pay links) fail to load assets when accessed via deep links. Prepending the extension ID ensures that template and component paths are absolute and resolve correctly regardless of the URL nesting or proxy configuration.