### PR TITLE
feat: optimise Uvicorn Settings for heavy web socket use

### DIFF
--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -28,7 +28,7 @@ from lnbits.settings import set_cli_settings, settings
     "--reload", is_flag=True, default=False, help="Enable auto-reload for development"
 )
 @click.option("--ws-max-queue", default=128, help="Websocket max queue size")
-@click.option("--ws-ping-timeout", default=900.0, help="Websocket ping timeout")
+@click.option("--ws-ping-timeout", default=300.0, help="Websocket ping timeout")
 def main(
     port: int,
     host: str,

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -37,7 +37,7 @@ def main(
     ssl_certfile: str,
     reload: bool,
     ws_max_queue: int,
-    ws_ping_timeout: float
+    ws_ping_timeout: float,
 ):
     """Launched with `uv run lnbits` at root level"""
 

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -58,6 +58,8 @@ def main(
             ssl_keyfile=ssl_keyfile,
             ssl_certfile=ssl_certfile,
             reload=reload or False,
+            ws_ping_interval=None,
+            ws_ping_timeout=None,
         )
 
         server = uvicorn.Server(config=config)

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -27,6 +27,8 @@ from lnbits.settings import set_cli_settings, settings
 @click.option(
     "--reload", is_flag=True, default=False, help="Enable auto-reload for development"
 )
+@click.option("--ws-max-queue", default=128, help="Websocket max queue size")
+@click.option("--ws-ping-timeout", default=900.0, help="Websocket ping timeout")
 def main(
     port: int,
     host: str,
@@ -34,6 +36,8 @@ def main(
     ssl_keyfile: str,
     ssl_certfile: str,
     reload: bool,
+    ws_max_queue: int,
+    ws_ping_timeout: float
 ):
     """Launched with `uv run lnbits` at root level"""
 
@@ -58,8 +62,8 @@ def main(
             ssl_keyfile=ssl_keyfile,
             ssl_certfile=ssl_certfile,
             reload=reload or False,
-            ws_ping_interval=None,
-            ws_ping_timeout=None,
+            ws_ping_timeout=ws_ping_timeout,
+            ws_max_queue=ws_max_queue,
         )
 
         server = uvicorn.Server(config=config)

--- a/lnbits/server.py
+++ b/lnbits/server.py
@@ -28,7 +28,7 @@ from lnbits.settings import set_cli_settings, settings
     "--reload", is_flag=True, default=False, help="Enable auto-reload for development"
 )
 @click.option("--ws-max-queue", default=128, help="Websocket max queue size")
-@click.option("--ws-ping-timeout", default=300.0, help="Websocket ping timeout")
+@click.option("--ws-ping-timeout", default=60.0, help="Websocket ping timeout")
 def main(
     port: int,
     host: str,


### PR DESCRIPTION
Uvicorn's default `ws_ping_interval=20` / `ws_ping_timeout=20` can non-deterministically close local WebSocket connections (e.g. NWC provider ↔ nostrclient relay) under event-loop load. The client side already sends its own pings, so server-side pings are redundant here.

See discussion on the related nostrclient PR: https://github.com/lnbits/nostrclient/pull/71#issuecomment-4803033307