### PR TITLE
fix: Sanitise lightning addresses by casing in lnurlscan

### DIFF
--- a/lnbits/core/views/lnurl_api.py
+++ b/lnbits/core/views/lnurl_api.py
@@ -36,6 +36,8 @@ lnurl_router = APIRouter(tags=["LNURL"])
 
 async def _handle(lnurl: str) -> LnurlResponseModel:
     try:
+        if "@" in lnurl:  # lower case lightning addresses
+            lnurl = lnurl.lower()
         res = await lnurl_handle(lnurl, user_agent=settings.user_agent, timeout=5)
         if isinstance(res, LnurlErrorResponse):
             raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=res.reason)


### PR DESCRIPTION
Lightning addresses are case insensitive. If a lightning address with uppercase characters is given to the lnurlscan endpoint, the LNURL lib returns a "Invalid Lightning address" error. This fix lower cases lightning addresses before calling the lnurl lib.