### PR TITLE
fix: default theme change for 1.5.1

### DIFF
--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -299,7 +299,7 @@ class ThemesSettings(LNbitsSettings):
     lnbits_default_dark: bool = Field(default=True)
     lnbits_default_card_rounded: bool = Field(default=True)
     lnbits_default_card_gradient: bool = Field(default=True)
-    lnbits_default_card_shadow: bool = Field(default=True)
+    lnbits_default_card_shadow: bool = Field(default=False)
 
 
 class OpsSettings(LNbitsSettings):


### PR DESCRIPTION
Lick of paint for v1.5.1
<img width="1842" height="957" alt="image" src="https://github.com/user-attachments/assets/ec2f6f1f-4100-4783-b8f6-ff47c68ad9d9" />


