### PR TITLE
fix: make payments tags chart display dependant on showPaymentTags

### DIFF
--- a/lnbits/templates/pages/payments.vue
+++ b/lnbits/templates/pages/payments.vue
@@ -136,7 +136,7 @@
         </q-card>
       </div>
       <div
-        v-show="chartData.showPaymentStatus"
+        v-show="chartData.showPaymentTags"
         class="col-lg-3 col-md-6 col-sm-12 text-center"
       >
         <q-card class="q-pt-sm">


### PR DESCRIPTION
**Bug description:**
On the Payments page the display condition of the Tag Chart is dependant on the Status Chart display condition.

**Fix:**
This PR changes the display condition of the Tag Chart from `showPaymentStatus` to `showPaymentTags`