### PR TITLE
fix: sort-by button tooltip text

### DIFF
--- a/lnbits/templates/components/lnbits-payment-list.vue
+++ b/lnbits/templates/components/lnbits-payment-list.vue
@@ -156,7 +156,7 @@
             </q-list>
           </q-menu>
           <q-tooltip>
-            <span v-text="$t('filter_payments')"></span>
+            <span v-text="$t('sort_by')"></span>
           </q-tooltip>
         </q-btn>
 


### PR DESCRIPTION
This PR corrects the incorrect tooltip text on the sort-by button, on the payment list. It was `filter_payments` even though there is a `sort_by` string.