### PR TITLE
Add fiat webhook dispatcher for extensions

### DIFF
--- a/lnbits/core/views/callback_api.py
+++ b/lnbits/core/views/callback_api.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Awaitable, Callable
 
 from fastapi import APIRouter, Request
 from loguru import logger
@@ -31,6 +32,82 @@ from lnbits.fiat.square import SquareWallet
 from lnbits.settings import settings
 
 callback_router = APIRouter(prefix="/api/v1/callback", tags=["callback"])
+FiatWebhookHandler = Callable[[str, dict, dict], Awaitable[bool]]
+fiat_webhook_handlers: list[tuple[str, str | None, FiatWebhookHandler]] = []
+
+
+def register_fiat_webhook_handler(
+    provider: str, source: str | None, handler: FiatWebhookHandler
+) -> None:
+    provider = provider.lower()
+    source = source.lower() if source else None
+    handler_key = (provider, source, handler)
+    if handler_key not in fiat_webhook_handlers:
+        fiat_webhook_handlers.append(handler_key)
+
+
+def unregister_fiat_webhook_handler(handler: FiatWebhookHandler) -> None:
+    fiat_webhook_handlers[:] = [
+        registered
+        for registered in fiat_webhook_handlers
+        if registered[2] is not handler
+    ]
+
+
+def _extract_fiat_webhook_metadata(provider: str, event: dict) -> dict:
+    provider = provider.lower()
+    if provider == "stripe":
+        event_object = event.get("data", {}).get("object", {})
+        return event_object.get("metadata") or {}
+
+    if provider == "paypal":
+        resource = event.get("resource", {})
+        custom_id = resource.get("custom_id") or resource.get("custom")
+        if not custom_id:
+            return {}
+        try:
+            metadata = json.loads(custom_id)
+            return metadata if isinstance(metadata, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+
+    if provider == "square":
+        payment = _square_extract_payment(event)
+        note = _square_payment_note(payment)
+        if not note:
+            return {}
+        try:
+            metadata = json.loads(note)
+            return metadata if isinstance(metadata, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+
+    if provider == "revolut":
+        metadata = event.get("metadata") or event.get("merchant_order_data") or {}
+        return metadata if isinstance(metadata, dict) else {}
+
+    return {}
+
+
+async def dispatch_fiat_webhook_event(provider: str, event: dict) -> bool:
+    provider = provider.lower()
+    metadata = _extract_fiat_webhook_metadata(provider, event)
+    source = metadata.get("source")
+    source = source.lower() if isinstance(source, str) else None
+
+    for handler_provider, handler_source, handler in list(fiat_webhook_handlers):
+        if handler_provider != provider:
+            continue
+        if handler_source and handler_source != source:
+            continue
+        handled = await handler(provider, event, metadata)
+        if handled:
+            logger.info(
+                f"Fiat webhook handled by extension handler. Provider: '{provider}'."
+            )
+            return True
+
+    return False
 
 
 @callback_router.post("/{provider_name}")
@@ -45,6 +122,11 @@ async def api_generic_webhook_handler(
             payload, sig_header, settings.stripe_webhook_signing_secret
         )
         event = await request.json()
+        if await dispatch_fiat_webhook_event("stripe", event):
+            return SimpleStatus(
+                success=True,
+                message=f"Callback received successfully from '{provider_name}'.",
+            )
         await handle_stripe_event(event)
 
         return SimpleStatus(
@@ -56,6 +138,11 @@ async def api_generic_webhook_handler(
         payload = await request.body()
         await verify_paypal_webhook(request.headers, payload)
         event = await request.json()
+        if await dispatch_fiat_webhook_event("paypal", event):
+            return SimpleStatus(
+                success=True,
+                message=f"Callback received successfully from '{provider_name}'.",
+            )
         await handle_paypal_event(event)
 
         return SimpleStatus(
@@ -73,6 +160,11 @@ async def api_generic_webhook_handler(
             settings.square_payment_webhook_url,
         )
         event = await request.json()
+        if await dispatch_fiat_webhook_event("square", event):
+            return SimpleStatus(
+                success=True,
+                message=f"Callback received successfully from '{provider_name}'.",
+            )
         await handle_square_event(event)
 
         return SimpleStatus(
@@ -91,6 +183,11 @@ async def api_generic_webhook_handler(
             settings.revolut_webhook_signing_secret,
         )
         event = await request.json()
+        if await dispatch_fiat_webhook_event("revolut", event):
+            return SimpleStatus(
+                success=True,
+                message=f"Callback received successfully from '{provider_name}'.",
+            )
         await handle_revolut_event(event)
 
         return SimpleStatus(

--- a/lnbits/settings.py
+++ b/lnbits/settings.py
@@ -1289,6 +1289,7 @@ class PublicSettings(BaseModel):
     extensions_reviews_url: str = Field(alias="extensionsReviewsUrl")
     ext_builder: bool = Field(alias="extBuilder")
     nostr_configured: bool = Field(alias="nostrConfigured")
+    email_configured: bool = Field(alias="emailConfigured")
     telegram_configured: bool = Field(alias="telegramConfigured")
     wallet_featured_button_label: str | None = Field(alias="walletFeaturedButtonLabel")
     wallet_featured_button_url: str | None = Field(alias="walletFeaturedButtonUrl")
@@ -1353,6 +1354,7 @@ class PublicSettings(BaseModel):
             extensionsReviewsUrl=settings.lnbits_extensions_reviews_url,
             extBuilder=settings.lnbits_extensions_builder_activate_non_admins,
             nostrConfigured=settings.is_nostr_notifications_configured(),
+            emailConfigured=settings.lnbits_email_notifications_enabled,
             telegramConfigured=settings.is_telegram_notifications_configured(),
             walletFeaturedButtonLabel=settings.lnbits_wallet_featured_button_label,
             walletFeaturedButtonUrl=settings.lnbits_wallet_featured_button_url,

--- a/lnbits/static/js/init-app.js
+++ b/lnbits/static/js/init-app.js
@@ -12,15 +12,15 @@ const quasarConfig = {
 const DynamicComponent = {
   async created() {
     const name = this.$route.path.split('/')[1]
-    const path = `/${name}/`
     const routesPath = `/${name}/static/routes.json`
-    if (this.$router.getRoutes().some(r => r.path === path)) return
     if (this.$route.fullPath.startsWith('/extensions/builder/preview')) return
     fetch(routesPath)
       .then(async res => {
         if (!res.ok) throw new Error('No dynamic routes found')
         const routes = await res.json()
+        const routeNames = new Set(this.$router.getRoutes().map(r => r.name))
         routes.forEach(r => {
+          if (routeNames.has(r.name)) return
           console.log('Adding dynamic route:', r.path)
           window.router.addRoute({
             path: r.path,
@@ -39,6 +39,7 @@ const DynamicComponent = {
               return window[r.name]
             }
           })
+          routeNames.add(r.name)
           window.router.push(this.$route.fullPath)
         })
       })


### PR DESCRIPTION
## Summary
Adds a core fiat webhook dispatch hook so extensions can handle verified provider webhook events without claiming shared callback URLs.
Also fixes DynamicComponent extension route loading so extension sub-routes can be added even when the extension root route is already registered.
## Changes
- Add register/unregister helpers for fiat webhook handlers.
- Dispatch verified Stripe, PayPal, Square, and Revolut events to matching extension handlers before existing core fallback handling.
- Extract provider metadata/source for handler matching.
- Deduplicate dynamic extension routes by route name instead of skipping route loading when the extension root path already exists.
## Context
This supports extensions such as SatsPay using the core-owned `/api/v1/callback/{provider}` endpoints while preserving existing core fiat webhook behavior as the fallback path.
Related extension PRs:
- https://github.com/lnbits/events/pull/64
- https://github.com/lnbits/satspay/pull/87