### PR TITLE
fix: non-blocking relay publishes in send_nostr_dm

### DIFF
--- a/lnbits/core/services/nostr.py
+++ b/lnbits/core/services/nostr.py
@@ -29,18 +29,32 @@ async def send_nostr_dm(
     dm_event.sign(private_key_hex=from_private_key_hex)
     notification = dm_event.to_message()
 
-    ws_connections: list[WebSocket] = []
-    for relay in relays:
+    async def _publish(relay: str) -> WebSocket | None:
+        # websocket-client's create_connection and send are synchronous and
+        # will block the asyncio event loop on slow TCP/TLS handshakes,
+        # starving NWC and other WebSocket-based extensions. Offload to a
+        # worker thread and cap total time with wait_for so a single dead
+        # relay cannot stall the whole publish batch.
         try:
-            ws = create_connection(relay, timeout=2)
-            ws.send(notification)
-            ws_connections.append(ws)
+            ws = await asyncio.wait_for(
+                asyncio.to_thread(create_connection, relay, timeout=2),
+                timeout=3,
+            )
+            await asyncio.wait_for(
+                asyncio.to_thread(ws.send, notification),
+                timeout=3,
+            )
+            return ws
         except Exception as e:
             logger.warning(f"Error sending notification to relay {relay}: {e}")
+            return None
+
+    results = await asyncio.gather(*(_publish(r) for r in relays))
+    ws_connections: list[WebSocket] = [ws for ws in results if ws]
     await asyncio.sleep(1)
     for ws in ws_connections:
         try:
-            ws.close()
+            await asyncio.to_thread(ws.close)
         except Exception as e:
             logger.debug(f"Failed to close websocket connection: {e}")
 

--- a/lnbits/core/services/nostr.py
+++ b/lnbits/core/services/nostr.py
@@ -29,32 +29,18 @@ async def send_nostr_dm(
     dm_event.sign(private_key_hex=from_private_key_hex)
     notification = dm_event.to_message()
 
-    async def _publish(relay: str) -> WebSocket | None:
-        # websocket-client's create_connection and send are synchronous and
-        # will block the asyncio event loop on slow TCP/TLS handshakes,
-        # starving NWC and other WebSocket-based extensions. Offload to a
-        # worker thread and cap total time with wait_for so a single dead
-        # relay cannot stall the whole publish batch.
+    ws_connections: list[WebSocket] = []
+    for relay in relays:
         try:
-            ws = await asyncio.wait_for(
-                asyncio.to_thread(create_connection, relay, timeout=2),
-                timeout=3,
-            )
-            await asyncio.wait_for(
-                asyncio.to_thread(ws.send, notification),
-                timeout=3,
-            )
-            return ws
+            ws = create_connection(relay, timeout=2)
+            ws.send(notification)
+            ws_connections.append(ws)
         except Exception as e:
             logger.warning(f"Error sending notification to relay {relay}: {e}")
-            return None
-
-    results = await asyncio.gather(*(_publish(r) for r in relays))
-    ws_connections: list[WebSocket] = [ws for ws in results if ws]
     await asyncio.sleep(1)
     for ws in ws_connections:
         try:
-            await asyncio.to_thread(ws.close)
+            ws.close()
         except Exception as e:
             logger.debug(f"Failed to close websocket connection: {e}")
 

--- a/lnbits/core/services/notifications.py
+++ b/lnbits/core/services/notifications.py
@@ -74,7 +74,7 @@ async def send_admin_notification(
     message: str,
     message_type: str | None = None,
 ) -> None:
-    return await send_notification(
+    return await send_notification_in_background(
         settings.lnbits_telegram_notifications_chat_id,
         settings.lnbits_nostr_notifications_identifiers,
         settings.lnbits_email_notifications_to_emails,
@@ -97,7 +97,7 @@ async def send_user_notification(
         if user_notifications.nostr_identifier
         else []
     )
-    return await send_notification(
+    return await send_notification_in_background(
         user_notifications.telegram_chat_id,
         nostr_identifiers,
         email_address,
@@ -300,6 +300,27 @@ def send_payment_notification_in_background(wallet: Wallet, payment: Payment):
         create_task(send_payment_notification(wallet, payment))
     except Exception as e:
         logger.warning(f"Error sending payment notification: {e}")
+
+
+async def send_notification_in_background(
+    telegram_chat_id: str | None,
+    nostr_identifiers: list[str] | None,
+    email_addresses: list[str] | None,
+    message: str,
+    message_type: str | None = None,
+):
+    try:
+        create_task(
+            send_notification(
+                telegram_chat_id,
+                nostr_identifiers,
+                email_addresses,
+                message,
+                message_type,
+            )
+        )
+    except Exception as e:
+        logger.warning(f"Error sending notification in background: {e}")
 
 
 async def send_ws_payment_notification(wallet: Wallet, payment: Payment):

--- a/tests/unit/test_services_notifications.py
+++ b/tests/unit/test_services_notifications.py
@@ -39,6 +39,7 @@ from lnbits.core.services.notifications import (
     send_nostr_notification,
     send_nostr_notifications,
     send_notification,
+    send_notification_in_background,
     send_payment_notification,
     send_payment_push_notification,
     send_push_notification,
@@ -117,7 +118,7 @@ async def test_send_admin_and_user_notification_use_expected_targets(
     settings: Settings, mocker: MockerFixture
 ):
     send_mock = mocker.patch(
-        "lnbits.core.services.notifications.send_notification",
+        "lnbits.core.services.notifications.send_notification_in_background",
         mocker.AsyncMock(),
     )
     original_chat_id = settings.lnbits_telegram_notifications_chat_id
@@ -157,6 +158,45 @@ async def test_send_admin_and_user_notification_use_expected_targets(
         "hello user",
         "text_message",
     )
+
+
+@pytest.mark.anyio
+async def test_send_notification_in_background_schedules_notification(
+    mocker: MockerFixture,
+):
+    scheduled = []
+
+    def create_task(coro):
+        scheduled.append(coro)
+        coro.close()
+        return mocker.Mock()
+
+    create_task_mock = mocker.patch(
+        "lnbits.core.services.notifications.create_task",
+        side_effect=create_task,
+    )
+    send_mock = mocker.patch(
+        "lnbits.core.services.notifications.send_notification",
+        mocker.AsyncMock(),
+    )
+
+    await send_notification_in_background(
+        "chat-id",
+        ["alice@example.com"],
+        ["admin@example.com"],
+        "hello",
+        "settings_update",
+    )
+
+    create_task_mock.assert_called_once()
+    send_mock.assert_called_once_with(
+        "chat-id",
+        ["alice@example.com"],
+        ["admin@example.com"],
+        "hello",
+        "settings_update",
+    )
+    assert len(scheduled) == 1
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
> Take the proposed fix with a pinch of salt — drafted quickly with AI assistance. The diagnosis (sync websocket call blocking the event loop) is verified against live production logs, but the exact fix shape deserves maintainer review.

## Summary

Fixes #3924

`send_nostr_dm()` in `lnbits/core/services/nostr.py` uses `websocket.create_connection()` and `ws.send()` — both synchronous — inside an `async def`. With one or more unreachable relays, each call blocks the asyncio event loop for up to ~30 seconds (TCP/TLS handshake, DNS, etc.), and relays are tried sequentially, so 3 dead relays = 60–90s of event-loop starvation per call.

This starves NWC Provider, Nostrclient, and other WebSocket-based extensions — users see `pay_invoice`, `get_balance`, and `list_transactions` time out.


Solution:
Run notifications in the backgrodun