### PR TITLE
docs(guide): fix typo enviroment → environment in super user guide

### DIFF
--- a/docs/guide/super_user.md
+++ b/docs/guide/super_user.md
@@ -42,7 +42,7 @@ nav_order: 1
 
 The **Super User** is the owner-operator account of an LNbits instance. Think of it as your “break glass” operator with a few capabilities that are intentionally reserved for the person ultimately responsible for the server and the funding rails.
 
-The SU is created alongside the [Admin UI](./admin_ui.md) and is meant to keep enviroment operations pleasant in the UI while keeping the most sensitive knobs in trusted hands.
+The SU is created alongside the [Admin UI](./admin_ui.md) and is meant to keep environment operations pleasant in the UI while keeping the most sensitive knobs in trusted hands.
 
 **Key SU capabilities**
 


### PR DESCRIPTION
## Summary

- Fix spelling typo in the Super User guide: `enviroment` → `environment`.
- Docs-only; no runtime or payment-path changes.

## Motivation

A single misspelling in `docs/guide/super_user.md` made the Super User intro slightly harder to read. Correct spelling improves clarity for operators reading the guide.

## AI disclosure

Assisted by an AI coding agent (Hermes/Sera). Human-reviewed before opening.

## Verification

- Docs-only change; verified by source inspection and `git diff` (+1/-1 on one file).
- Did NOT change: payment paths, wallets, auth, LNURL/Bolt11, or code.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** sera
