### PR TITLE
Fix: “Show all” table pagination

### DIFF
--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -560,7 +560,9 @@ class Filters(BaseModel, Generic[TFilterModel]):
 
     def pagination(self) -> str:
         stmt = ""
-        self.limit = self.limit or 10
+        if self.limit == 0:
+            return stmt
+        self.limit = 10 if self.limit is None else self.limit
         stmt += f"LIMIT {min(1000, self.limit)} "
         if self.offset:
             stmt += f"OFFSET {self.offset}"

--- a/lnbits/db.py
+++ b/lnbits/db.py
@@ -35,7 +35,7 @@ if settings.lnbits_database_url:
     else:
         if not database_uri.startswith("postgres://"):
             raise ValueError(
-                "Please use the 'postgres://...' " "format for the database URL."
+                "Please use the 'postgres://...' format for the database URL."
             )
         DB_TYPE = POSTGRES
 
@@ -561,7 +561,7 @@ class Filters(BaseModel, Generic[TFilterModel]):
     def pagination(self) -> str:
         stmt = ""
         if self.limit == 0:
-            return stmt
+            self.limit = 1000
         self.limit = 10 if self.limit is None else self.limit
         stmt += f"LIMIT {min(1000, self.limit)} "
         if self.offset:

--- a/tests/unit/test_db_fetch_page.py
+++ b/tests/unit/test_db_fetch_page.py
@@ -1,5 +1,6 @@
 import pytest
 
+from lnbits.db import Filters
 from tests.helpers import DbTestModel
 
 
@@ -29,6 +30,19 @@ async def fetch_page(db):
 async def test_db_fetch_page_simple(fetch_page, db):
     row = await db.fetch_page(
         query="select * from test_db_fetch_page",
+        model=DbTestModel,
+    )
+
+    assert row
+    assert row.total == 5
+    assert len(row.data) == 5
+
+
+@pytest.mark.anyio
+async def test_db_fetch_page_limit_zero_returns_all(fetch_page, db):
+    row = await db.fetch_page(
+        query="select * from test_db_fetch_page",
+        filters=Filters(limit=0),
         model=DbTestModel,
     )
 

--- a/tests/unit/test_db_fetch_page.py
+++ b/tests/unit/test_db_fetch_page.py
@@ -3,6 +3,30 @@ import pytest
 from lnbits.db import Filters
 from tests.helpers import DbTestModel
 
+TEST_DB_FETCH_PAGE_ROWS: tuple[dict[str, str], ...] = (
+    {"id": "1", "name": "Alice", "value": "foo"},
+    {"id": "2", "name": "Bob", "value": "bar"},
+    {"id": "3", "name": "Carol", "value": "bar"},
+    {"id": "4", "name": "Dave", "value": "bar"},
+    {"id": "5", "name": "Dave", "value": "foo"},
+    {"id": "6", "name": "Eve", "value": "foo"},
+    {"id": "7", "name": "Frank", "value": "bar"},
+    {"id": "8", "name": "Grace", "value": "foo"},
+    {"id": "9", "name": "Heidi", "value": "bar"},
+    {"id": "10", "name": "Ivan", "value": "foo"},
+    {"id": "11", "name": "Judy", "value": "bar"},
+    {"id": "12", "name": "Mallory", "value": "foo"},
+    {"id": "13", "name": "Niaj", "value": "bar"},
+    {"id": "14", "name": "Olivia", "value": "foo"},
+    {"id": "15", "name": "Peggy", "value": "bar"},
+    {"id": "16", "name": "Rupert", "value": "foo"},
+    {"id": "17", "name": "Sybil", "value": "bar"},
+    {"id": "18", "name": "Trent", "value": "foo"},
+    {"id": "19", "name": "Victor", "value": "bar"},
+    {"id": "20", "name": "Walter", "value": "foo"},
+    {"id": "21", "name": "Zoe", "value": "bar"},
+)
+
 
 @pytest.fixture(scope="session")
 async def fetch_page(db):
@@ -14,14 +38,14 @@ async def fetch_page(db):
             name TEXT NOT NULL
         )
         """)
-    await db.execute("""
-        INSERT INTO test_db_fetch_page (id, name, value) VALUES
-            ('1', 'Alice', 'foo'),
-            ('2', 'Bob', 'bar'),
-            ('3', 'Carol', 'bar'),
-            ('4', 'Dave', 'bar'),
-            ('5', 'Dave', 'foo')
-        """)
+    for row in TEST_DB_FETCH_PAGE_ROWS:
+        await db.execute(
+            """
+            INSERT INTO test_db_fetch_page (id, name, value)
+            VALUES (:id, :name, :value)
+            """,
+            row,
+        )
     yield
     await db.execute("DROP TABLE test_db_fetch_page")
 
@@ -34,8 +58,8 @@ async def test_db_fetch_page_simple(fetch_page, db):
     )
 
     assert row
-    assert row.total == 5
-    assert len(row.data) == 5
+    assert row.total == len(TEST_DB_FETCH_PAGE_ROWS)
+    assert len(row.data) == Filters().limit
 
 
 @pytest.mark.anyio
@@ -47,8 +71,8 @@ async def test_db_fetch_page_limit_zero_returns_all(fetch_page, db):
     )
 
     assert row
-    assert row.total == 5
-    assert len(row.data) == 5
+    assert row.total == len(TEST_DB_FETCH_PAGE_ROWS)
+    assert len(row.data) == len(TEST_DB_FETCH_PAGE_ROWS)
 
 
 @pytest.mark.anyio
@@ -59,7 +83,7 @@ async def test_db_fetch_page_group_by(fetch_page, db):
         group_by=["name"],
     )
     assert row
-    assert row.total == 4
+    assert row.total == len({test_row["name"] for test_row in TEST_DB_FETCH_PAGE_ROWS})
 
 
 @pytest.mark.anyio
@@ -70,7 +94,9 @@ async def test_db_fetch_page_group_by_multiple(fetch_page, db):
         group_by=["value", "name"],
     )
     assert row
-    assert row.total == 5
+    assert row.total == len(
+        {(test_row["value"], test_row["name"]) for test_row in TEST_DB_FETCH_PAGE_ROWS}
+    )
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_db_fetch_page.py
+++ b/tests/unit/test_db_fetch_page.py
@@ -76,6 +76,20 @@ async def test_db_fetch_page_limit_zero_returns_all(fetch_page, db):
 
 
 @pytest.mark.anyio
+async def test_db_fetch_page_limit(fetch_page, db):
+    limit = 5
+    row = await db.fetch_page(
+        query="select * from test_db_fetch_page",
+        filters=Filters(limit=limit),
+        model=DbTestModel,
+    )
+
+    assert row
+    assert row.total == len(TEST_DB_FETCH_PAGE_ROWS)
+    assert len(row.data) == limit
+
+
+@pytest.mark.anyio
 async def test_db_fetch_page_group_by(fetch_page, db):
     row = await db.fetch_page(
         query="select max(id) as id, name from test_db_fetch_page",


### PR DESCRIPTION
This fixes table pagination when selecting “Show all” from the records-per-page dropdown.

Quasar sends `rowsPerPage: 0` to mean “all rows”, but LNbits treated `limit=0` as a missing limit and replaced it with the default of 10. As a result, tables like Users and wallet transactions still showed only 10 records.

The fix preserves `limit=0` as “no SQL limit” and keeps the existing default of 10 only when no limit is provided.

Also added a regression test for `limit=0` pagination.

Closes #3945