### PR TITLE
docs(guide): fix mangled LNPay webhook example markdown

### DIFF
--- a/docs/guide/wallets.md
+++ b/docs/guide/wallets.md
@@ -197,7 +197,7 @@ uv run lnbits-cli encrypt macaroon
 
 ## LNPay
 
-For the invoice listener to work you must have a publicly accessible URL in your LNbits and set up [LNPay webhooks](https://dashboard.lnpay.co/webhook/) pointing to `<your LNbits host>/wallet/webhook` with the event **Wallet Receive** and no secret. Example: [https://mylnbits/wallet/webhook](`https://mylnbits/wallet/webhook).
+For the invoice listener to work you must have a publicly accessible URL in your LNbits and set up [LNPay webhooks](https://dashboard.lnpay.co/webhook/) pointing to `<your LNbits host>/wallet/webhook` with the event **Wallet Receive** and no secret. Example: `https://mylnbits.example/wallet/webhook`.
 
 **Required env vars**
 


### PR DESCRIPTION
## Summary
Fix a broken markdown construct in the LNPay funding-source docs.

**Before:** reverse-broken link with backtick-prefixed destination  
**After:** a clear example webhook path: `https://mylnbits.example/wallet/webhook`

## Why
The previous example did not render as usable docs (markdown link text/destination mismatch), making LNPay webhook setup harder to follow.

## AI disclosure
Assisted by an AI coding agent (Hermes/Sera). Human-reviewed before opening.

## Testing
Docs-only; verified by source inspection.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** sera