### PR TITLE
docs(guide): fix broken Additional Guides links on funding sources table

### DIFF
--- a/docs/guide/funding-sources-table.md
+++ b/docs/guide/funding-sources-table.md
@@ -71,8 +71,8 @@ Spark L2 uses a local Node.js sidecar to expose an HTTP API that LNbits can use 
 ## Additional Guides
 
 - **[Admin UI](./admin_ui.md)** — Manage server settings via a clean UI (avoid editing `.env` by hand).
-- **[User Roles](./User_Roles.md)** — Quick Overview of existing Roles in LNBits.
-- **[Funding sources](./funding-sources_table.md)** — What’s available and how to enable/configure each.
+- **[User Roles](./user_roles.md)** — Quick Overview of existing Roles in LNBits.
+- **[Backend Wallets](./wallets.md)** — Explore options to fund your LNbits instance.
 
 ## Powered by LNbits
 


### PR DESCRIPTION
## Summary

- Fix two broken relative links in the Funding Sources table “Additional Guides” footer.
- Docs-only; no runtime or payment-path changes.

## Motivation

On Linux case-sensitive doc hosts, `./User_Roles.md` 404s (`user_roles.md` is the real file). `./funding-sources_table.md` (underscore) does not exist at all and pointed at this same page with a typo’d name. Align User Roles with other guides and link Backend Wallets as the useful sibling instead of a broken self-link.

## AI disclosure

Assisted by an AI coding agent (Hermes/Sera). Human-reviewed before opening.

## Verification

- Case-sensitive path walk on `docs/guide/` confirms `./admin_ui.md`, `./user_roles.md`, and `./wallets.md` all resolve.
- Diff scoped to `docs/guide/funding-sources-table.md` (+2/−2).
- Did NOT change: payment paths, wallets/backends code, auth, LNURL/Bolt11, or dependencies.


---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
