### PR TITLE
fix: run blocking SMTP calls in a thread to avoid blocking the event loop

### DIFF
--- a/lnbits/core/services/notifications.py
+++ b/lnbits/core/services/notifications.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import smtplib
+from asyncio.tasks import create_task
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from http import HTTPStatus
@@ -28,7 +29,6 @@ from lnbits.core.services.nostr import fetch_nip5_details, send_nostr_dm
 from lnbits.core.services.websockets import websocket_manager
 from lnbits.helpers import check_callback_url, is_valid_email_address
 from lnbits.settings import settings
-from lnbits.tasks import create_task
 from lnbits.utils.nostr import normalize_private_key
 
 notifications_queue: asyncio.Queue[NotificationMessage] = asyncio.Queue()

--- a/lnbits/core/services/notifications.py
+++ b/lnbits/core/services/notifications.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import smtplib
-from asyncio import create_task
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from http import HTTPStatus
@@ -29,6 +28,7 @@ from lnbits.core.services.nostr import fetch_nip5_details, send_nostr_dm
 from lnbits.core.services.websockets import websocket_manager
 from lnbits.helpers import check_callback_url, is_valid_email_address
 from lnbits.settings import settings
+from lnbits.tasks import create_task
 from lnbits.utils.nostr import normalize_private_key
 
 notifications_queue: asyncio.Queue[NotificationMessage] = asyncio.Queue()

--- a/lnbits/core/services/notifications.py
+++ b/lnbits/core/services/notifications.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import smtplib
-from asyncio.tasks import create_task
+from asyncio import create_task
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from http import HTTPStatus
@@ -222,11 +222,15 @@ async def send_email(
     msg["Subject"] = subject
     msg.attach(MIMEText(message, "plain"))
     username = username if len(username) > 0 else from_email
-    with smtplib.SMTP(server, port) as smtp_server:
-        smtp_server.starttls()
-        smtp_server.login(username, password)
-        smtp_server.sendmail(from_email, to_emails, msg.as_string())
-        return True
+
+    def _send():
+        with smtplib.SMTP(server, port) as smtp_server:
+            smtp_server.starttls()
+            smtp_server.login(username, password)
+            smtp_server.sendmail(from_email, to_emails, msg.as_string())
+
+    await asyncio.to_thread(_send)
+    return True
 
 
 async def dispatch_webhook(payment: Payment):

--- a/lnbits/core/services/notifications.py
+++ b/lnbits/core/services/notifications.py
@@ -223,15 +223,15 @@ async def send_email(
     msg.attach(MIMEText(message, "plain"))
     username = username if len(username) > 0 else from_email
 
-    def _send():
+    def _send() -> bool:
         with smtplib.SMTP(server, port) as smtp_server:
             smtp_server.starttls()
             smtp_server.login(username, password)
             smtp_server.sendmail(from_email, to_emails, msg.as_string())
+        return True
 
     try:
-        await asyncio.to_thread(_send)
-        return True
+        return await asyncio.to_thread(_send)
     except Exception as e:
         logger.warning(f"Sending Email failed. {e!s}")
         return False

--- a/lnbits/core/services/notifications.py
+++ b/lnbits/core/services/notifications.py
@@ -229,8 +229,12 @@ async def send_email(
             smtp_server.login(username, password)
             smtp_server.sendmail(from_email, to_emails, msg.as_string())
 
-    await asyncio.to_thread(_send)
-    return True
+    try:
+        await asyncio.to_thread(_send)
+        return True
+    except Exception as e:
+        logger.warning(f"Sending Email failed. {e!s}")
+        return False
 
 
 async def dispatch_webhook(payment: Payment):


### PR DESCRIPTION
The `send_email` function used synchronous `smtplib.SMTP` calls inside an `async def` with no `await` points. When the SMTP server was unreachable, the TCP `connect()` blocked the entire asyncio event loop for the OS timeout duration (~127 seconds), freezing all HTTP request processing.

Wrapped the blocking SMTP operations in `asyncio.to_thread()` to move them off the event loop.