### PR TITLE
feat: reset settings and superuser via enviroment setting

### DIFF
--- a/lnbits/app.py
+++ b/lnbits/app.py
@@ -24,6 +24,7 @@ from lnbits.core.crud import (
     update_installed_extension_state,
 )
 from lnbits.core.crud.extensions import create_installed_extension
+from lnbits.core.crud.settings import reset_settings_and_superuser
 from lnbits.core.helpers import migrate_extension_database
 from lnbits.core.models.notifications import NotificationType
 from lnbits.core.services.extensions import deactivate_extension, get_valid_extensions
@@ -74,8 +75,13 @@ async def startup(app: FastAPI):
     logger.info(f"Starting LNbits Version: {settings.version}")
     start = time.perf_counter()
     settings.lnbits_running = True
+
     # wait till migration is done
     await migrate_databases()
+
+    if settings.permanently_delete_settings_and_superuser:
+        logger.warning("Permanently deleting all settings and change superuser...")
+        await reset_settings_and_superuser()
 
     # setup admin settings
     await check_admin_settings()

--- a/lnbits/core/crud/settings.py
+++ b/lnbits/core/crud/settings.py
@@ -81,6 +81,14 @@ async def reset_core_settings() -> None:
     )
 
 
+async def reset_settings_and_superuser() -> None:
+    await db.execute(
+        "UPDATE wallets SET deleted = true FROM system_settings WHERE "
+        "system_settings.id = 'super_user' AND wallets.user = system_settings.value;"
+    )
+    await db.execute("DELETE from system_settings;")
+
+
 async def create_admin_settings(super_user: str, new_settings: dict) -> SuperSettings:
     data = {"super_user": super_user, **new_settings}
     for key, value in data.items():

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -990,6 +990,7 @@ class UpdateSettings(EditableSettings):
 
 
 class EnvSettings(LNbitsSettings):
+    permanently_delete_settings_and_superuser: bool = Field(default=False)
     debug: bool = Field(default=False)
     debug_database: bool = Field(default=False)
     bundle_assets: bool = Field(default=True)


### PR DESCRIPTION
usage: `PERMANENTLY_DELETE_SETTINGS_AND_SUPERUSER=true uv run lnbits` run once to cleanup all settings and reset superuser

this is the current action ran in the saas, if you reset and instance.