### PR TITLE
ci: only run ci on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: LNbits CI
 on:
-  push:
-    branches:
-      - main
-      - dev
   pull_request:
 
 


### PR DESCRIPTION
as its required for every contribution, else it will always run again after a merge to dev or main.