### PR TITLE
fix: Infinite invoice listener loop with VoidWallet

### DIFF
--- a/lnbits/wallets/void.py
+++ b/lnbits/wallets/void.py
@@ -1,5 +1,3 @@
-from collections.abc import AsyncGenerator
-
 from loguru import logger
 
 from .base import (
@@ -40,6 +38,3 @@ class VoidWallet(Wallet):
 
     async def get_payment_status(self, *_, **__) -> PaymentStatus:
         return PaymentPendingStatus()
-
-    async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:
-        yield ""


### PR DESCRIPTION
Removes the `VoidWallet.paid_invoices_stream()` override.

**Issue**

VoidWallet yielded an empty checking ID and immediately completed. Since the funding-source invoice producer is registered as a permanent task, it restarted immediately and repeatedly logged:

`No incoming payment found for ''.`

This affects fresh installations because `VoidWallet` is the default backend.

**Why removing should be safe**

The override was added when `paid_invoices_stream()` was abstract and every wallet needed to provide an async generator implementation.

`Wallet` now provides a fallback stream that polls pending invoices and sleeps. `VoidWallet` has no pending invoices, so inheriting it correctly keeps the listener idle without emitting a fake payment notification or causing a restart loop.