### PR TITLE
fix(nwc): decode bolt11 before NWC call to prevent payment record loss

### DIFF
--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any, cast
 from urllib.parse import parse_qs, unquote, urlparse
 
+from bolt11 import Bolt11Exception
 from bolt11 import decode as bolt11_decode
 from coincurve import PrivateKey, PublicKey
 from Cryptodome.Cipher import ChaCha20
@@ -575,12 +576,20 @@ class NWCWallet(Wallet):
             resp = await self.conn.call("get_balance", {})
             balance = int(resp["balance"])
             return StatusResponse(None, balance)
-        except Exception as e:
-            return StatusResponse(str(e), 0)
+        except Exception as exc:
+            return StatusResponse(str(exc), 0)
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
-        invoice_data = bolt11_decode(bolt11)
-        payment_hash = invoice_data.payment_hash
+        try:
+            invoice_data = bolt11_decode(bolt11)
+            payment_hash = invoice_data.payment_hash
+        except Bolt11Exception as exc:
+            logger.error("Error decoding invoice: " + str(exc))
+            return PaymentResponse(
+                ok=False,
+                checking_id=None,
+                error_message="Invalid invoice: " + str(exc),
+            )
         try:
             resp = await self.conn.call("pay_invoice", {"invoice": bolt11})
             preimage = resp.get("preimage", None)

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -579,11 +579,11 @@ class NWCWallet(Wallet):
             return StatusResponse(str(e), 0)
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
+        invoice_data = bolt11_decode(bolt11)
+        payment_hash = invoice_data.payment_hash
         try:
             resp = await self.conn.call("pay_invoice", {"invoice": bolt11})
             preimage = resp.get("preimage", None)
-            invoice_data = bolt11_decode(bolt11)
-            payment_hash = invoice_data.payment_hash
             # pay_invoice doesn't return payment data, so we need
             # to call lookup_invoice too (if supported)
             await self.conn.get_info()
@@ -630,15 +630,23 @@ class NWCWallet(Wallet):
                 "PAYMENT_FAILED",
             ]
             failed = e.code in failure_codes
+            if failed:
+                return PaymentResponse(
+                    ok=False,
+                    checking_id=payment_hash,
+                    error_message=e.message,
+                )
             return PaymentResponse(
-                ok=None if not failed else False,
-                error_message=e.message if failed else None,
+                ok=None,
+                checking_id=payment_hash,
+                error_message=e.message,
             )
         except Exception as e:
             msg = "Error paying invoice: " + str(e)
             logger.error(msg)
-            # assume pending
-            return PaymentResponse(error_message=msg)
+            # assume pending so the core keeps the payment record
+            # and can settle it later via get_payment_status
+            return PaymentResponse(checking_id=payment_hash)
 
     async def _get_status_via_transactions(
         self, checking_id: str, unpaid_filters: list[bool]


### PR DESCRIPTION
Some NWC transactions were being silently dropped from the DB despite being paid as the transaction is being rolled back at the database level.

The flow:
1. _pay_external_invoice calls create_payment (INSERT) inside a db.connect() transaction
2. NWC pay_invoice sends the request to the rizful relay — the provider processes it
3. But the relay response is lost/delayed, so self.conn.call("pay_invoice", ...) raises an exception
4. The outer except Exception in nwc.py:637 returns PaymentResponse(error_message=msg) — checking_id is None because payment_hash was never extracted
5. _pay_external_invoice sees checking_id is None, marks the payment FAILED, then raises PaymentError
6. The exception propagates out of db.connect() → SQLAlchemy rolls back the entire transaction — the create_payment INSERT is undone
7. The payment record vanishes from the database entirely
8. NWC provider already sent the sats, but LNbits has zero record