### PR TITLE
feat: use cached rate from exchange_rate_history_setting

### DIFF
--- a/lnbits/core/tasks.py
+++ b/lnbits/core/tasks.py
@@ -25,6 +25,7 @@ from lnbits.core.services.notifications import (
 )
 from lnbits.db import Filters
 from lnbits.settings import settings
+from lnbits.utils.cache import cache
 from lnbits.utils.exchange_rates import btc_rates
 
 audit_queue: asyncio.Queue[AuditEntry] = asyncio.Queue()
@@ -155,7 +156,11 @@ async def collect_exchange_rates_data() -> None:
                     rates_values = [r[1] for r in rates]
                     lnbits_rate = sum(rates_values) / len(rates_values)
                     rates.append(("LNbits", lnbits_rate))
-                    settings.set_exchange_rate(currency, lnbits_rate)
+                    cache.set(
+                        f"btc-price-{currency}",
+                        lnbits_rate,
+                        expiry=settings.lnbits_exchange_rate_cache_seconds,
+                    )
                 settings.append_exchange_rate_datapoint(dict(rates), max_history_size)
             except Exception as ex:
                 logger.warning(ex)

--- a/lnbits/core/tasks.py
+++ b/lnbits/core/tasks.py
@@ -155,6 +155,7 @@ async def collect_exchange_rates_data() -> None:
                     rates_values = [r[1] for r in rates]
                     lnbits_rate = sum(rates_values) / len(rates_values)
                     rates.append(("LNbits", lnbits_rate))
+                    settings.set_exchange_rate(currency, lnbits_rate)
                 settings.append_exchange_rate_datapoint(dict(rates), max_history_size)
             except Exception as ex:
                 logger.warning(ex)

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -241,7 +241,6 @@ class InstalledExtensionsSettings(LNbitsSettings):
 
 class ExchangeHistorySettings(LNbitsSettings):
     lnbits_exchange_rate_history: list[dict] = Field(default=[])
-    lnbits_exchange_rates: dict[str, float] = Field(default_factory=dict)
 
     def append_exchange_rate_datapoint(self, rates: dict, max_size: int):
         data = {
@@ -251,12 +250,6 @@ class ExchangeHistorySettings(LNbitsSettings):
         self.lnbits_exchange_rate_history.append(data)
         if len(self.lnbits_exchange_rate_history) > max_size:
             self.lnbits_exchange_rate_history.pop(0)
-
-    def get_exchange_rate(self, currency: str) -> float:
-        return self.lnbits_exchange_rates.get(currency.upper(), 0.0)
-
-    def set_exchange_rate(self, currency: str, price: float) -> None:
-        self.lnbits_exchange_rates[currency.upper()] = price
 
 
 class ThemesSettings(LNbitsSettings):
@@ -366,7 +359,7 @@ class FeeSettings(LNbitsSettings):
 
 
 class ExchangeProvidersSettings(LNbitsSettings):
-    lnbits_exchange_rate_cache_seconds: int = Field(default=30, ge=0)
+    lnbits_exchange_rate_cache_seconds: int = Field(default=60, ge=0)
     lnbits_exchange_history_size: int = Field(default=60, ge=0)
     lnbits_exchange_history_refresh_interval_seconds: int = Field(default=300, ge=0)
 

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -241,6 +241,7 @@ class InstalledExtensionsSettings(LNbitsSettings):
 
 class ExchangeHistorySettings(LNbitsSettings):
     lnbits_exchange_rate_history: list[dict] = Field(default=[])
+    lnbits_exchange_rates: dict[str, float] = Field(default_factory=dict)
 
     def append_exchange_rate_datapoint(self, rates: dict, max_size: int):
         data = {
@@ -250,6 +251,12 @@ class ExchangeHistorySettings(LNbitsSettings):
         self.lnbits_exchange_rate_history.append(data)
         if len(self.lnbits_exchange_rate_history) > max_size:
             self.lnbits_exchange_rate_history.pop(0)
+
+    def get_exchange_rate(self, currency: str) -> float:
+        return self.lnbits_exchange_rates.get(currency.upper(), 0.0)
+
+    def set_exchange_rate(self, currency: str, price: float) -> None:
+        self.lnbits_exchange_rates[currency.upper()] = price
 
 
 class ThemesSettings(LNbitsSettings):

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -302,14 +302,8 @@ async def btc_price(currency: str) -> float:
 
 
 async def get_fiat_rate_and_price_satoshis(currency: str) -> tuple[float, float]:
-    async def _get_price() -> float:
-        price = settings.get_exchange_rate(currency)
-        if price > 0:
-            return price
-        return await btc_price(currency)
-
     price = await cache.save_result(
-        _get_price,
+        lambda: btc_price(currency),
         f"btc-price-{currency}",
         settings.lnbits_exchange_rate_cache_seconds,
     )

--- a/lnbits/utils/exchange_rates.py
+++ b/lnbits/utils/exchange_rates.py
@@ -302,8 +302,14 @@ async def btc_price(currency: str) -> float:
 
 
 async def get_fiat_rate_and_price_satoshis(currency: str) -> tuple[float, float]:
+    async def _get_price() -> float:
+        price = settings.get_exchange_rate(currency)
+        if price > 0:
+            return price
+        return await btc_price(currency)
+
     price = await cache.save_result(
-        lambda: btc_price(currency),
+        _get_price,
         f"btc-price-{currency}",
         settings.lnbits_exchange_rate_cache_seconds,
     )


### PR DESCRIPTION
performance improvement for wallet page, use already fetched rate from background task if available