### PR TITLE
fix: use iterative loop instead of recursion in catch_everything_and_restart

### DIFF
--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -61,7 +61,7 @@ def cancel_all_tasks() -> None:
 async def catch_everything_and_restart(
     func: Callable[[], Coroutine],
     name: str = "unnamed",
-) -> Coroutine:
+) -> None:
     while settings.lnbits_running:
         try:
             return await func()

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -62,16 +62,16 @@ async def catch_everything_and_restart(
     func: Callable[[], Coroutine],
     name: str = "unnamed",
 ) -> Coroutine:
-    try:
-        return await func()
-    except asyncio.CancelledError:
-        raise  # because we must pass this up
-    except Exception as exc:
-        logger.error(f"exception in background task `{name}`:", exc)
-        logger.error(traceback.format_exc())
-        logger.error("will restart the task in 5 seconds.")
-        await asyncio.sleep(5)
-        return await catch_everything_and_restart(func, name)
+    while True:
+        try:
+            return await func()
+        except asyncio.CancelledError:
+            raise  # because we must pass this up
+        except Exception as exc:
+            logger.error(f"exception in background task `{name}`:", exc)
+            logger.error(traceback.format_exc())
+            logger.error("will restart the task in 5 seconds.")
+            await asyncio.sleep(5)
 
 
 invoice_listeners: dict[str, asyncio.Queue] = {}

--- a/lnbits/tasks.py
+++ b/lnbits/tasks.py
@@ -62,7 +62,7 @@ async def catch_everything_and_restart(
     func: Callable[[], Coroutine],
     name: str = "unnamed",
 ) -> Coroutine:
-    while True:
+    while settings.lnbits_running:
         try:
             return await func()
         except asyncio.CancelledError:


### PR DESCRIPTION
The `catch_everything_and_restart` function used recursion to restart failed background tasks, causing the call stack to grow by one frame every 5 seconds on each failure. Over long-running instances (12+ hours), this accumulated ~8,640 frames deep, gradually congesting the asyncio event loop until the service became unresponsive.

Replaced recursion with a `while True` loop to eliminate stack growth.