### PR TITLE
Fix: compatibility for postgres

### DIFF
--- a/lnbits/core/crud/extensions.py
+++ b/lnbits/core/crud/extensions.py
@@ -253,13 +253,14 @@ async def get_wasm_invocation_stats(
     since: datetime | None = None,
     conn: Connection | None = None,
 ) -> WasmInvocationStats:
+    database = conn or db
     where: list[str] = []
     values: dict = {}
     if extension_id:
         where.append("extension_id = :extension_id")
         values["extension_id"] = extension_id
     if since:
-        where.append("started_at >= :since")
+        where.append(f"started_at >= {database.timestamp_placeholder('since')}")
         values["since"] = since
 
     query = """
@@ -314,11 +315,13 @@ async def delete_old_wasm_invocations(
         return 0
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
-    result = await (conn or db).execute(
-        """
+    database = conn or db
+    placeholder = database.timestamp_placeholder("cutoff")
+    result = await database.execute(
+        f"""
         DELETE FROM wasm_invocations
-        WHERE status != 'running' AND started_at < :cutoff
-        """,
+        WHERE status != 'running' AND started_at < {placeholder}
+        """,  # noqa: S608
         {"cutoff": cutoff},
     )
     return int(result.rowcount or 0)
@@ -327,13 +330,15 @@ async def delete_old_wasm_invocations(
 async def mark_stale_wasm_invocations(
     conn: Connection | None = None,
 ) -> None:
-    await (conn or db).execute(
-        """
+    database = conn or db
+    placeholder = database.timestamp_placeholder("finished_at")
+    await database.execute(
+        f"""
         UPDATE wasm_invocations
         SET status = 'abandoned',
-            finished_at = :finished_at,
+            finished_at = {placeholder},
             stop_reason = 'Server restarted before invocation finished.'
         WHERE status = 'running'
-        """,
+        """,  # noqa: S608
         {"finished_at": datetime.now(timezone.utc)},
     )

--- a/lnbits/core/crud/extensions.py
+++ b/lnbits/core/crud/extensions.py
@@ -316,11 +316,11 @@ async def delete_old_wasm_invocations(
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     database = conn or db
-    placeholder = database.timestamp_placeholder("cutoff")
     result = await database.execute(
         f"""
         DELETE FROM wasm_invocations
-        WHERE status != 'running' AND started_at < {placeholder}
+        WHERE status != 'running'
+            AND started_at < {database.timestamp_placeholder("cutoff")}
         """,  # noqa: S608
         {"cutoff": cutoff},
     )
@@ -331,12 +331,11 @@ async def mark_stale_wasm_invocations(
     conn: Connection | None = None,
 ) -> None:
     database = conn or db
-    placeholder = database.timestamp_placeholder("finished_at")
     await database.execute(
         f"""
         UPDATE wasm_invocations
         SET status = 'abandoned',
-            finished_at = {placeholder},
+            finished_at = {database.timestamp_placeholder("finished_at")},
             stop_reason = 'Server restarted before invocation finished.'
         WHERE status = 'running'
         """,  # noqa: S608

--- a/lnbits/core/wasm_ext/storage/crud.py
+++ b/lnbits/core/wasm_ext/storage/crud.py
@@ -86,18 +86,21 @@ async def storage_set_row(
     conflict_sql = (
         "DO UPDATE SET "
         + ", ".join(updates)
-        + f" WHERE {OWNER_ID_FIELD} = :{OWNER_ID_FIELD}"
+        + f" WHERE storage_row.{OWNER_ID_FIELD} = :{OWNER_ID_FIELD}"
         if updates
         else "DO NOTHING"
     )
 
     async with Database(f"ext_{ext_id}").connect() as conn:
+        fields = _fields_by_name(table_schema)
         placeholders = [
-            _value_placeholder(conn, _fields_by_name(table_schema)[column], column)
+            f":{column}"
+            if column == OWNER_ID_FIELD
+            else _value_placeholder(conn, fields[column], column)
             for column in columns
         ]
         query = f"""
-            INSERT INTO {_table_ref_for_schema(ext_id, table)}
+            INSERT INTO {_table_ref_for_schema(ext_id, table)} AS storage_row
                 ({", ".join(columns)})
             VALUES
                 ({", ".join(placeholders)})

--- a/lnbits/core/wasm_ext/storage/crud.py
+++ b/lnbits/core/wasm_ext/storage/crud.py
@@ -12,7 +12,7 @@ from lnbits.core.crud import update_migration_version
 from lnbits.core.db import db as core_db
 from lnbits.core.models import DbVersion
 from lnbits.core.models.extensions import InstallableExtension
-from lnbits.db import POSTGRES, SQLITE, Connection, Database
+from lnbits.db import POSTGRES, SQLITE, Compat, Connection, Database
 from lnbits.settings import settings
 
 _MIGRATION_FILE_RE = re.compile(r"^(\d+)_.*\.json$")
@@ -78,7 +78,6 @@ async def storage_set_row(
     clean_data = _data_to_db(table_schema, data, require_id=True)
     clean_data[OWNER_ID_FIELD] = owner_id
     columns = list(clean_data.keys())
-    placeholders = [f":{column}" for column in columns]
     updates = [
         f"{column} = excluded.{column}"
         for column in columns
@@ -91,15 +90,19 @@ async def storage_set_row(
         if updates
         else "DO NOTHING"
     )
-    query = f"""
-        INSERT INTO {_table_ref_for_schema(ext_id, table)}
-            ({", ".join(columns)})
-        VALUES
-            ({", ".join(placeholders)})
-        ON CONFLICT (id) {conflict_sql}
-    """  # noqa: S608
 
     async with Database(f"ext_{ext_id}").connect() as conn:
+        placeholders = [
+            _value_placeholder(conn, _fields_by_name(table_schema)[column], column)
+            for column in columns
+        ]
+        query = f"""
+            INSERT INTO {_table_ref_for_schema(ext_id, table)}
+                ({", ".join(columns)})
+            VALUES
+                ({", ".join(placeholders)})
+            ON CONFLICT (id) {conflict_sql}
+        """  # noqa: S608
         await conn.execute(query, clean_data)
 
 
@@ -117,27 +120,28 @@ async def storage_get_paginated_rows(
     offset: int,
 ) -> dict[str, Any]:
     table_schema = _load_table_schema(ext_id, table)
-    where_sql, values = _where_sql(table_schema, filters, search, search_fields)
-    where_sql = _append_owner_where_sql(where_sql)
-    values[OWNER_ID_FIELD] = owner_id
-    order_sql = _order_sql(table_schema, sort_by, descending)
-    count_values = dict(values)
-    values.update({"limit": min(limit, 1000), "offset": offset})
-
     table_ref = _table_ref_for_schema(ext_id, table)
-    rows_query = f"""
-        SELECT * FROM {table_ref}
-        {where_sql}
-        {order_sql}
-        LIMIT :limit
-        OFFSET :offset
-    """  # noqa: S608
-    count_query = f"""
-        SELECT COUNT(*) AS count FROM {table_ref}
-        {where_sql}
-    """  # noqa: S608
 
     async with Database(f"ext_{ext_id}").connect() as conn:
+        where_sql, values = _where_sql(
+            conn, table_schema, filters, search, search_fields
+        )
+        where_sql = _append_owner_where_sql(where_sql)
+        values[OWNER_ID_FIELD] = owner_id
+        order_sql = _order_sql(table_schema, sort_by, descending)
+        count_values = dict(values)
+        values.update({"limit": min(limit, 1000), "offset": offset})
+        rows_query = f"""
+            SELECT * FROM {table_ref}
+            {where_sql}
+            {order_sql}
+            LIMIT :limit
+            OFFSET :offset
+        """  # noqa: S608
+        count_query = f"""
+            SELECT COUNT(*) AS count FROM {table_ref}
+            {where_sql}
+        """  # noqa: S608
         rows = await conn.fetchall(rows_query, values)
         count_row = await conn.fetchone(count_query, count_values)
 
@@ -403,14 +407,25 @@ def _filters_to_db(
     }
 
 
+def _value_placeholder(db: Compat, field: dict[str, Any], key: str) -> str:
+    if field.get("type") == "datetime" and not field.get("list"):
+        return db.timestamp_placeholder(key)
+    return f":{key}"
+
+
 def _where_sql(
+    db: Compat,
     table_schema: dict[str, Any],
     filters: dict[str, Any],
     search: str | None,
     search_fields: list[str],
 ) -> tuple[str, dict[str, Any]]:
     clean_filters = _filters_to_db(table_schema, filters)
-    clauses = [f"{field} = :filter_{field}" for field in clean_filters]
+    fields = _fields_by_name(table_schema)
+    clauses = [
+        f"{field} = {_value_placeholder(db, fields[field], f'filter_{field}')}"
+        for field in clean_filters
+    ]
     values = {f"filter_{field}": value for field, value in clean_filters.items()}
 
     clean_search = search.strip().lower() if search else ""

--- a/lnbits/core/wasm_ext/storage/crud.py
+++ b/lnbits/core/wasm_ext/storage/crud.py
@@ -76,8 +76,16 @@ async def storage_set_row(
 ) -> None:
     table_schema = _load_table_schema(ext_id, table)
     clean_data = _data_to_db(table_schema, data, require_id=True)
-    clean_data[OWNER_ID_FIELD] = owner_id
     columns = list(clean_data.keys())
+    database = Database(f"ext_{ext_id}")
+    fields = _fields_by_name(table_schema)
+    placeholders = [
+        _value_placeholder(database, fields[column], column) for column in columns
+    ]
+
+    clean_data[OWNER_ID_FIELD] = owner_id
+    columns.append(OWNER_ID_FIELD)
+    placeholders.append(f":{OWNER_ID_FIELD}")
     updates = [
         f"{column} = excluded.{column}"
         for column in columns
@@ -90,11 +98,6 @@ async def storage_set_row(
         if updates
         else "DO NOTHING"
     )
-    database = Database(f"ext_{ext_id}")
-    fields = _fields_by_name(table_schema)
-    placeholders = [
-        _value_placeholder(database, fields.get(column), column) for column in columns
-    ]
     query = f"""
         INSERT INTO {_table_ref_for_schema(ext_id, table)} AS storage_row
             ({", ".join(columns)})
@@ -410,8 +413,8 @@ def _filters_to_db(
     }
 
 
-def _value_placeholder(db: Compat, field: dict[str, Any] | None, key: str) -> str:
-    if field and field.get("type") == "datetime" and not field.get("list"):
+def _value_placeholder(db: Compat, field: dict[str, Any], key: str) -> str:
+    if field.get("type") == "datetime" and not field.get("list"):
         return db.timestamp_placeholder(key)
     return f":{key}"
 

--- a/lnbits/core/wasm_ext/storage/crud.py
+++ b/lnbits/core/wasm_ext/storage/crud.py
@@ -94,9 +94,11 @@ async def storage_set_row(
     async with Database(f"ext_{ext_id}").connect() as conn:
         fields = _fields_by_name(table_schema)
         placeholders = [
-            f":{column}"
-            if column == OWNER_ID_FIELD
-            else _value_placeholder(conn, fields[column], column)
+            (
+                f":{column}"
+                if column == OWNER_ID_FIELD
+                else _value_placeholder(conn, fields[column], column)
+            )
             for column in columns
         ]
         query = f"""

--- a/lnbits/core/wasm_ext/storage/crud.py
+++ b/lnbits/core/wasm_ext/storage/crud.py
@@ -90,24 +90,20 @@ async def storage_set_row(
         if updates
         else "DO NOTHING"
     )
+    database = Database(f"ext_{ext_id}")
+    fields = _fields_by_name(table_schema)
+    placeholders = [
+        _value_placeholder(database, fields.get(column), column) for column in columns
+    ]
+    query = f"""
+        INSERT INTO {_table_ref_for_schema(ext_id, table)} AS storage_row
+            ({", ".join(columns)})
+        VALUES
+            ({", ".join(placeholders)})
+        ON CONFLICT (id) {conflict_sql}
+    """  # noqa: S608
 
-    async with Database(f"ext_{ext_id}").connect() as conn:
-        fields = _fields_by_name(table_schema)
-        placeholders = [
-            (
-                f":{column}"
-                if column == OWNER_ID_FIELD
-                else _value_placeholder(conn, fields[column], column)
-            )
-            for column in columns
-        ]
-        query = f"""
-            INSERT INTO {_table_ref_for_schema(ext_id, table)} AS storage_row
-                ({", ".join(columns)})
-            VALUES
-                ({", ".join(placeholders)})
-            ON CONFLICT (id) {conflict_sql}
-        """  # noqa: S608
+    async with database.connect() as conn:
         await conn.execute(query, clean_data)
 
 
@@ -125,28 +121,30 @@ async def storage_get_paginated_rows(
     offset: int,
 ) -> dict[str, Any]:
     table_schema = _load_table_schema(ext_id, table)
-    table_ref = _table_ref_for_schema(ext_id, table)
+    database = Database(f"ext_{ext_id}")
+    where_sql, values = _where_sql(
+        database, table_schema, filters, search, search_fields
+    )
+    where_sql = _append_owner_where_sql(where_sql)
+    values[OWNER_ID_FIELD] = owner_id
+    order_sql = _order_sql(table_schema, sort_by, descending)
+    count_values = dict(values)
+    values.update({"limit": min(limit, 1000), "offset": offset})
 
-    async with Database(f"ext_{ext_id}").connect() as conn:
-        where_sql, values = _where_sql(
-            conn, table_schema, filters, search, search_fields
-        )
-        where_sql = _append_owner_where_sql(where_sql)
-        values[OWNER_ID_FIELD] = owner_id
-        order_sql = _order_sql(table_schema, sort_by, descending)
-        count_values = dict(values)
-        values.update({"limit": min(limit, 1000), "offset": offset})
-        rows_query = f"""
-            SELECT * FROM {table_ref}
-            {where_sql}
-            {order_sql}
-            LIMIT :limit
-            OFFSET :offset
-        """  # noqa: S608
-        count_query = f"""
-            SELECT COUNT(*) AS count FROM {table_ref}
-            {where_sql}
-        """  # noqa: S608
+    table_ref = _table_ref_for_schema(ext_id, table)
+    rows_query = f"""
+        SELECT * FROM {table_ref}
+        {where_sql}
+        {order_sql}
+        LIMIT :limit
+        OFFSET :offset
+    """  # noqa: S608
+    count_query = f"""
+        SELECT COUNT(*) AS count FROM {table_ref}
+        {where_sql}
+    """  # noqa: S608
+
+    async with database.connect() as conn:
         rows = await conn.fetchall(rows_query, values)
         count_row = await conn.fetchone(count_query, count_values)
 
@@ -412,8 +410,8 @@ def _filters_to_db(
     }
 
 
-def _value_placeholder(db: Compat, field: dict[str, Any], key: str) -> str:
-    if field.get("type") == "datetime" and not field.get("list"):
+def _value_placeholder(db: Compat, field: dict[str, Any] | None, key: str) -> str:
+    if field and field.get("type") == "datetime" and not field.get("list"):
         return db.timestamp_placeholder(key)
     return f":{key}"
 

--- a/tests/unit/test_wasm_extension_storage.py
+++ b/tests/unit/test_wasm_extension_storage.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 from uuid import uuid4
 
 import pytest
@@ -15,6 +17,7 @@ from lnbits.core.migrations import (
     m048_add_wasm_runtime_limits_to_installed_extensions,
 )
 from lnbits.core.models.extensions import ExtensionPermission, WasmInvocation
+from lnbits.core.wasm_ext.storage import crud as storage_crud
 from lnbits.core.wasm_ext.storage.crud import (
     OWNER_ID_FIELD,
     migrate_wasm_extension_database,
@@ -24,7 +27,7 @@ from lnbits.core.wasm_ext.storage.crud import (
     storage_get_row,
     storage_set_row,
 )
-from lnbits.db import Database
+from lnbits.db import Compat, Connection, Database
 from lnbits.settings import Settings
 from tests.helpers import make_installable_extension
 
@@ -172,6 +175,39 @@ async def test_wasm_invocation_crud_stats_and_cleanup_are_isolated(
     assert stats.storage_call_count == 2
     assert deleted == 1
     assert [invocation.id for invocation in remaining_running] == [invocations[2].id]
+
+
+@pytest.mark.anyio
+async def test_wasm_datetime_queries_use_postgres_placeholders(
+    mocker: MockerFixture,
+):
+    db = mocker.Mock()
+    db.timestamp_placeholder.side_effect = lambda key: f"to_timestamp(:{key})"
+    db.fetchone = mocker.AsyncMock(return_value=None)
+    db.execute = mocker.AsyncMock(return_value=SimpleNamespace(rowcount=0))
+
+    field = {"name": "created_at", "type": "datetime"}
+    assert (
+        storage_crud._value_placeholder(cast(Compat, db), field, "created_at")
+        == "to_timestamp(:created_at)"
+    )
+    where_sql, _ = storage_crud._where_sql(
+        cast(Compat, db), {"fields": [field]}, {"created_at": 0}, None, []
+    )
+    assert "created_at = to_timestamp(:filter_created_at)" in where_sql
+
+    conn = cast(Connection, db)
+    await extension_crud.get_wasm_invocation_stats(
+        since=datetime.now(timezone.utc), conn=conn
+    )
+    await extension_crud.delete_old_wasm_invocations(1, conn=conn)
+    await extension_crud.mark_stale_wasm_invocations(conn=conn)
+
+    queries = [
+        db.fetchone.call_args.args[0],
+        *[c.args[0] for c in db.execute.call_args_list],
+    ]
+    assert all("to_timestamp(:" in query for query in queries)
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_wasm_extension_storage.py
+++ b/tests/unit/test_wasm_extension_storage.py
@@ -10,6 +10,7 @@ from pytest_mock.plugin import MockerFixture
 
 from lnbits.core.crud import extensions as extension_crud
 from lnbits.core.crud import update_migration_version
+from lnbits.core.db import db as core_db
 from lnbits.core.migrations import (
     m010_create_installed_extensions_table,
     m046_add_permissions_to_installed_extensions,
@@ -27,7 +28,7 @@ from lnbits.core.wasm_ext.storage.crud import (
     storage_get_row,
     storage_set_row,
 )
-from lnbits.db import Compat, Connection, Database
+from lnbits.db import DB_TYPE, SQLITE, Compat, Connection, Database
 from lnbits.settings import Settings
 from tests.helpers import make_installable_extension
 
@@ -36,6 +37,9 @@ from tests.helpers import make_installable_extension
 async def test_core_wasm_migrations_create_persistent_columns(
     tmp_path: Path, settings: Settings
 ):
+    if DB_TYPE != SQLITE:
+        pytest.skip("temporary core databases are SQLite-only")
+
     db = _temporary_database(tmp_path, settings, "wasm_core_migrations")
 
     async with db.connect() as conn:
@@ -69,6 +73,7 @@ async def test_core_wasm_migrations_create_persistent_columns(
 
 @pytest.mark.anyio
 async def test_installed_extension_permissions_and_wasm_limits_round_trip(
+    app,
     tmp_path: Path,
     settings: Settings,
     mocker: MockerFixture,
@@ -98,6 +103,7 @@ async def test_installed_extension_permissions_and_wasm_limits_round_trip(
 
 @pytest.mark.anyio
 async def test_wasm_invocation_crud_stats_and_cleanup_are_isolated(
+    app,
     tmp_path: Path,
     settings: Settings,
     mocker: MockerFixture,
@@ -348,6 +354,9 @@ async def _temporary_core_crud_database(
     tmp_path: Path,
     settings: Settings,
 ) -> Database:
+    if DB_TYPE != SQLITE:
+        return core_db
+
     db = _temporary_database(tmp_path, settings, f"core_{uuid4().hex[:8]}")
     async with db.connect() as conn:
         await conn.execute("""


### PR DESCRIPTION
There was a timestamp compatibility issue with PostgreSQL. WASM storage uses Unix timestamps, but PostgreSQL expects timestamp values. It now uses LNbits existing timestamp_placeholder helper to convert them into the correct database format. A small _value_placeholder helper was added to apply this conversion only to datetime fields.