### PR TITLE
fix: return preimages for Phoenixd invoices and settled payments

### DIFF
--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -640,9 +640,7 @@ async def check_transaction_status(
 async def check_payment_status(payment: Payment) -> PaymentStatus:
     if payment.is_internal:
         if payment.success:
-            return PaymentSuccessStatus(
-                fee_msat=payment.fee, preimage=payment.preimage
-            )
+            return PaymentSuccessStatus(fee_msat=payment.fee, preimage=payment.preimage)
         if payment.failed:
             return PaymentFailedStatus()
         if payment.is_in and payment.fiat_provider:

--- a/lnbits/core/services/payments.py
+++ b/lnbits/core/services/payments.py
@@ -632,7 +632,7 @@ async def check_transaction_status(
         return PaymentPendingStatus()
 
     if payment.status == PaymentState.SUCCESS.value:
-        return PaymentSuccessStatus(fee_msat=payment.fee)
+        return PaymentSuccessStatus(fee_msat=payment.fee, preimage=payment.preimage)
 
     return await check_payment_status(payment)
 
@@ -640,7 +640,9 @@ async def check_transaction_status(
 async def check_payment_status(payment: Payment) -> PaymentStatus:
     if payment.is_internal:
         if payment.success:
-            return PaymentSuccessStatus()
+            return PaymentSuccessStatus(
+                fee_msat=payment.fee, preimage=payment.preimage
+            )
         if payment.failed:
             return PaymentFailedStatus()
         if payment.is_in and payment.fiat_provider:

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -148,6 +148,22 @@ class PhoenixdWallet(Wallet):
             checking_id = data["paymentHash"]
             payment_request = data["serialized"]
             preimage = data.get("paymentPreimage", None)  # if available
+            # Phoenixd createinvoice omits paymentPreimage; fetch from incoming payment.
+            if not preimage:
+                try:
+                    r2 = await self.client.get(
+                        f"/payments/incoming/{checking_id}",
+                        timeout=40,
+                    )
+                    if not r2.is_error:
+                        incoming = r2.json()
+                        preimage = incoming.get("preimage") or None
+                except Exception as exc:
+                    logger.warning(
+                        "Phoenixd: could not fetch preimage for %s: %s",
+                        checking_id,
+                        exc,
+                    )
             return InvoiceResponse(
                 ok=True,
                 checking_id=checking_id,

--- a/lnbits/wallets/phoenixd.py
+++ b/lnbits/wallets/phoenixd.py
@@ -98,6 +98,24 @@ class PhoenixdWallet(Wallet):
             logger.warning(exc)
             return StatusResponse(f"Unable to connect to {self.endpoint}.", 0)
 
+    async def _incoming_preimage(self, payment_hash: str) -> str | None:
+        """Fetch preimage from Phoenixd incoming payment (createinvoice omits it)."""
+        try:
+            r = await self.client.get(
+                f"/payments/incoming/{payment_hash}",
+                timeout=40,
+            )
+            if r.is_error:
+                return None
+            return r.json().get("preimage") or None
+        except Exception as exc:
+            logger.warning(
+                "Phoenixd: could not fetch preimage for %s: %s",
+                payment_hash,
+                exc,
+            )
+            return None
+
     async def create_invoice(
         self,
         amount: int,
@@ -147,23 +165,10 @@ class PhoenixdWallet(Wallet):
 
             checking_id = data["paymentHash"]
             payment_request = data["serialized"]
-            preimage = data.get("paymentPreimage", None)  # if available
-            # Phoenixd createinvoice omits paymentPreimage; fetch from incoming payment.
-            if not preimage:
-                try:
-                    r2 = await self.client.get(
-                        f"/payments/incoming/{checking_id}",
-                        timeout=40,
-                    )
-                    if not r2.is_error:
-                        incoming = r2.json()
-                        preimage = incoming.get("preimage") or None
-                except Exception as exc:
-                    logger.warning(
-                        "Phoenixd: could not fetch preimage for %s: %s",
-                        checking_id,
-                        exc,
-                    )
+            # Phoenixd createinvoice often omits paymentPreimage.
+            preimage = data.get("paymentPreimage") or await self._incoming_preimage(
+                checking_id
+            )
             return InvoiceResponse(
                 ok=True,
                 checking_id=checking_id,


### PR DESCRIPTION
## Summary

Same-node / NWC pays against Phoenixd-backed LNbits can settle successfully while returning an unusable (missing or all-zero) preimage. That breaks L402 and any NIP-47 client that needs `SHA256(preimage) == payment_hash`.

Two gaps:

1. **Phoenixd `createinvoice`** does not include `paymentPreimage`. The preimage is already available from `GET /payments/incoming/{paymentHash}` (even before the invoice is paid). Without storing it, internal settles copy a null preimage into the payer row.
2. **`check_transaction_status`** (and the internal branch of `check_payment_status`) returned `PaymentSuccessStatus` **without** the payment’s stored `preimage`. The NWC provider then substitutes the FakeWallet placeholder (`0000…0000`).

## Changes

- `lnbits/wallets/phoenixd.py`: after `createinvoice`, if `paymentPreimage` is absent, fetch `preimage` from `/payments/incoming/{paymentHash}` (best-effort; warn and continue if the follow-up fails).
- `lnbits/core/services/payments.py`: pass `preimage=payment.preimage` (and fee on the internal path) when returning success from `check_transaction_status` / internal `check_payment_status`.

## Test plan

- [ ] Phoenixd funding source: create invoice via API; confirm response/DB row has a non-empty 64-hex preimage (not only after pay).
- [ ] Same-node internal pay between two LNbits wallets: payer payment row has real preimage; `check_transaction_status` returns that preimage.
- [ ] NWC `pay_invoice` against an invoice from another wallet on the same instance: response `preimage` is 64-hex and not all-zeros; `sha256(preimage) == payment_hash`.
- [ ] Non-Phoenixd funding source: create/pay still behave as before (no regression on status/preimage for backends that already return preimage).

## Context

Validated on a Phoenixd + LNbits + NWC stack used for L402 settle (merchant invoice → NWC `pay_invoice` → retry with `Authorization: L402 macaroon:preimage`).
