### PR TITLE
CI: appimage upload-urls with `gh upload` command

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -7,19 +7,11 @@ on:
         description: 'The tag name for the release'
         required: true
         type: string
-      upload_url:
-        description: 'The upload URL for the release'
-        required: true
-        type: string
 
   workflow_dispatch:
     inputs:
       tag_name:
         description: 'The tag name for the release'
-        required: true
-        type: string
-      upload_url:
-        description: 'The upload URL for the release'
         required: true
         type: string
 
@@ -113,11 +105,6 @@ jobs:
         shell: bash
 
       - name: Upload Linux Release Asset
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: ${{ env.APPIMAGE_NAME }}
-          asset_name: ${{ env.APPIMAGE_NAME }}
-          asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ inputs.tag_name }}" "${{ env.APPIMAGE_NAME }}" --clobber

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -12,8 +12,6 @@ jobs:
 
   release:
     runs-on: ubuntu-24.04
-    outputs:
-      upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v4
       - name: Create github pre-release
@@ -22,14 +20,6 @@ jobs:
           tag: ${{ github.ref_name }}
         run: |
           gh release create "$tag" --prerelease --generate-notes --draft
-      - id: get_upload_url
-        name: Get upload url of Github release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref_name }}
-        run: |
-          upload_url=$(gh release view "$tag" --json uploadUrl -q ".uploadUrl")
-          echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
 
   docker:
     if: github.repository == 'lnbits/lnbits'
@@ -74,4 +64,3 @@ jobs:
     uses: ./.github/workflows/appimage.yml
     with:
       tag_name: ${{ github.ref_name }}
-      upload_url: ${{ needs.release.outputs.upload_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
 
   release:
     runs-on: ubuntu-24.04
-    outputs:
-      upload_url: ${{ steps.get_upload_url.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v4
       - name: Create github release
@@ -23,14 +21,6 @@ jobs:
           tag: ${{ github.ref_name }}
         run: |
           gh release create "$tag" --generate-notes --draft
-      - id: get_upload_url
-        name: Get upload url of Github release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref_name }}
-        run: |
-          upload_url=$(gh release view "$tag" --json uploadUrl -q ".uploadUrl")
-          echo "upload_url=$upload_url" >> "$GITHUB_OUTPUT"
 
   docker:
     if: github.repository == 'lnbits/lnbits'
@@ -85,4 +75,3 @@ jobs:
     uses: ./.github/workflows/appimage.yml
     with:
       tag_name: ${{ github.ref_name }}
-      upload_url: ${{ needs.release.outputs.upload_url }}


### PR DESCRIPTION
The gh release upload command resolves the asset upload URL itself from the tag name, so no need to fetch and pass upload_url at all.