### PR TITLE
fix: skip funding source status check for internal payments

### DIFF
--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -178,14 +178,15 @@ async def invoice_callback_dispatcher(checking_id: str, is_internal: bool = Fals
         logger.warning(f"Payment '{checking_id}' is not incoming, skipping.")
         return
 
-    from lnbits.core.services.payments import check_payment_status
+    if not is_internal:
+        from lnbits.core.services.payments import check_payment_status
 
-    status = await check_payment_status(
-        payment, skip_internal_payment_notifications=True
-    )
-    payment.fee = status.fee_msat or payment.fee
-    # only overwrite preimage if status.preimage provides it
-    payment.preimage = status.preimage or payment.preimage
+        status = await check_payment_status(
+            payment, skip_internal_payment_notifications=True
+        )
+        payment.fee = status.fee_msat or payment.fee
+        # only overwrite preimage if status.preimage provides it
+        payment.preimage = status.preimage or payment.preimage
     payment.status = PaymentState.SUCCESS
     await update_payment(payment)
     if payment.fiat_provider:


### PR DESCRIPTION
## Summary

- Fixes internal payments zeroing out receiver wallet balance when using CLNRestWallet
- Uses the existing `is_internal` parameter in `invoice_callback_dispatcher` to skip the funding source status check for internal payments

## Root cause

When an internal payment settles, `invoice_callback_dispatcher` queries the funding source (`get_invoice_status`) for the receiver's invoice. Since the invoice was paid internally and never settled on CLN, `amount_received_msat` is 0 while `amount_msat` equals the invoice amount. The fee calculation:

```python
fee_msat = amount_received_msat - amount_msat  # 0 - 1000000 = -1000000
```

This negative fee overwrites the receiver's payment record. Since balance is computed as `SUM(amount - ABS(fee))`, the fee cancels the amount exactly, resulting in a zero balance.

LND is unaffected because `LndRestWallet.get_invoice_status` returns `PaymentSuccessStatus()` with `fee_msat=None`.

## Fix

The `is_internal` parameter was already passed to `invoice_callback_dispatcher` but never used. This change skips the funding source status check when `is_internal=True`, since the payment has already been verified internally by LNbits.

## Test plan

- [x] Create two wallets on LNbits with CLNRestWallet backend
- [x] Generate invoice from Wallet B, pay from Wallet A
- [x] Verify Wallet B balance reflects the received amount
- [x] Verify external (non-internal) payments still update status correctly

Fixes #3816

🤖 Generated with [Claude Code](https://claude.com/claude-code)