### PR TITLE
fix: `/first_install` new superuser may duplicate an username

### DIFF
--- a/lnbits/core/views/auth_api.py
+++ b/lnbits/core/views/auth_api.py
@@ -511,15 +511,21 @@ async def update_ui_customization(
 async def first_install(data: UpdateSuperuserPassword) -> JSONResponse:
     if not settings.first_install:
         raise HTTPException(HTTPStatus.FORBIDDEN, "This is not your first install")
+
     if settings.first_install_token:
         if not data.first_install_token:
             raise HTTPException(HTTPStatus.UNAUTHORIZED, "Missing first_install_token.")
         if settings.first_install_token != data.first_install_token:
             raise HTTPException(HTTPStatus.UNAUTHORIZED, "Invalid first_install_token.")
 
+    account = await get_account_by_username(data.username, False)
+    if account:
+        raise HTTPException(HTTPStatus.BAD_REQUEST, "Username already exists.")
+
     account = await get_account(settings.super_user)
     if not account:
         raise HTTPException(HTTPStatus.INTERNAL_SERVER_ERROR, "Superuser not found.")
+
     account.username = data.username
     account.extra = account.extra or UserExtra()
     account.extra.provider = "lnbits"


### PR DESCRIPTION
this checks if an existing account already has the username for the new superuser. this can happen by resetting lnbits.