### PR TITLE
Fix funding sources component inclusion in funding.vue

### DIFF
--- a/lnbits/templates/components/admin/funding.vue
+++ b/lnbits/templates/components/admin/funding.vue
@@ -79,7 +79,7 @@
         <lnbits-admin-funding-sources
           :form-data="formData"
           :allowed-funding-sources="settings.lnbits_allowed_funding_sources"
-        />
+        ></lnbits-admin-funding-sources>
         <div class="row q-col-gutter-md q-my-md">
           <div class="col-12 col-sm-8">
             <q-item tag="div">


### PR DESCRIPTION
Fix hidden Admin Funding settings caused by a self-closing custom component tag.

Browsers don’t self-close custom HTML elements, so the component captured the following fields as children and prevented them from rendering. Using an explicit closing tag lets them render.