### PR TITLE
fix(nwc): prevent false payment failures on NWC provider sync delay

### DIFF
--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -405,7 +405,7 @@ class NWCWallet(Wallet):
             await self._reconcile_pending_invoices(now)
 
         await self._run_fallback_lookups(now)
-        self._prune_payment_status_cache(self._cache_ids())
+        self._prune_payment_status_cache()
 
     def _payment_data_is_settled(self, payment_data: dict[str, Any]) -> bool:
         state = payment_data.get("state")

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -86,6 +86,7 @@ class NWCWallet(Wallet):
             nwc_data["relay"],
             notification_handler=self._handle_notification,
         )
+        self.pending_invoices: list[str] = []
         self.pending_invoice_details: dict[str, dict[str, Any]] = {}
         self.payment_status_cache: dict[str, dict[str, Any]] = {}
         self.payment_status_cache_pending_ttl = 30

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import Any, cast
 from urllib.parse import parse_qs, unquote, urlparse
 
+from bolt11 import Bolt11Exception
 from bolt11 import decode as bolt11_decode
 from coincurve import PrivateKey, PublicKey
 from Cryptodome.Cipher import ChaCha20
@@ -243,7 +244,6 @@ class NWCWallet(Wallet):
                     "until": int(now),
                     "limit": limit,
                     "offset": offset,
-                    "type": "incoming",
                     "unpaid": unpaid,
                 },
             )
@@ -580,10 +580,18 @@ class NWCWallet(Wallet):
 
     async def pay_invoice(self, bolt11: str, fee_limit_msat: int) -> PaymentResponse:
         try:
-            resp = await self.conn.call("pay_invoice", {"invoice": bolt11})
-            preimage = resp.get("preimage", None)
             invoice_data = bolt11_decode(bolt11)
             payment_hash = invoice_data.payment_hash
+        except Bolt11Exception as exc:
+            logger.error("Error decoding invoice: " + str(exc))
+            return PaymentResponse(
+                ok=False,
+                checking_id=None,
+                error_message="Invalid invoice: " + str(exc),
+            )
+        try:
+            resp = await self.conn.call("pay_invoice", {"invoice": bolt11})
+            preimage = resp.get("preimage", None)
             # pay_invoice doesn't return payment data, so we need
             # to call lookup_invoice too (if supported)
             await self.conn.get_info()
@@ -594,9 +602,24 @@ class NWCWallet(Wallet):
                     ok=True, checking_id=payment_hash, preimage=preimage, fee_msat=0
                 )
 
+            # Cache the successful pay_invoice response so status checks
+            # can use it if lookup_invoice is not yet consistent.
+            self._cache_payment_data(
+                payment_hash,
+                {
+                    "payment_hash": payment_hash,
+                    "preimage": preimage,
+                    "settled_at": int(time.time()),
+                    "state": "settled",
+                    "amount": invoice_data.amount_msat,
+                    "fees_paid": resp.get("fees_paid", None),
+                    "type": "outgoing",
+                },
+            )
+
             try:
                 payment_data = await self.conn.call(
-                    "lookup_invoice", {"invoice": bolt11}
+                    "lookup_invoice", {"payment_hash": payment_hash}
                 )
                 settled = payment_data.get("settled_at", None) and payment_data.get(
                     "preimage", None
@@ -630,13 +653,15 @@ class NWCWallet(Wallet):
             failed = e.code in failure_codes
             return PaymentResponse(
                 ok=None if not failed else False,
+                checking_id=payment_hash,
                 error_message=e.message if failed else None,
             )
         except Exception as e:
             msg = "Error paying invoice: " + str(e)
             logger.error(msg)
-            # assume pending
-            return PaymentResponse(error_message=msg)
+            # assume pending so the core keeps the payment record
+            # and can settle it later via get_payment_status
+            return PaymentResponse(checking_id=payment_hash)
 
     async def _get_status_via_transactions(
         self, checking_id: str, unpaid_filters: list[bool]
@@ -698,10 +723,16 @@ class NWCWallet(Wallet):
             return status or PaymentStatus(None, fee_msat=None, preimage=None)
         except NWCError as e:
             logger.error("Error getting payment status: " + str(e))
-            failed = e.code == "NOT_FOUND"
-            return PaymentStatus(
-                None if not failed else False, fee_msat=None, preimage=None
-            )
+            if e.code == "NOT_FOUND":
+                # The NWC provider hasn't indexed the payment yet, but we may
+                # have cached a successful pay_invoice response with the
+                # preimage. Check the cache before declaring the payment
+                # failed.
+                cached = self._get_cached_payment_data(checking_id)
+                if cached and self._payment_data_is_settled(cached):
+                    return self._payment_data_to_status(cached)
+                return PaymentStatus(False, fee_msat=None, preimage=None)
+            return PaymentStatus(None, fee_msat=None, preimage=None)
         except Exception as e:
             logger.error("Error getting payment status: " + str(e))
             # assume pending (eg. exception due to network error)

--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -431,11 +431,25 @@ class NWCWallet(Wallet):
     def _payment_data_to_status(self, payment_data: dict[str, Any]) -> PaymentStatus:
         fee_msat = payment_data.get("fees_paid", None)
         preimage = payment_data.get("preimage", None)
+        if self._payment_data_needs_fees(payment_data):
+            # The core finalizes missing fees as zero and stops checking success.
+            return PaymentStatus(None, fee_msat=None, preimage=preimage)
         if self._payment_data_is_settled(payment_data):
             return PaymentStatus(True, fee_msat=fee_msat, preimage=preimage)
         if self._payment_data_is_failed(payment_data):
             return PaymentStatus(False, fee_msat=fee_msat, preimage=preimage)
         return PaymentStatus(None, fee_msat=fee_msat, preimage=preimage)
+
+    def _payment_data_needs_fees(self, payment_data: dict[str, Any]) -> bool:
+        return (
+            payment_data.get("type") == "outgoing"
+            and self._payment_data_is_settled(payment_data)
+            and payment_data.get("fees_paid") is None
+            and (
+                self.conn.supports_method("lookup_invoice")
+                or self.conn.supports_method("list_transactions")
+            )
+        )
 
     def _cache_payment_data(
         self,
@@ -444,6 +458,24 @@ class NWCWallet(Wallet):
         cached_at: float | None = None,
     ) -> None:
         cached_at = cached_at or time.time()
+        cached = self._get_cached_payment_data(checking_id)
+        if (
+            cached
+            and cached.get("type") == "outgoing"
+            and self._payment_data_is_settled(cached)
+        ):
+            # Delayed lookups must not overwrite proof of settlement. Enrich it
+            # with fees and other details once the provider catches up.
+            if not self._payment_data_is_settled(payment_data):
+                return
+            payment_data = {
+                **cached,
+                **{
+                    key: value
+                    for key, value in payment_data.items()
+                    if value is not None
+                },
+            }
         ttl = (
             self.payment_status_cache_terminal_ttl
             if self._payment_data_is_settled(payment_data)
@@ -593,15 +625,8 @@ class NWCWallet(Wallet):
         try:
             resp = await self.conn.call("pay_invoice", {"invoice": bolt11})
             preimage = resp.get("preimage", None)
-            # pay_invoice doesn't return payment data, so we need
-            # to call lookup_invoice too (if supported)
-            await self.conn.get_info()
-
-            if not self.conn.supports_method("lookup_invoice"):
-                # if not supported, we assume it succeeded
-                return PaymentResponse(
-                    ok=True, checking_id=payment_hash, preimage=preimage, fee_msat=0
-                )
+            if not preimage:
+                return PaymentResponse(checking_id=payment_hash)
 
             # Cache the successful pay_invoice response so status checks
             # can use it if lookup_invoice is not yet consistent.
@@ -618,28 +643,13 @@ class NWCWallet(Wallet):
                 },
             )
 
-            try:
-                payment_data = await self.conn.call(
-                    "lookup_invoice", {"payment_hash": payment_hash}
-                )
-                settled = payment_data.get("settled_at", None) and payment_data.get(
-                    "preimage", None
-                )
-                if not settled:
-                    return PaymentResponse(checking_id=payment_hash)
-                else:
-                    fee_msat = payment_data.get("fees_paid", None)
-                    return PaymentResponse(
-                        ok=True,
-                        checking_id=payment_hash,
-                        fee_msat=fee_msat,
-                        preimage=preimage,
-                    )
-            except Exception:
-                # Workaround: some nwc service providers might not store the invoice
-                # right away, so this call may raise an exception.
-                # We will assume the payment is pending anyway
-                return PaymentResponse(checking_id=payment_hash)
+            status = await self.get_payment_status(payment_hash)
+            return PaymentResponse(
+                ok=status.paid,
+                checking_id=payment_hash,
+                fee_msat=(status.fee_msat or 0) if status.success else None,
+                preimage=status.preimage,
+            )
         except NWCError as e:
             logger.error("Error paying invoice: " + str(e))
             failure_codes = [
@@ -670,7 +680,7 @@ class NWCWallet(Wallet):
         keep_ids = self._cache_ids(checking_id)
         self._prune_payment_status_cache()
         payment_data = self._get_cached_payment_data(checking_id)
-        if payment_data:
+        if payment_data and not self._payment_data_needs_fees(payment_data):
             return self._payment_data_to_status(payment_data)
 
         if self.conn.supports_method("list_transactions"):
@@ -690,7 +700,7 @@ class NWCWallet(Wallet):
                     unpaid=unpaid,
                 )
                 payment_data = self._get_cached_payment_data(checking_id)
-                if payment_data:
+                if payment_data and not self._payment_data_needs_fees(payment_data):
                     return self._payment_data_to_status(payment_data)
 
         if self.conn.supports_method("lookup_invoice"):
@@ -698,6 +708,7 @@ class NWCWallet(Wallet):
                 "lookup_invoice", {"payment_hash": checking_id}
             )
             self._cache_payment_data(checking_id, payment_data)
+            payment_data = self._get_cached_payment_data(checking_id) or payment_data
             return self._payment_data_to_status(payment_data)
 
         return None
@@ -724,20 +735,14 @@ class NWCWallet(Wallet):
             return status or PaymentStatus(None, fee_msat=None, preimage=None)
         except NWCError as e:
             logger.error("Error getting payment status: " + str(e))
-            if e.code == "NOT_FOUND":
-                # The NWC provider hasn't indexed the payment yet, but we may
-                # have cached a successful pay_invoice response with the
-                # preimage. Check the cache before declaring the payment
-                # failed.
-                cached = self._get_cached_payment_data(checking_id)
-                if cached and self._payment_data_is_settled(cached):
-                    return self._payment_data_to_status(cached)
-                return PaymentStatus(False, fee_msat=None, preimage=None)
-            return PaymentStatus(None, fee_msat=None, preimage=None)
         except Exception as e:
             logger.error("Error getting payment status: " + str(e))
-            # assume pending (eg. exception due to network error)
-            return PaymentStatus(None, fee_msat=None, preimage=None)
+        # NOT_FOUND can mean the payment has not been indexed yet, including
+        # when the pay_invoice response was lost. Only explicit failure is final.
+        cached = self._get_cached_payment_data(checking_id)
+        if cached and self._payment_data_is_settled(cached):
+            return self._payment_data_to_status(cached)
+        return PaymentStatus(None, fee_msat=None, preimage=None)
 
     async def paid_invoices_stream(self) -> AsyncGenerator[str, None]:
         while not self._is_shutting_down():

--- a/tests/unit/test_wallet_payment_ambiguity.py
+++ b/tests/unit/test_wallet_payment_ambiguity.py
@@ -449,6 +449,10 @@ async def test_nwc_only_explicit_payment_failure_is_failed(
     cast(Any, wallet).conn = SimpleNamespace(
         call=mocker.AsyncMock(side_effect=NWCError(code, "error"))
     )
+    mocker.patch(
+        "lnbits.wallets.nwc.bolt11_decode",
+        return_value=SimpleNamespace(payment_hash="payment-hash"),
+    )
 
     response = await wallet.pay_invoice("bolt11", 1_000)
 

--- a/tests/wallets/fixtures/json/fixtures_nwc.json
+++ b/tests/wallets/fixtures/json/fixtures_nwc.json
@@ -230,7 +230,7 @@
                   "request_body": {
                     "method": "lookup_invoice",
                     "params": {
-                      "invoice": "lnbc210n1pjlgal5sp5xr3uwlfm7ltumdjyukhys0z2rw6grgm8me9k4w9vn05zt9svzzjspp5ud2jdfpaqn5c2k2vphatsjypfafyk8rcvkvwexnrhmwm94ex4jtqdqu24hxjapq23jhxapqf9h8vmmfvdjscqpjrzjqta942048v7qxh5x7pxwplhmtwfl0f25cq23jh87rhx7lgrwwvv86r90guqqnwgqqqqqqqqqqqqqqpsqyg9qxpqysgqylngsyg960lltngzy90e8n22v4j2hvjs4l4ttuy79qqefjv8q87q9ft7uhwdjakvnsgk44qyhalv6ust54x98whl3q635hkwgsyw8xgqjl7jwu"
+                      "payment_hash": "e35526a43d04e985594c0dfab848814f524b1c786598ec9a63beddb2d726ac96"
                     }
                   },
                   "response_type": "json",

--- a/tests/wallets/test_nwc_wallets.py
+++ b/tests/wallets/test_nwc_wallets.py
@@ -3,6 +3,7 @@ import base64
 import hashlib
 import json
 import time
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -13,7 +14,7 @@ from Cryptodome.Util.Padding import pad, unpad
 from websockets import ServerConnection
 from websockets import serve as ws_serve
 
-from lnbits.wallets.nwc import NWCConnection, NWCWallet
+from lnbits.wallets.nwc import NWCConnection, NWCError, NWCWallet
 from tests.wallets.helpers import (
     WalletTest,
     build_test_id,
@@ -301,6 +302,198 @@ async def test_nwc_spreads_fallback_lookups_with_cooldown(mocker):
 
     assert wallet.conn.call.await_count == 2
     sleep_mock.assert_awaited_once_with(1.0)
+
+
+@pytest.fixture
+def nwc_payment_wallet(mocker):
+    conn = mocker.Mock(spec=NWCConnection)
+    conn.get_info = mocker.AsyncMock(return_value={})
+    conn.call = mocker.AsyncMock()
+    conn.supports_method.side_effect = lambda method: method == "lookup_invoice"
+    mocker.patch("lnbits.wallets.nwc.NWCConnection", return_value=conn)
+    mocker.patch(
+        "lnbits.wallets.nwc.parse_nwc",
+        return_value={"pubkey": "pubkey", "secret": "secret", "relay": "relay"},
+    )
+    mocker.patch(
+        "lnbits.wallets.nwc.bolt11_decode",
+        return_value=SimpleNamespace(payment_hash="payment-hash", amount_msat=1000),
+    )
+    return NWCWallet()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("fee_msat", [0, 123])
+@pytest.mark.parametrize(
+    "delayed_lookup",
+    [
+        NWCError("NOT_FOUND", "Not indexed yet"),
+        {"type": "outgoing", "state": "pending", "fees_paid": 0},
+        {"type": "outgoing", "state": "settled", "preimage": "01" * 32},
+    ],
+)
+async def test_nwc_waits_for_payment_fees(nwc_payment_wallet, delayed_lookup, fee_msat):
+    wallet = nwc_payment_wallet
+    preimage = "01" * 32
+    wallet.conn.call.side_effect = [
+        {"preimage": preimage},
+        delayed_lookup,
+        delayed_lookup,
+        {"type": "outgoing", "state": "settled", "fees_paid": fee_msat},
+    ]
+
+    response = await wallet.pay_invoice("bolt11", 1000)
+    assert response.ok is None
+    assert response.checking_id == "payment-hash"
+
+    status = await wallet.get_payment_status("payment-hash")
+    assert status.paid is None
+    assert status.preimage == preimage
+
+    status = await wallet.get_payment_status("payment-hash")
+    assert status.paid is True
+    assert status.fee_msat == fee_msat
+    assert status.preimage == preimage
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("preimage", [None, ""])
+async def test_nwc_missing_preimage_stays_pending(nwc_payment_wallet, preimage):
+    wallet = nwc_payment_wallet
+    wallet.conn.call.side_effect = [
+        {"preimage": preimage},
+        {"type": "outgoing", "state": "pending"},
+    ]
+
+    response = await wallet.pay_invoice("bolt11", 1000)
+
+    assert response.ok is None
+    assert response.checking_id == "payment-hash"
+    assert wallet._get_cached_payment_data("payment-hash") is None
+    status = await wallet.get_payment_status("payment-hash")
+    assert status.paid is None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "error",
+    [
+        TimeoutError("Payment response lost"),
+        NWCError("INTERNAL", "Payment response lost"),
+        NWCError("OTHER", "Payment response lost"),
+    ],
+)
+async def test_nwc_reconciles_payment_after_lost_response(nwc_payment_wallet, error):
+    wallet = nwc_payment_wallet
+    wallet.conn.call.side_effect = [
+        error,
+        NWCError("NOT_FOUND", "Not indexed yet"),
+        {
+            "type": "outgoing",
+            "state": "settled",
+            "fees_paid": 123,
+            "preimage": "01" * 32,
+        },
+    ]
+
+    response = await wallet.pay_invoice("bolt11", 1000)
+    assert response.ok is None
+    assert response.checking_id == "payment-hash"
+    status = await wallet.get_payment_status("payment-hash")
+    assert status.paid is None
+    status = await wallet.get_payment_status("payment-hash")
+    assert status.paid is True
+    assert status.fee_msat == 123
+
+
+@pytest.mark.anyio
+async def test_nwc_reconciles_explicit_payment_failure(nwc_payment_wallet):
+    wallet = nwc_payment_wallet
+    wallet.conn.call.side_effect = [
+        TimeoutError("Payment response lost"),
+        {"type": "outgoing", "state": "failed"},
+    ]
+
+    response = await wallet.pay_invoice("bolt11", 1000)
+    assert response.ok is None
+    status = await wallet.get_payment_status("payment-hash")
+    assert status.paid is False
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("fee_msat", [0, 123])
+async def test_nwc_uses_payment_response_with_fees(nwc_payment_wallet, fee_msat):
+    wallet = nwc_payment_wallet
+    preimage = "01" * 32
+    wallet.conn.call.side_effect = [
+        {"preimage": preimage, "fees_paid": fee_msat},
+        NWCError("NOT_FOUND", "Not indexed yet"),
+    ]
+
+    response = await wallet.pay_invoice("bolt11", 1000)
+    status = await wallet.get_payment_status("payment-hash")
+
+    assert response.ok is True
+    assert response.fee_msat == fee_msat
+    assert status.paid is True
+    assert status.fee_msat == fee_msat
+    assert status.preimage == preimage
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("preimage", [None, "01" * 32])
+async def test_nwc_pay_only_provider_requires_preimage(nwc_payment_wallet, preimage):
+    wallet = nwc_payment_wallet
+    wallet.conn.supports_method.side_effect = lambda method: False
+    wallet.conn.call.return_value = {"preimage": preimage}
+
+    response = await wallet.pay_invoice("bolt11", 1000)
+
+    assert response.ok is (True if preimage else None)
+    assert response.checking_id == "payment-hash"
+    if preimage:
+        assert response.fee_msat == 0
+
+
+@pytest.mark.anyio
+async def test_nwc_reconciles_fees_via_transactions(nwc_payment_wallet):
+    wallet = nwc_payment_wallet
+    wallet.conn.supports_method.side_effect = (
+        lambda method: method == "list_transactions"
+    )
+    wallet.transactions_refresh_interval = 0
+    wallet.conn.call.side_effect = [
+        {"preimage": "01" * 32},
+        {"transactions": []},
+        {
+            "transactions": [
+                {
+                    "payment_hash": "payment-hash",
+                    "type": "outgoing",
+                    "state": "settled",
+                    "fees_paid": 123,
+                }
+            ]
+        },
+    ]
+
+    response = await wallet.pay_invoice("bolt11", 1000)
+    assert response.ok is None
+    status = await wallet.get_payment_status("payment-hash")
+    assert status.paid is True
+    assert status.fee_msat == 123
+    assert status.preimage == "01" * 32
+    assert wallet.conn.call.call_args.args[0] == "list_transactions"
+
+
+@pytest.mark.anyio
+async def test_nwc_incoming_settlement_does_not_wait_for_fees(nwc_payment_wallet):
+    wallet = nwc_payment_wallet
+    wallet.conn.call.return_value = {"type": "incoming", "state": "settled"}
+
+    status = await wallet.get_invoice_status("payment-hash")
+
+    assert status.paid is True
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Problem

NWC payments that succeed on the provider side were being incorrectly marked as failed in LNbits due to a race condition where `lookup_invoice` is not yet consistent with the provider.

### Root Causes

1. **`pay_invoice` NWCError handling**: When the NWC provider throws an exception after processing the payment, `payment_hash` was never extracted and `PaymentResponse` was returned with `checking_id=None`, causing the core to mark the payment as failed.

2. **`get_payment_status` NOT_FOUND handling**: When `lookup_invoice` returned `NOT_FOUND` (because the provider hasn't indexed the payment yet), it was immediately treated as failed instead of checking if we have cached proof of settlement.

3. **`list_transactions` type filter**: The `_fetch_incoming_transactions` hardcoded `type: incoming`, which excluded outgoing payments from `list_transactions` lookups.

## Changes

### 1. Always extract `payment_hash` before NWC call
Move `bolt11_decode` before the try block with its own `Bolt11Exception` handler, so `payment_hash` is always available even when the NWC call fails.

### 2. Cache `pay_invoice` success data
When `pay_invoice` returns a preimage, cache it in `payment_status_cache` with state "settled" so `get_payment_status` can use it later when the provider's lookup is not yet consistent.

### 3. Check cache on `NOT_FOUND`
In `get_payment_status`, when `lookup_invoice` returns `NOT_FOUND`, check the cached `pay_invoice` success data before declaring the payment failed.

### 4. Remove `type: incoming` filter
Remove the hardcoded `type: incoming` filter from `list_transactions` calls so both incoming and outgoing payments are returned (per NWC spec, omitting type returns both).

## Test Plan

- Make a payment via NWC with a provider that has slight lookup delay
- Verify payment shows as "success" instead of "failed" in LNbits
- Verify `pay_invoice` NWCError with failure codes still returns correct status
- Verify invalid bolt11 invoices return proper error with `checking_id=None`