### PR TITLE
fix: prevent incoming payments from having fees set

### DIFF
--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -1091,7 +1091,13 @@ async def update_invoice_callback(checking_id: str) -> Payment | None:
     status = await check_payment_status(
         payment, skip_internal_payment_notifications=True
     )
-    payment.fee = status.fee_msat or payment.fee
+    # Incoming payments should never have fees — fees are a sender-side concept.
+    # Without this guard, internal transfers (same instance) get fee_msat from the
+    # funding source equal to the full payment amount, zeroing out the balance.
+    if payment.is_in:
+        payment.fee = 0
+    else:
+        payment.fee = status.fee_msat or payment.fee
     # only overwrite preimage if status.preimage provides it
     payment.preimage = status.preimage or payment.preimage
     payment.status = PaymentState.SUCCESS


### PR DESCRIPTION
## Summary

Incoming payments should never have fees — fees are a sender-side concept. Without this guard, internal transfers between wallets on the same LNbits instance get `fee_msat` from the funding source equal to the full payment amount, effectively zeroing out the received balance.

## Root cause

In `update_invoice_callback()`, `check_payment_status()` is called for incoming payments. For internal transfers, the incoming payment's `checking_id` doesn't have the `internal_` prefix (only the outgoing side does), so `payment.is_internal` is `False`. This causes the code to fall through to `funding_source.get_invoice_status()`, which (at least with CLNRest) returns `fee_msat` equal to the payment amount. This value then gets written to `payment.fee`, zeroing out the balance.

## Fix

Incoming payments (`payment.is_in`) always get `fee = 0`. Only outgoing payments use `status.fee_msat`.

## Evidence

From a production instance (v1.5.3, CLNRestWallet backend):

```
-- Outgoing (sender side) - correct, fee=0
internal_80bea0c7...|wallet_a|-102000|0|success

-- Incoming (receiver side) - BUG: fee=-102000 (equals amount)  
80bea0c7...|wallet_b|102000|-102000|success
```

61 payments were affected across multiple wallets on our instance.

Fixes #3907