### PR TITLE
Fix: skip internal invoice staus check

### DIFF
--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -1074,7 +1074,9 @@ async def _send_payment_notification_in_background(
     send_payment_notification_in_background(wallet, payment)
 
 
-async def update_invoice_callback(checking_id: str) -> Payment | None:
+async def update_invoice_callback(
+    checking_id: str, internal: bool = False
+) -> Payment | None:
     """
     Takes a checking_id of an incoming payment, from either paid_invoices_stream()
     or internal_invoice_queue. Checks its status, updates and returns it.
@@ -1088,12 +1090,13 @@ async def update_invoice_callback(checking_id: str) -> Payment | None:
         logger.warning(f"Payment '{checking_id}' is not incoming, skipping.")
         return None
 
-    status = await check_payment_status(
-        payment, skip_internal_payment_notifications=True
-    )
-    payment.fee = status.fee_msat or payment.fee
-    # only overwrite preimage if status.preimage provides it
-    payment.preimage = status.preimage or payment.preimage
+    if not internal:
+        status = await check_payment_status(
+            payment, skip_internal_payment_notifications=True
+        )
+        payment.fee = status.fee_msat or payment.fee
+        # only overwrite preimage if status.preimage provides it
+        payment.preimage = status.preimage or payment.preimage
     payment.status = PaymentState.SUCCESS
     await update_payment(payment)
     if payment.fiat_provider:

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -112,7 +112,7 @@ async def internal_invoice_listener() -> None:
     while settings.lnbits_running:
         checking_id = await internal_invoice_queue.get()
         logger.info(f"got an internal payment notification {checking_id}")
-        payment = await update_invoice_callback(checking_id)
+        payment = await update_invoice_callback(checking_id, internal=True)
         if payment:
             logger.success(f"internal invoice {checking_id} settled")
             await invoice_callback_dispatcher(payment)

--- a/tests/unit/test_services_payments.py
+++ b/tests/unit/test_services_payments.py
@@ -370,6 +370,7 @@ async def test_internal_invoice_callback_does_not_zero_receiver_balance(
 
     payment = await get_payment(checking_id)
     wallet = await get_wallet(wallet.id)
+    assert wallet is not None
 
     funding_source.get_invoice_status.assert_not_awaited()
     assert (payment.fee, wallet.balance_msat) == (0, amount_msat)

--- a/tests/unit/test_services_payments.py
+++ b/tests/unit/test_services_payments.py
@@ -369,11 +369,11 @@ async def test_internal_invoice_callback_does_not_zero_receiver_balance(
     await update_invoice_callback(checking_id, internal=True)
 
     payment = await get_payment(checking_id)
-    wallet = await get_wallet(wallet.id)
-    assert wallet is not None
+    _wallet = await get_wallet(wallet.id)
+    assert _wallet is not None
 
     funding_source.get_invoice_status.assert_not_awaited()
-    assert (payment.fee, wallet.balance_msat) == (0, amount_msat)
+    assert (payment.fee, _wallet.balance_msat) == (0, amount_msat)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_services_payments.py
+++ b/tests/unit/test_services_payments.py
@@ -11,6 +11,7 @@ from lnbits.core.crud import (
     create_wallet,
     get_payment,
     get_payments,
+    get_wallet,
     update_payment,
 )
 from lnbits.core.models import (
@@ -31,6 +32,7 @@ from lnbits.core.services.payments import (
     create_payment_request,
     get_payments_daily_stats,
     settle_hold_invoice,
+    update_invoice_callback,
     update_pending_payment,
     update_pending_payments,
     update_wallet_balance,
@@ -42,6 +44,7 @@ from lnbits.wallets.base import (
     InvoiceResponse,
     PaymentFailedStatus,
     PaymentPendingStatus,
+    PaymentStatus,
     PaymentSuccessStatus,
 )
 
@@ -339,6 +342,37 @@ async def test_check_transaction_status_and_payment_status(mocker: MockerFixture
 
     assert (await check_payment_status(outgoing)).success is True
     assert (await check_payment_status(incoming)).pending is True
+
+
+@pytest.mark.anyio
+async def test_internal_invoice_callback_does_not_zero_receiver_balance(
+    mocker: MockerFixture,
+):
+    wallet = await _create_wallet()
+    amount_msat = 123_000
+    checking_id = await _create_payment(
+        wallet,
+        amount_msat=amount_msat,
+        status=PaymentState.SUCCESS,
+        fee=0,
+    )
+    funding_source = SimpleNamespace(
+        get_invoice_status=mocker.AsyncMock(
+            return_value=PaymentStatus(paid=True, fee_msat=-amount_msat)
+        )
+    )
+    mocker.patch(
+        "lnbits.core.services.payments.get_funding_source",
+        return_value=funding_source,
+    )
+
+    await update_invoice_callback(checking_id, internal=True)
+
+    payment = await get_payment(checking_id)
+    wallet = await get_wallet(wallet.id)
+
+    funding_source.get_invoice_status.assert_not_awaited()
+    assert (payment.fee, wallet.balance_msat) == (0, amount_msat)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Internal invoices are already marked `SUCCESS`, no need to check for status in funding source (apparently when using CLNRest it send a negative value) that would effectively make the receiver balance as 0!

Closes #3816
Closes #3869
Closes #3907