### PR TITLE
fix: node version for sparkl2 docker

### DIFF
--- a/docker/sparkl2/Dockerfile
+++ b/docker/sparkl2/Dockerfile
@@ -5,7 +5,7 @@ FROM lnbits/lnbits:${LNBITS_TAG}
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
 
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y ca-certificates curl gnupg netcat-openbsd git npm nodejs
+RUN apt-get install -y ca-certificates curl gnupg netcat-openbsd git nodejs
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"


### PR DESCRIPTION
spark failed to connect on node version 18