### PR TITLE
feat: Add fork migrations namespace

### DIFF
--- a/lnbits/core/helpers.py
+++ b/lnbits/core/helpers.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from loguru import logger
 
 from lnbits.core import migrations as core_migrations
+from lnbits.core import migrations_fork as core_migrations_fork
 from lnbits.core.crud import (
     get_db_versions,
     get_installed_extensions,
@@ -99,6 +100,15 @@ async def migrate_databases():
             DbVersion(db="core", version=0),
         )
         await run_migration(conn, core_migrations, "core", core_version)
+
+        # Run fork-specific migrations under a separate dbversions key so
+        # downstream forks can add their own schema changes without
+        # conflicting with upstream's `core` migration numbering.
+        core_fork_version = next(
+            (v for v in current_versions if v.db == "core_fork"),
+            DbVersion(db="core_fork", version=0),
+        )
+        await run_migration(conn, core_migrations_fork, "core_fork", core_fork_version)
 
     # here is the first place we can be sure that the
     # `installed_extensions` table has been created

--- a/lnbits/core/migrations_fork.py
+++ b/lnbits/core/migrations_fork.py
@@ -13,4 +13,20 @@ Conventions:
     `OperationalError` so re-runs on partially-migrated databases don't fail.
 
 This file is intentionally empty in upstream. Forks fill it in.
+
+Example (uncomment and adapt in your fork):
+
+    from sqlalchemy.exc import OperationalError
+
+    from lnbits.db import Connection
+
+
+    async def m001_add_custom_column_to_accounts(db: Connection):
+        '''
+        Adds a fork-specific column to the accounts table.
+        '''
+        try:
+            await db.execute("ALTER TABLE accounts ADD COLUMN my_column TEXT")
+        except OperationalError:
+            pass
 """

--- a/lnbits/core/migrations_fork.py
+++ b/lnbits/core/migrations_fork.py
@@ -1,0 +1,16 @@
+"""
+Fork-specific database migrations.
+
+Forks of LNbits that need to add their own schema changes (extra columns,
+tables, indexes, etc.) can add migrations to this file. They are tracked
+separately under the 'core_fork' key in the dbversions table, so they do not
+collide with upstream's `core` migrations when pulling from upstream.
+
+Conventions:
+  - Use sequential numbering starting from m001.
+  - Each migration is `async def m{NNN}_<description>(db: Connection)`.
+  - Wrap idempotent DDL (e.g. ALTER TABLE ADD COLUMN) in a try/except for
+    `OperationalError` so re-runs on partially-migrated databases don't fail.
+
+This file is intentionally empty in upstream. Forks fill it in.
+"""

--- a/lnbits/core/migrations_fork.py
+++ b/lnbits/core/migrations_fork.py
@@ -13,20 +13,18 @@ Conventions:
     `OperationalError` so re-runs on partially-migrated databases don't fail.
 
 This file is intentionally empty in upstream. Forks fill it in.
-
-Example (uncomment and adapt in your fork):
-
-    from sqlalchemy.exc import OperationalError
-
-    from lnbits.db import Connection
-
-
-    async def m001_add_custom_column_to_accounts(db: Connection):
-        '''
-        Adds a fork-specific column to the accounts table.
-        '''
-        try:
-            await db.execute("ALTER TABLE accounts ADD COLUMN my_column TEXT")
-        except OperationalError:
-            pass
 """
+
+# Example (uncomment and adapt in your fork):
+#
+# from sqlalchemy.exc import OperationalError
+#
+# from lnbits.db import Connection
+#
+#
+# async def m001_add_custom_column_to_accounts(db: Connection):
+#     """Adds a fork-specific column to the accounts table."""
+#     try:
+#         await db.execute("ALTER TABLE accounts ADD COLUMN my_column TEXT")
+#     except OperationalError:
+#         pass


### PR DESCRIPTION
## Summary

- Adds an empty lnbits/core/migrations_fork.py and wires it into migrate_databases() under a separate core_fork key in the dbversions table.
- Lets downstream forks add custom schema changes (m001_*, m002_*, …) without conflicting with upstream's core migration numbering on every git pull upstream.
- Upstream behavior unchanged: the file is empty, so the new run_migration call is a no-op.

## Motivation

Forks that need extra columns/tables today have to patch lnbits/core/migrations.py directly, which produces conflicts on every upstream sync. This gives forks a stable, conflict-free migrations :hugs: 
