### PR TITLE
docs(guide): fix prefared typo and LNbits brand on install links

### DIFF
--- a/docs/guide/admin_ui.md
+++ b/docs/guide/admin_ui.md
@@ -118,7 +118,7 @@ When set **at least one**, LNbits becomes private: only the listed users and Adm
 - **[Backend Wallets](./wallets.md)** — Explore options to fund your LNbits instance.
 - **[User Roles](./user_roles.md)** — Overview of existing roles in LNbits.
 - **[Funding sources](./funding-sources-table.md)** — What is available and how to configure each.
-- **[Install LNBits](./installation.md)** — Choose your prefared way to install LNBits.
+- **[Install LNbits](./installation.md)** — Choose your preferred way to install LNbits.
 
 ## Powered by LNbits
 

--- a/docs/guide/super_user.md
+++ b/docs/guide/super_user.md
@@ -117,7 +117,7 @@ These are practical tips for running a safe and friendly instance.
 - **[Admin UI](./admin_ui.md)** — Manage server settings in the browser instead of editing `.env` or using the CLI for routine tasks.
 - **[User Roles](./user_roles.md)** — Overview of roles and what they can do.
 - **[Funding sources](./funding-sources-table.md)** — Available options and how to enable and configure them.
-- **[Install LNBits](./installation.md)** — Choose your prefared way to install LNBits.
+- **[Install LNbits](./installation.md)** — Choose your preferred way to install LNbits.
 
 ## Powered by LNbits
 


### PR DESCRIPTION
## Summary

- Fix the `prefared` → `preferred` typo on Additional Guides install bullets.
- Align link label/wording to the project brand `LNbits` on those same lines.

## Motivation

These footer links in the Admin UI and Super User guides had a clear dictation/typo (`prefared`) and used `LNBits` while the surrounding docs brand is `LNbits`. Docs-only; no behavior change.

## AI disclosure

Assisted by an AI coding agent (Hermes/Sera). Human-reviewed before opening.

## Verification

- Diff scoped to two guide bullets: `docs/guide/admin_ui.md`, `docs/guide/super_user.md` (+2/−2).
- Grep confirms no remaining `prefared` in those files.
- Did NOT change: payment paths, wallets/backends code, auth, LNURL/Bolt11, dependencies, or unrelated brand strings elsewhere.


---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
