### PR TITLE
fix(phoenixd): use descriptionHash when unhashed_description is provided

### DIFF
--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -117,11 +117,12 @@ class PhoenixdWallet(Wallet):
             # PhoenixD description limited to 128 characters
             if description_hash:
                 data["descriptionHash"] = description_hash.hex()
+            elif unhashed_description:
+                data["descriptionHash"] = hashlib.sha256(
+                    unhashed_description
+                ).hexdigest()
             else:
-                desc = memo
-                if desc is None and unhashed_description:
-                    desc = unhashed_description.decode()
-                desc = desc or ""
+                desc = memo or ""
                 if len(desc) > 128:
                     data["descriptionHash"] = hashlib.sha256(desc.encode()).hexdigest()
                 else:


### PR DESCRIPTION
## Summary
- When LNURL-pay generates an invoice via `PhoenixdWallet`, it passes `unhashed_description` (the raw metadata JSON) to `create_invoice`
- The previous code only used `descriptionHash` when the description exceeded 128 characters, otherwise falling back to a plain `description` field
- This produced invoices with a `d` tag instead of the required `h` tag, violating the LNURL-pay spec ([LUD-06](https://github.com/lnurl/luds/blob/luds/06.md)) which mandates that the invoice description hash must match the SHA256 of the metadata
- Wallets correctly reject these non-compliant invoices

## Fix
Prioritize `unhashed_description` over `memo` — when `unhashed_description` is provided (as LNURL-pay always does), always SHA256-hash it and use the `descriptionHash` field in the phoenixd API call.

## Test plan
- [ ] Create a Lightning Address via LNURLp extension with PhoenixdWallet backend
- [ ] Resolve the Lightning Address and generate an invoice via the LNURL callback
- [ ] Verify the invoice uses `description_hash` (h tag), not `description` (d tag)
- [ ] Verify the hash matches SHA256 of the LNURL metadata
- [ ] Confirm payment succeeds from strict wallets

🤖 Generated with [Claude Code](https://claude.com/claude-code)