### PR TITLE
Fix OIDC SSO login crash when provider returns state=null

### DIFF
--- a/lnbits/helpers.py
+++ b/lnbits/helpers.py
@@ -215,7 +215,7 @@ def decrypt_internal_message(m: str | None = None, urlsafe: bool = False) -> str
         m: Message to decrypt
         urlsafe: Whether the message uses URL-safe base64 encoding
     """
-    if not m:
+    if not m or m == "null":
         return None
     return AESCipher(key=settings.auth_secret_key).decrypt(m, urlsafe=urlsafe)
 


### PR DESCRIPTION
## Summary
- Some OIDC providers (e.g. PocketID) return the literal string `"null"` as the OAuth `state` parameter when the original state was `None`/empty
- `decrypt_internal_message()` tries to AES-decrypt the string `"null"`, which fails with an `AssertionError` because the bytes don't start with the expected `Salted__` prefix
- This one-line fix treats `"null"` the same as `None`/empty in `decrypt_internal_message()`

## Reproduction
1. Configure LNbits with a generic OIDC provider (via the Keycloak settings) that returns `state=null` in the callback URL
2. Attempt SSO login
3. Callback hits `/api/v1/auth/keycloak/token?...&state=null` → 400 error with `{"detail":""}`

## Test plan
- [ ] Verify SSO login works with OIDC providers that return `state=null`
- [ ] Verify SSO login still works with providers that return a valid encrypted state
- [ ] Verify SSO login still works when state is omitted entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)