### PR TITLE
fix(payments): propagate per-call fee_limit_msat

### DIFF
--- a/lnbits/core/models/payments.py
+++ b/lnbits/core/models/payments.py
@@ -269,6 +269,14 @@ class CreateInvoice(BaseModel):
     fiat_provider: str | None = None
     labels: list[str] = []
     external_id: str | None = Query(default=None, max_length=256)
+    fee_limit_msat: int | None = Query(
+        default=None,
+        ge=0,
+        description=(
+            "Caller-supplied cap on routing fees in millisatoshis. "
+            "Applied as min(fee_limit_msat, operator cap)."
+        ),
+    )
 
     @validator("payment_hash")
     def check_hex(cls, v):

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from bolt11 import Bolt11, MilliSatoshi, Tags
 from bolt11 import decode as bolt11_decode
 from bolt11 import encode as bolt11_encode
+from fastapi import HTTPException
 from lnurl import LnurlErrorResponse, LnurlSuccessResponse
 from lnurl import execute_withdraw as lnurl_withdraw
 from loguru import logger
@@ -66,6 +67,7 @@ async def pay_invoice(
     labels: list[str] | None = None,
     external_id: str | None = None,
     conn: Connection | None = None,
+    fee_limit_msat: int | None = None,
 ) -> Payment:
     if settings.lnbits_only_allow_incoming_payments:
         raise PaymentError("Only incoming payments allowed.", status="failed")
@@ -103,7 +105,10 @@ async def pay_invoice(
 
     async with db.reuse_conn(conn) if conn else db.connect() as new_conn:
         payment = await _pay_invoice(
-            wallet.source_wallet_id, create_payment_model, conn=new_conn
+            wallet.source_wallet_id,
+            create_payment_model,
+            conn=new_conn,
+            fee_limit_msat=fee_limit_msat,
         )
 
         await _credit_service_fee_wallet(wallet, payment, conn=new_conn)
@@ -420,6 +425,27 @@ def fee_reserve(amount_msat: int, internal: bool = False) -> int:
     return settings.fee_reserve(amount_msat, internal)
 
 
+def _resolve_fee_limit_msat(amount_msat: int, caller_fee_limit_msat: int | None) -> int:
+    # The operator's policy (LNBITS_RESERVE_FEE_PERCENT) is always the ceiling.
+    # If the caller supplied its own cap, the effective limit is the lower of
+    # the two — neither party can raise the other's bound. A caller passing a
+    # cap to a backend that cannot honor it must fail loudly rather than
+    # silently fall back to the operator cap (the "Rug the Mints" bug).
+    operator_cap_msat = fee_reserve(amount_msat, internal=False)
+    if caller_fee_limit_msat is None:
+        return operator_cap_msat
+    funding_source = get_funding_source()
+    if not getattr(funding_source, "supports_fee_limit_msat", False):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "The configured funding source does not support a per-call "
+                "fee_limit_msat."
+            ),
+        )
+    return min(caller_fee_limit_msat, operator_cap_msat)
+
+
 def service_fee(amount_msat: int, internal: bool = False) -> int:
     amount_msat = abs(amount_msat)
     service_fee_percent = settings.lnbits_service_fee
@@ -704,6 +730,7 @@ async def _pay_invoice(
     wallet_id: str,
     create_payment_model: CreatePayment,
     conn: Connection | None = None,
+    fee_limit_msat: int | None = None,
 ):
     async with payment_lock:
         if wallet_id not in wallets_payments_lock:
@@ -719,7 +746,9 @@ async def _pay_invoice(
 
         payment = await _pay_internal_invoice(wallet, create_payment_model, conn)
         if not payment:
-            payment = await _pay_external_invoice(wallet, create_payment_model, conn)
+            payment = await _pay_external_invoice(
+                wallet, create_payment_model, conn, fee_limit_msat=fee_limit_msat
+            )
         return payment
 
 
@@ -798,6 +827,7 @@ async def _pay_external_invoice(
     wallet: Wallet,
     create_payment_model: CreatePayment,
     conn: Connection | None = None,
+    fee_limit_msat: int | None = None,
 ) -> Payment:
     checking_id = create_payment_model.payment_hash
     amount_msat = create_payment_model.amount_msat
@@ -824,12 +854,12 @@ async def _pay_external_invoice(
         conn=conn,
     )
 
-    fee_reserve_msat = fee_reserve(amount_msat, internal=False)
+    effective_cap_msat = _resolve_fee_limit_msat(amount_msat, fee_limit_msat)
 
     from lnbits.tasks import create_task
 
     task = create_task(
-        _fundingsource_pay_invoice(checking_id, payment.bolt11, fee_reserve_msat)
+        _fundingsource_pay_invoice(checking_id, payment.bolt11, effective_cap_msat)
     )
 
     # make sure a hold invoice or deferred payment is not blocking the server

--- a/lnbits/core/views/payment_api.py
+++ b/lnbits/core/views/payment_api.py
@@ -265,6 +265,7 @@ async def api_payments_create(
             extra=invoice_data.extra,
             labels=invoice_data.labels,
             external_id=invoice_data.external_id,
+            fee_limit_msat=invoice_data.fee_limit_msat,
         )
         return payment
 

--- a/lnbits/wallets/alby.py
+++ b/lnbits/wallets/alby.py
@@ -123,7 +123,9 @@ class AlbyWallet(Wallet):
                 ok=False, error_message=f"Unable to connect to {self.endpoint}."
             )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
             # https://api.getalby.com/payments/bolt11
             r = await self.client.post(

--- a/lnbits/wallets/base.py
+++ b/lnbits/wallets/base.py
@@ -110,6 +110,12 @@ class Wallet(ABC):
     __node_cls__: type[Node] | None = None
     features: list[Feature] | None = None
 
+    # Whether the backend honors the per-call `fee_limit_msat` argument by
+    # propagating it to the underlying Lightning node / API. Drivers that
+    # accept the argument and silently drop it MUST leave this as `False` so
+    # the service layer can reject calls that would otherwise overspend.
+    supports_fee_limit_msat: bool = False
+
     def has_feature(self, feature: Feature) -> bool:
         return self.features is not None and feature in self.features
 
@@ -137,7 +143,7 @@ class Wallet(ABC):
 
     @abstractmethod
     def pay_invoice(
-        self, bolt11: str, fee_limit_msat: int
+        self, bolt11: str, fee_limit_msat: int | None
     ) -> Coroutine[None, None, PaymentResponse]:
         pass
 

--- a/lnbits/wallets/blink.py
+++ b/lnbits/wallets/blink.py
@@ -164,7 +164,9 @@ class BlinkWallet(Wallet):
                 ok=False, error_message=f"Unable to connect to {self.endpoint}."
             )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         # https://dev.blink.sv/api/btc-ln-send
         # Future: add check fee estimate is < fee_limit_msat before paying invoice
 

--- a/lnbits/wallets/boltz.py
+++ b/lnbits/wallets/boltz.py
@@ -123,8 +123,12 @@ class BoltzWallet(Wallet):
             fee_msat=fee_msat,
         )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
-
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
+        # The service layer's _resolve_fee_limit_msat always supplies an int;
+        # the `int | None` here is the abstract contract from `Wallet`.
+        assert fee_limit_msat is not None
         pair = boltzrpc_pb2.Pair(**{"from": boltzrpc_pb2.LBTC})
         try:
             pair_info: boltzrpc_pb2.PairInfo

--- a/lnbits/wallets/breez.py
+++ b/lnbits/wallets/breez.py
@@ -210,7 +210,7 @@ else:
                 return InvoiceResponse(ok=False, error_message=str(e))
 
         async def pay_invoice(
-            self, bolt11: str, fee_limit_msat: int
+            self, bolt11: str, fee_limit_msat: int | None
         ) -> PaymentResponse:
             logger.debug(f"fee_limit_msat {fee_limit_msat} is ignored by Breez SDK")
             try:

--- a/lnbits/wallets/breez_liquid.py
+++ b/lnbits/wallets/breez_liquid.py
@@ -171,8 +171,11 @@ else:
                 return InvoiceResponse(ok=False, error_message=str(e))
 
         async def pay_invoice(
-            self, bolt11: str, fee_limit_msat: int
+            self, bolt11: str, fee_limit_msat: int | None
         ) -> PaymentResponse:
+            # The service layer's _resolve_fee_limit_msat always supplies an
+            # int; the `int | None` here is the abstract contract from `Wallet`.
+            assert fee_limit_msat is not None
             invoice_data = bolt11_decode(bolt11)
 
             try:

--- a/lnbits/wallets/cliche.py
+++ b/lnbits/wallets/cliche.py
@@ -103,7 +103,9 @@ class ClicheWallet(Wallet):
             preimage=data["result"].get("preimage"),
         )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         ws = create_connection(self.endpoint)
         ws.send(f"pay-invoice --invoice {bolt11}")
         checking_id, fee_msat, preimage, payment_ok = (

--- a/lnbits/wallets/clnrest.py
+++ b/lnbits/wallets/clnrest.py
@@ -29,6 +29,8 @@ from .base import (
 
 
 class CLNRestWallet(Wallet):
+    supports_fee_limit_msat = True
+
     def __init__(self):
         if not settings.clnrest_url:
             raise ValueError("Cannot initialize CLNRestWallet: missing CLNREST_URL")
@@ -247,7 +249,7 @@ class CLNRestWallet(Wallet):
     async def pay_invoice(
         self,
         bolt11: str,
-        fee_limit_msat: int,
+        fee_limit_msat: int | None,
         **_,
     ) -> PaymentResponse:
 

--- a/lnbits/wallets/corelightning.py
+++ b/lnbits/wallets/corelightning.py
@@ -36,6 +36,7 @@ class CoreLightningWallet(Wallet):
 
     __node_cls__ = CoreLightningNode
     features = [Feature.nodemanager]
+    supports_fee_limit_msat = True
 
     async def cleanup(self):
         pass
@@ -147,7 +148,9 @@ class CoreLightningWallet(Wallet):
             logger.warning(e)
             return InvoiceResponse(ok=False, error_message=str(e))
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
             invoice = bolt11_decode(bolt11)
         except Bolt11Exception as exc:

--- a/lnbits/wallets/corelightningrest.py
+++ b/lnbits/wallets/corelightningrest.py
@@ -25,6 +25,8 @@ from .macaroon import load_macaroon
 
 
 class CoreLightningRestWallet(Wallet):
+    supports_fee_limit_msat = True
+
     def __init__(self):
         if not settings.corelightning_rest_url:
             raise ValueError(
@@ -176,7 +178,9 @@ class CoreLightningRestWallet(Wallet):
                 ok=False, error_message=f"Unable to connect to {self.url}."
             )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
             invoice = decode(bolt11)
         except Bolt11Exception as exc:

--- a/lnbits/wallets/eclair.py
+++ b/lnbits/wallets/eclair.py
@@ -144,7 +144,9 @@ class EclairWallet(Wallet):
                 ok=False, error_message=f"Unable to connect to {self.url}."
             )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
             r = await self.client.post(
                 "/payinvoice",

--- a/lnbits/wallets/fake.py
+++ b/lnbits/wallets/fake.py
@@ -103,7 +103,9 @@ class FakeWallet(Wallet):
             preimage=preimage.hex(),
         )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
             invoice = decode(bolt11)
         except Bolt11Exception as exc:

--- a/lnbits/wallets/lnbits.py
+++ b/lnbits/wallets/lnbits.py
@@ -24,6 +24,8 @@ from .base import (
 class LNbitsWallet(Wallet):
     """https://github.com/lnbits/lnbits"""
 
+    supports_fee_limit_msat = True
+
     def __init__(self):
         if not settings.lnbits_endpoint:
             raise ValueError("cannot initialize LNbitsWallet: missing lnbits_endpoint")
@@ -117,11 +119,16 @@ class LNbitsWallet(Wallet):
                 ok=False, error_message=f"Unable to connect to {self.endpoint}."
             )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
+            payload: dict = {"out": True, "bolt11": bolt11}
+            if fee_limit_msat is not None:
+                payload["fee_limit_msat"] = fee_limit_msat
             r = await self.client.post(
                 url="/api/v1/payments",
-                json={"out": True, "bolt11": bolt11},
+                json=payload,
                 timeout=None,
             )
 

--- a/lnbits/wallets/lndgrpc.py
+++ b/lnbits/wallets/lndgrpc.py
@@ -89,6 +89,7 @@ class LndWallet(Wallet):
     invoices_rpc: InvoicesStub
 
     features = [Feature.holdinvoice]
+    supports_fee_limit_msat = True
 
     def __init__(self):
         if not settings.lnd_grpc_endpoint:
@@ -185,7 +186,9 @@ class LndWallet(Wallet):
             preimage=preimage,
         )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         # fee_limit_fixed = ln.FeeLimit(fixed=fee_limit_msat // 1000)
         req = SendPaymentRequest(
             payment_request=bolt11,

--- a/lnbits/wallets/lndrest.py
+++ b/lnbits/wallets/lndrest.py
@@ -31,6 +31,7 @@ class LndRestWallet(Wallet):
 
     __node_cls__ = LndRestNode
     features = [Feature.nodemanager, Feature.holdinvoice]
+    supports_fee_limit_msat = True
 
     def __init__(self):
         if not settings.lnd_rest_endpoint:
@@ -170,7 +171,9 @@ class LndRestWallet(Wallet):
                 ok=False, error_message=f"Unable to connect to {self.endpoint}."
             )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         req = {
             "payment_request": bolt11,
             "fee_limit_msat": fee_limit_msat,

--- a/lnbits/wallets/lnpay.py
+++ b/lnbits/wallets/lnpay.py
@@ -104,7 +104,9 @@ class LNPayWallet(Wallet):
             error_message=r.text,
         )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         r = await self.client.post(
             f"/wallet/{self.wallet_key}/withdraw",
             json={"payment_request": bolt11},

--- a/lnbits/wallets/lntips.py
+++ b/lnbits/wallets/lntips.py
@@ -102,7 +102,9 @@ class LnTipsWallet(Wallet):
             preimage=data.get("preimage"),
         )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         r = await self.client.post(
             "/api/v1/payinvoice",
             json={"pay_req": bolt11},

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -194,7 +194,9 @@ class NWCWallet(Wallet):
         except Exception as e:
             return StatusResponse(str(e), 0)
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
             resp = await self.conn.call("pay_invoice", {"invoice": bolt11})
             preimage = resp.get("preimage", None)

--- a/lnbits/wallets/opennode.py
+++ b/lnbits/wallets/opennode.py
@@ -99,7 +99,9 @@ class OpenNodeWallet(Wallet):
             ok=True, checking_id=checking_id, payment_request=payment_request
         )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         r = await self.client.post(
             "/v2/withdrawals",
             json={"type": "ln", "address": bolt11},

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -168,7 +168,9 @@ class PhoenixdWallet(Wallet):
                 ok=False, error_message=f"Unable to connect to {self.endpoint}."
             )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
             r = await self.client.post(
                 "/payinvoice",

--- a/lnbits/wallets/spark.py
+++ b/lnbits/wallets/spark.py
@@ -31,6 +31,8 @@ class UnknownError(Exception):
 
 
 class SparkWallet(Wallet):
+    supports_fee_limit_msat = True
+
     def __init__(self):
         if not settings.spark_url:
             raise ValueError("cannot initialize SparkWallet: missing spark_url")
@@ -146,7 +148,9 @@ class SparkWallet(Wallet):
         except (SparkError, UnknownError) as e:
             return InvoiceResponse(ok=False, error_message=str(e))
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         try:
             r = await self.pay(
                 bolt11=bolt11,

--- a/lnbits/wallets/sparkl2.py
+++ b/lnbits/wallets/sparkl2.py
@@ -41,6 +41,8 @@ class SparkL2Wallet(Wallet):
       - SPARK_L2_API_KEY
     """
 
+    supports_fee_limit_msat = True
+
     def __init__(self):
         self._status = "Initializing"
         self._sidecar_path = Path(settings.lnbits_data_folder, "light_spark")
@@ -140,9 +142,14 @@ class SparkL2Wallet(Wallet):
         except Exception as e:
             return InvoiceResponse(ok=False, error_message=str(e))
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
+        # The service layer's _resolve_fee_limit_msat always supplies an int;
+        # the `int | None` here is the abstract contract from `Wallet`.
+        assert fee_limit_msat is not None
         try:
-            max_fee_sats = (int(fee_limit_msat) + 999) // 1000
+            max_fee_sats = (fee_limit_msat + 999) // 1000
             logger.info(
                 f"Paying invoice via Spark sidecar with max fee {max_fee_sats} sats."
             )

--- a/lnbits/wallets/strike.py
+++ b/lnbits/wallets/strike.py
@@ -225,7 +225,9 @@ class StrikeWallet(Wallet):
             logger.warning(e)
             return InvoiceResponse(ok=False, error_message="Connection error")
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         # Extract payment hash from invoice for checking_id
 
         try:

--- a/lnbits/wallets/zbd.py
+++ b/lnbits/wallets/zbd.py
@@ -103,7 +103,9 @@ class ZBDWallet(Wallet):
             preimage=preimage,
         )
 
-    async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+    async def pay_invoice(
+        self, bolt11: str, fee_limit_msat: int | None
+    ) -> PaymentResponse:
         # https://api.zebedee.io/v0/payments
         r = await self.client.post(
             "payments",

--- a/tests/unit/test_pay_invoice_fee_limit.py
+++ b/tests/unit/test_pay_invoice_fee_limit.py
@@ -1,0 +1,176 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from pytest_mock.plugin import MockerFixture
+
+from lnbits.core.services.payments import _resolve_fee_limit_msat
+from lnbits.settings import Settings
+
+
+def _funding_source_mock(supports: bool) -> MagicMock:
+    fs = MagicMock()
+    fs.supports_fee_limit_msat = supports
+    return fs
+
+
+@pytest.mark.anyio
+async def test_resolve_fee_limit_none_returns_operator_cap(
+    settings: Settings, mocker: MockerFixture
+):
+    settings.lnbits_reserve_fee_percent = 1
+    settings.lnbits_reserve_fee_min = 0
+    get_fs = mocker.patch(
+        "lnbits.core.services.payments.get_funding_source",
+        return_value=_funding_source_mock(supports=False),
+    )
+
+    effective = _resolve_fee_limit_msat(
+        amount_msat=1_000_000, caller_fee_limit_msat=None
+    )
+
+    # 1% of 1_000_000 msat = 10_000 msat; caller passed nothing so we fall back
+    # to the operator cap unconditionally and never consult the funding source.
+    assert effective == 10_000
+    assert get_fs.call_count == 0
+
+
+@pytest.mark.anyio
+async def test_resolve_fee_limit_caller_below_operator(
+    settings: Settings, mocker: MockerFixture
+):
+    settings.lnbits_reserve_fee_percent = 1
+    settings.lnbits_reserve_fee_min = 0
+    mocker.patch(
+        "lnbits.core.services.payments.get_funding_source",
+        return_value=_funding_source_mock(supports=True),
+    )
+
+    effective = _resolve_fee_limit_msat(
+        amount_msat=1_000_000, caller_fee_limit_msat=2_500
+    )
+
+    # operator allows 10_000 msat, caller asks 2_500 → caller wins (stricter).
+    assert effective == 2_500
+
+
+@pytest.mark.anyio
+async def test_resolve_fee_limit_caller_above_operator(
+    settings: Settings, mocker: MockerFixture
+):
+    settings.lnbits_reserve_fee_percent = 1
+    settings.lnbits_reserve_fee_min = 0
+    mocker.patch(
+        "lnbits.core.services.payments.get_funding_source",
+        return_value=_funding_source_mock(supports=True),
+    )
+
+    effective = _resolve_fee_limit_msat(
+        amount_msat=1_000_000, caller_fee_limit_msat=50_000
+    )
+
+    # caller can never raise the operator's ceiling.
+    assert effective == 10_000
+
+
+@pytest.mark.anyio
+async def test_resolve_fee_limit_unsupported_backend_raises(
+    settings: Settings, mocker: MockerFixture
+):
+    settings.lnbits_reserve_fee_percent = 1
+    settings.lnbits_reserve_fee_min = 0
+    mocker.patch(
+        "lnbits.core.services.payments.get_funding_source",
+        return_value=_funding_source_mock(supports=False),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _resolve_fee_limit_msat(amount_msat=1_000_000, caller_fee_limit_msat=2_500)
+
+    assert exc_info.value.status_code == 400
+    assert "fee_limit_msat" in exc_info.value.detail
+
+
+@pytest.mark.anyio
+async def test_lnbits_driver_propagates_fee_limit_msat_in_payload(
+    settings: Settings, mocker: MockerFixture
+):
+    settings.lnbits_endpoint = "https://example.invalid"
+    settings.lnbits_admin_key = "deadbeef"
+    settings.lnbits_invoice_key = "deadbeef"
+    settings.lnbits_key = "deadbeef"
+
+    from lnbits.wallets.lnbits import LNbitsWallet
+
+    # The capability flag is declared at the class — not env — so that
+    # operators cannot opt a non-propagating driver into the feature.
+    assert LNbitsWallet.supports_fee_limit_msat is True
+
+    wallet = LNbitsWallet()
+
+    # Capture the JSON payload sent by the driver without doing real I/O.
+    captured: dict = {}
+
+    async def fake_post(url, json, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        del timeout
+        response = MagicMock(spec=httpx.Response)
+        response.raise_for_status = MagicMock()
+        response.json = MagicMock(return_value={"payment_hash": "ph"})
+        return response
+
+    mocker.patch.object(wallet.client, "post", side_effect=fake_post)
+    mocker.patch.object(
+        wallet,
+        "get_payment_status",
+        AsyncMock(
+            return_value=MagicMock(success=True, fee_msat=0, preimage="00", paid=True)
+        ),
+    )
+
+    # With a cap → field present.
+    await wallet.pay_invoice(bolt11="lnbcdummy", fee_limit_msat=1234)
+    assert captured["json"]["fee_limit_msat"] == 1234
+    assert captured["json"]["out"] is True
+    assert captured["json"]["bolt11"] == "lnbcdummy"
+
+    # Without a cap (legacy callers) → field absent.
+    captured.clear()
+    await wallet.pay_invoice(bolt11="lnbcdummy", fee_limit_msat=None)
+    assert "fee_limit_msat" not in captured["json"]
+
+
+@pytest.mark.anyio
+async def test_custodial_drivers_keep_default_supports_flag():
+    # The flag defaults to False; only the audited propagating drivers may
+    # flip it. Catching a regression here is cheaper than reading every diff.
+    from lnbits.wallets.alby import AlbyWallet
+    from lnbits.wallets.blink import BlinkWallet
+    from lnbits.wallets.boltz import BoltzWallet
+    from lnbits.wallets.cliche import ClicheWallet
+    from lnbits.wallets.eclair import EclairWallet
+    from lnbits.wallets.lnpay import LNPayWallet
+    from lnbits.wallets.lntips import LnTipsWallet
+    from lnbits.wallets.nwc import NWCWallet
+    from lnbits.wallets.opennode import OpenNodeWallet
+    from lnbits.wallets.phoenixd import PhoenixdWallet
+    from lnbits.wallets.strike import StrikeWallet
+    from lnbits.wallets.zbd import ZBDWallet
+
+    for cls in (
+        AlbyWallet,
+        BlinkWallet,
+        BoltzWallet,
+        ClicheWallet,
+        EclairWallet,
+        LNPayWallet,
+        LnTipsWallet,
+        NWCWallet,
+        OpenNodeWallet,
+        PhoenixdWallet,
+        StrikeWallet,
+        ZBDWallet,
+    ):
+        assert cls.supports_fee_limit_msat is False, cls.__name__


### PR DESCRIPTION
## Summary
 
`POST /api/v1/payments` now accepts an optional `fee_limit_msat`. The service computes `effective_cap = min(caller, operator_cap)` so neither party  can raise the other's ceiling the operator's `LNBITS_RESERVE_FEE_PERCENT` remains the upper bound, but the caller can tighten it per request.

## What changed 

- New optional field `fee_limit_msat` on `CreateInvoice`.
- New capability flag `Wallet.supports_fee_limit_msat` (default `False`). Drivers that already propagate natively opt in: `lndrest`, `lndgrpc`, `clnrest`, `corelightning`, `corelightningrest`, `spark`, `sparkl2`, `lnbits`.
- The `lnbits → lnbits` driver now includes `fee_limit_msat` in its outgoing payload when the caller supplies one.
- Service raises `HTTPException(400)` if a caller passes a cap to a backend that cannot honor it, rather than silently dropping it.
- Abstract `Wallet.pay_invoice` signature widened to `int | None` to match the contract; drivers that arithmetically use the value narrow back via `assert`.                                                                                                                                             

## Test plan
                
- [x] Unit tests for `_resolve_fee_limit_msat`: None / caller<op / caller>op / unsupported backend.
- [x] Unit test for `lnbits → lnbits` payload propagation (present when set, absent when not).
- [x] Regression test asserting 12 custodial drivers keep `supports_fee_limit_msat = False`.
- [x] `ruff check lnbits/wallets/` clean.
- [x] `mypy lnbits/wallets/` clean (28 source files, 0 errors).