### PR TITLE
fix(nwc): resolve in-flight request futures when relay disconnects

### DIFF
--- a/lnbits/wallets/nwc.py
+++ b/lnbits/wallets/nwc.py
@@ -949,10 +949,12 @@ class NWCConnection:
             while not self._is_shutting_down():
                 try:
                     await asyncio.sleep(int(self.subscription_timeout * 0.5))
-                    # skip if connection is not established
-                    if not self.connected:
-                        continue
-                    # Find all subscriptions that have timed out
+                    # Find all subscriptions that have timed out.
+                    # This must run even while the connection is down:
+                    # otherwise in-flight request futures on a dropped
+                    # connection are never resolved and callers await forever
+                    # (the socket can reconnect but the old subscriptions never
+                    # complete), which requires a process restart to recover.
                     now = time.time()
                     subscriptions_to_close = []
                     for subscription in self.subscriptions.values():
@@ -970,9 +972,14 @@ class NWCConnection:
                                 subscription["future"].set_exception(
                                     Exception("timed out")
                                 )
-                    # Close all timed out subscriptions
+                    # Close all timed out subscriptions. When the connection is
+                    # down, drop the stale entries locally instead of sending
+                    # CLOSE (which blocks on _wait_for_connection); the futures
+                    # are already resolved above so callers do not hang.
                     for sub_id in subscriptions_to_close:
-                        await self._close_subscription_by_subid(sub_id)
+                        await self._close_subscription_by_subid(
+                            sub_id, send_event=self.connected
+                        )
                 except Exception as e:
                     logger.error("Error handling subscription timeout: " + str(e))
         except Exception as e:


### PR DESCRIPTION
Follow-on from PR https://github.com/lnbits/lnbits/pull/4066

## Problem

When an NWC relay connection drops, the `NWCConnection` subscription-timeout sweeper (`_handle_timeouts`) skipped entirely because it started with `if not self.connected: continue`. As a result, in-flight request futures held by the old subscriptions were never resolved — not given a result and not given the timeout exception. Callers `await` those futures forever, so every NWC wallet on that connection stalls — and only a process restart (which wipes the state) recovers it.

## Change

- Run the sweeper's timeout scan even while the relay is disconnected, so timed-out subscriptions have their `future` raised with `Exception("timed out")` and callers unblock instead of hanging indefinitely.
- When the connection is down, close the stale subscriptions with `send_event=False` — dropping them from local state rather than attempting `CLOSE` against a dead socket (which would block on `_wait_for_connection` for up to 2 minutes per entry).

The change reuses the existing `send_event` parameter on `_close_subscription_by_subid` to avoid adding a new method.

## Test plan

- Drop the relay connection while requests are in flight and confirm callers resolve (timeout) rather than hang.\n- Confirm normal relay disconnect/reconnect still behaves as before.